### PR TITLE
SIMPLEITK-86 Remove use of outdated CMake commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,16 +12,16 @@ if( NOT ITK_USE_REVIEW )
 #  message(FATAL_ERROR "Please reconfigure ITK by turning ITK_USE_REVIEW ON")
 endif()
 
-
-# Put all files in a bin directory to keep things tidy.
-# Output directories.
-if(NOT LIBRARY_OUTPUT_PATH)
-  set(LIBRARY_OUTPUT_PATH ${SimpleITK_BINARY_DIR}/bin CACHE INTERNAL "Single output directory for building all libraries.")
+# Setup build locations.
+if(NOT CMAKE_RUNTIME_OUTPUT_DIRECTORY)
+  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
 endif()
-if(NOT EXECUTABLE_OUTPUT_PATH)
-  set(EXECUTABLE_OUTPUT_PATH ${SimpleITK_BINARY_DIR}/bin CACHE INTERNAL "Single output directory for building all executables.")
+if(NOT CMAKE_LIBRARY_OUTPUT_DIRECTORY)
+  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
 endif()
-mark_as_advanced(LIBRARY_OUTPUT_PATH EXECUTABLE_OUTPUT_PATH)
+if(NOT CMAKE_ARCHIVE_OUTPUT_DIRECTORY)
+  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
+endif()
 
 set ( SimpleITK_INCLUDE_DIR
       ${CMAKE_SOURCE_DIR}/Code/Common

--- a/Testing/Unit/CMakeLists.txt
+++ b/Testing/Unit/CMakeLists.txt
@@ -138,7 +138,7 @@ SET(GTEST_LIBRARY_DIRS "${CMAKE_CURRENT_BINARY_DIR}" PARENT_SCOPE)
 # Test data directory
 set(TEST_HARNESS_TEMP_DIRECTORY ${SimpleITK_BINARY_DIR}/Testing/Temporary)
 set(TEST_HARNESS_DATA_DIRECTORY ${SimpleITK_SOURCE_DIR}/Testing/Data)
-set(TEST_HARNESS_EXECUTABLE_DIRECTORY "${EXECUTABLE_OUTPUT_PATH}/${CMAKE_CFG_INTDIR}/" )
+set(TEST_HARNESS_EXECUTABLE_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/" )
 
 # Set some variables
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/SimpleITKTestHarnessPaths.h.in
@@ -217,4 +217,4 @@ endmacro()
 
 
 # Here we add all the tests
-add_google_tests ( ${EXECUTABLE_OUTPUT_PATH}/SimpleITKUnitTestDriver ${TestSource})
+add_google_tests ( ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SimpleITKUnitTestDriver ${TestSource})

--- a/sitkGenerateSimpleITKConfig.cmake
+++ b/sitkGenerateSimpleITKConfig.cmake
@@ -3,13 +3,11 @@
 # SimpleITK.
 
 
-
-
 #-----------------------------------------------------------------------------
 # Settings specific to the build tree.
 
 # Library directory.
-set(SimpleITK_LIBRARY_DIRS_CONFIG ${LIBRARY_OUTPUT_PATH})
+set(SimpleITK_LIBRARY_DIRS_CONFIG ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 
 # Determine the include directories needed.
 set(SimpleITK_INCLUDE_DIRS_CONFIG


### PR DESCRIPTION
EXECUTABLE_OUTPUT_PATH and LIBRARY_OUTPUT_PATH should not
be used in projects.
http://www.cmake.org/pipermail/cmake-commits/2008-February/003333.html
