### PR TITLE
N4BiasCorrectionFilter

### DIFF
--- a/Code/BasicFilters/json/N4BiasFieldCorrection.json
+++ b/Code/BasicFilters/json/N4BiasFieldCorrection.json
@@ -1,5 +1,5 @@
 {
-  "name" : "N4MRIBiasFieldCorrection",
+  "name" : "N4BiasFieldCorrection",
   "template_code_filename" : "DualImageFilter",
   "template_test_filename" : "ImageFilter",
   "number_of_inputs" : 2,

--- a/Examples/N4BiasFieldCorrection.py
+++ b/Examples/N4BiasFieldCorrection.py
@@ -26,7 +26,7 @@ if len ( sys.argv ) > 3:
 
 inputImage = sitk.Cast( inputImage, sitk.sitkFloat32 )
 
-corrector = sitk.N4MRIBiasFieldCorrectionImageFilter();
+corrector = sitk.N4BiasFieldCorrectionImageFilter();
 
 numberFilltingLevels = 4
 

--- a/Wrapping/JavaDoc.i
+++ b/Wrapping/JavaDoc.i
@@ -3433,8 +3433,8 @@ This class is parametrized over the types of the two input images and the type o
 li {ImageProcessing/MultiplyImageFilter,Multiply two images together}
 
 */"
-// Generated for ClassName from ../ITK-doxygen/Utilities/Doxygen/xml/classitk_1_1N4MRIBiasFieldCorrectionImageFilter.xml
-%typemap(javaimports) itk::simple::N4MRIBiasFieldCorrectionImageFilter "/** Implementation of the N4 MRI bias field correction algorithm.
+// Generated for ClassName from ../ITK-doxygen/Utilities/Doxygen/xml/classitk_1_1N4BiasFieldCorrectionImageFilter.xml
+%typemap(javaimports) itk::simple::N4BiasFieldCorrectionImageFilter "/** Implementation of the N4 MRI bias field correction algorithm.
 
 The nonparametric nonuniform intensity normalization (N3) algorithm, as introduced by Sled et al. in 1998 is a method for correcting nonuniformity associated with MR images. The algorithm assumes a simple parametric model (Gaussian) for the bias field and does not require tissue class segmentation. In addition, there are only a couple of parameters to tune with the default values performing quite well. N3 has been publicly available as a set of perl scripts (http://www.bic.mni.mcgill.ca/ServicesSoftwareAdvancedImageProcessingTools/HomePage)
 The N4 algorithm, encapsulated with this class, is a variation of the original N3 algorithm with the additional benefits of an improved B-spline fitting routine which allows for multiple resolutions to be used during the correction process. We also modify the iterative update component of algorithm such that the residual bias field is continually updated
@@ -3446,11 +3446,11 @@ par REFERENCE
 J.G. Sled, A.P. Zijdenbos and A.C. Evans. A Nonparametric Method for Automatic Correction of Intensity Nonuniformity in MRI Data IEEE Transactions on Medical Imaging, Vol 17, No 1. Feb 1998.
 N.J. Tustison, B.B. Avants, P.A. Cook, Y. Zheng, A. Egan, P.A. Yushkevich, and J.C. Gee. N4ITK: Improved N3 Bias Correction IEEE Transactions on Medical Imaging, 29(6):1310-1320, June 2010.
 */"
-%javamethodmodifiers itk::simple::N4MRIBiasFieldCorrectionImageFilter::execute() "
+%javamethodmodifiers itk::simple::N4BiasFieldCorrectionImageFilter::execute() "
 /**Implementation of the N4 MRI bias field correction algorithm.
 
 */"
-%javamethodmodifiers itk::simple::N4MRIBiasFieldCorrection "/**
+%javamethodmodifiers itk::simple::N4BiasFieldCorrection "/**
 Implementation of the N4 MRI bias field correction algorithm.
 
 The nonparametric nonuniform intensity normalization (N3) algorithm, as introduced by Sled et al. in 1998 is a method for correcting nonuniformity associated with MR images. The algorithm assumes a simple parametric model (Gaussian) for the bias field and does not require tissue class segmentation. In addition, there are only a couple of parameters to tune with the default values performing quite well. N3 has been publicly available as a set of perl scripts (http://www.bic.mni.mcgill.ca/ServicesSoftwareAdvancedImageProcessingTools/HomePage)
@@ -3463,86 +3463,86 @@ par REFERENCE
 J.G. Sled, A.P. Zijdenbos and A.C. Evans. A Nonparametric Method for Automatic Correction of Intensity Nonuniformity in MRI Data IEEE Transactions on Medical Imaging, Vol 17, No 1. Feb 1998.
 N.J. Tustison, B.B. Avants, P.A. Cook, Y. Zheng, A. Egan, P.A. Yushkevich, and J.C. Gee. N4ITK: Improved N3 Bias Correction IEEE Transactions on Medical Imaging, 29(6):1310-1320, June 2010.
 */"
-%javamethodmodifiers itk::simple::N4MRIBiasFieldCorrectionImageFilter::setConvergenceThreshold "/**
-virtual void itk::N4MRIBiasFieldCorrectionImageFilter::SetConvergenceThreshold(RealType _arg)
+%javamethodmodifiers itk::simple::N4BiasFieldCorrectionImageFilter::setConvergenceThreshold "/**
+virtual void itk::N4BiasFieldCorrectionImageFilter::SetConvergenceThreshold(RealType _arg)
 
 Set the convergence threshold. Convergence is determined by the coefficient of variation of the difference image between the current bias field estimate and the previous estimate. If this value is less than the specified threshold, the algorithm proceeds to the next fitting level or terminates if it is at the last level.
 */"
 
-%javamethodmodifiers itk::simple::N4MRIBiasFieldCorrectionImageFilter::getConvergenceThreshold "/**
-virtual RealType itk::N4MRIBiasFieldCorrectionImageFilter::GetConvergenceThreshold() const
+%javamethodmodifiers itk::simple::N4BiasFieldCorrectionImageFilter::getConvergenceThreshold "/**
+virtual RealType itk::N4BiasFieldCorrectionImageFilter::GetConvergenceThreshold() const
 
 Get the convergence threshold. Convergence is determined by the coefficient of variation of the difference image between the current bias field estimate and the previous estimate. If this value is less than the specified threshold, the algorithm proceeds to the next fitting level or terminates if it is at the last level.
 */"
 
-%javamethodmodifiers itk::simple::N4MRIBiasFieldCorrectionImageFilter::setMaximumNumberOfIterations "/**
-virtual void itk::N4MRIBiasFieldCorrectionImageFilter::SetMaximumNumberOfIterations(VariableSizeArrayType _arg)
+%javamethodmodifiers itk::simple::N4BiasFieldCorrectionImageFilter::setMaximumNumberOfIterations "/**
+virtual void itk::N4BiasFieldCorrectionImageFilter::SetMaximumNumberOfIterations(VariableSizeArrayType _arg)
 
 Set the maximum number of iterations specified at each fitting level. Default = 50.
 */"
 
-%javamethodmodifiers itk::simple::N4MRIBiasFieldCorrectionImageFilter::getMaximumNumberOfIterations "/**
-virtual VariableSizeArrayType itk::N4MRIBiasFieldCorrectionImageFilter::GetMaximumNumberOfIterations() const
+%javamethodmodifiers itk::simple::N4BiasFieldCorrectionImageFilter::getMaximumNumberOfIterations "/**
+virtual VariableSizeArrayType itk::N4BiasFieldCorrectionImageFilter::GetMaximumNumberOfIterations() const
 
 Get the maximum number of iterations specified at each fitting level. Default = 50.
 */"
 
-%javamethodmodifiers itk::simple::N4MRIBiasFieldCorrectionImageFilter::setBiasFieldFullWidthAtHalfMaximum "/**
-virtual void itk::N4MRIBiasFieldCorrectionImageFilter::SetBiasFieldFullWidthAtHalfMaximum(RealType _arg)
+%javamethodmodifiers itk::simple::N4BiasFieldCorrectionImageFilter::setBiasFieldFullWidthAtHalfMaximum "/**
+virtual void itk::N4BiasFieldCorrectionImageFilter::SetBiasFieldFullWidthAtHalfMaximum(RealType _arg)
 
 Set the full width at half maximum parameter characterizing the width of the Gaussian deconvolution. Default = 0.15.
 */"
 
-%javamethodmodifiers itk::simple::N4MRIBiasFieldCorrectionImageFilter::getBiasFieldFullWidthAtHalfMaximum "/**
-virtual RealType itk::N4MRIBiasFieldCorrectionImageFilter::GetBiasFieldFullWidthAtHalfMaximum() const
+%javamethodmodifiers itk::simple::N4BiasFieldCorrectionImageFilter::getBiasFieldFullWidthAtHalfMaximum "/**
+virtual RealType itk::N4BiasFieldCorrectionImageFilter::GetBiasFieldFullWidthAtHalfMaximum() const
 
 Get the full width at half maximum parameter characterizing the width of the Gaussian deconvolution. Default = 0.15.
 */"
 
-%javamethodmodifiers itk::simple::N4MRIBiasFieldCorrectionImageFilter::setWienerFilterNoise "/**
-virtual void itk::N4MRIBiasFieldCorrectionImageFilter::SetWienerFilterNoise(RealType _arg)
+%javamethodmodifiers itk::simple::N4BiasFieldCorrectionImageFilter::setWienerFilterNoise "/**
+virtual void itk::N4BiasFieldCorrectionImageFilter::SetWienerFilterNoise(RealType _arg)
 
 Set the noise estimate defining the Wiener filter. Default = 0.01.
 */"
 
-%javamethodmodifiers itk::simple::N4MRIBiasFieldCorrectionImageFilter::getWienerFilterNoise "/**
-virtual RealType itk::N4MRIBiasFieldCorrectionImageFilter::GetWienerFilterNoise() const
+%javamethodmodifiers itk::simple::N4BiasFieldCorrectionImageFilter::getWienerFilterNoise "/**
+virtual RealType itk::N4BiasFieldCorrectionImageFilter::GetWienerFilterNoise() const
 
 Get the noise estimate defining the Wiener filter. Default = 0.01.
 */"
 
-%javamethodmodifiers itk::simple::N4MRIBiasFieldCorrectionImageFilter::setNumberOfHistogramBins "/**
-virtual void itk::N4MRIBiasFieldCorrectionImageFilter::SetNumberOfHistogramBins(unsigned int _arg)
+%javamethodmodifiers itk::simple::N4BiasFieldCorrectionImageFilter::setNumberOfHistogramBins "/**
+virtual void itk::N4BiasFieldCorrectionImageFilter::SetNumberOfHistogramBins(unsigned int _arg)
 
 Set number of bins defining the log input intensity histogram. Default = 200.
 */"
 
-%javamethodmodifiers itk::simple::N4MRIBiasFieldCorrectionImageFilter::getNumberOfHistogramBins "/**
-virtual unsigned int itk::N4MRIBiasFieldCorrectionImageFilter::GetNumberOfHistogramBins() const
+%javamethodmodifiers itk::simple::N4BiasFieldCorrectionImageFilter::getNumberOfHistogramBins "/**
+virtual unsigned int itk::N4BiasFieldCorrectionImageFilter::GetNumberOfHistogramBins() const
 
 Get number of bins defining the log input intensity histogram. Default = 200.
 */"
 
-%javamethodmodifiers itk::simple::N4MRIBiasFieldCorrectionImageFilter::setNumberOfControlPoints "/**
-virtual void itk::N4MRIBiasFieldCorrectionImageFilter::SetNumberOfControlPoints(ArrayType _arg)
+%javamethodmodifiers itk::simple::N4BiasFieldCorrectionImageFilter::setNumberOfControlPoints "/**
+virtual void itk::N4BiasFieldCorrectionImageFilter::SetNumberOfControlPoints(ArrayType _arg)
 
 Set the control point grid size definining the B-spline estimate of the scalar bias field. In each dimension, the B-spline mesh size is equal to the number of control points in that dimension minus the spline order. Default = 4 control points in each dimension for a mesh size of 1 in each dimension.
 */"
 
-%javamethodmodifiers itk::simple::N4MRIBiasFieldCorrectionImageFilter::getNumberOfControlPoints "/**
-virtual ArrayType itk::N4MRIBiasFieldCorrectionImageFilter::GetNumberOfControlPoints() const
+%javamethodmodifiers itk::simple::N4BiasFieldCorrectionImageFilter::getNumberOfControlPoints "/**
+virtual ArrayType itk::N4BiasFieldCorrectionImageFilter::GetNumberOfControlPoints() const
 
 Get the control point grid size definining the B-spline estimate of the scalar bias field. In each dimension, the B-spline mesh size is equal to the number of control points in that dimension minus the spline order. Default = 4 control points in each dimension for a mesh size of 1 in each dimension.
 */"
 
-%javamethodmodifiers itk::simple::N4MRIBiasFieldCorrectionImageFilter::setSplineOrder "/**
-virtual void itk::N4MRIBiasFieldCorrectionImageFilter::SetSplineOrder(unsigned int _arg)
+%javamethodmodifiers itk::simple::N4BiasFieldCorrectionImageFilter::setSplineOrder "/**
+virtual void itk::N4BiasFieldCorrectionImageFilter::SetSplineOrder(unsigned int _arg)
 
 Set the spline order defining the bias field estimate. Default = 3.
 */"
 
-%javamethodmodifiers itk::simple::N4MRIBiasFieldCorrectionImageFilter::getSplineOrder "/**
-virtual unsigned int itk::N4MRIBiasFieldCorrectionImageFilter::GetSplineOrder() const
+%javamethodmodifiers itk::simple::N4BiasFieldCorrectionImageFilter::getSplineOrder "/**
+virtual unsigned int itk::N4BiasFieldCorrectionImageFilter::GetSplineOrder() const
 
 Get the spline order defining the bias field estimate. Default = 3.
 */"

--- a/Wrapping/PythonDocstrings.i
+++ b/Wrapping/PythonDocstrings.i
@@ -2951,8 +2951,8 @@ This class is parametrized over the types of the two input images and the type o
 li {ImageProcessing/MultiplyImageFilter,Multiply two images together}
 
 "
-// Generated for ClassName from ../ITK-doxygen/Utilities/Doxygen/xml/classitk_1_1N4MRIBiasFieldCorrectionImageFilter.xml
-%feature("docstring") itk::simple::N4MRIBiasFieldCorrectionImageFilter "Implementation of the N4 MRI bias field correction algorithm.
+// Generated for ClassName from ../ITK-doxygen/Utilities/Doxygen/xml/classitk_1_1N4BiasFieldCorrectionImageFilter.xml
+%feature("docstring") itk::simple::N4BiasFieldCorrectionImageFilter "Implementation of the N4 MRI bias field correction algorithm.
 
 The nonparametric nonuniform intensity normalization (N3) algorithm, as introduced by Sled et al. in 1998 is a method for correcting nonuniformity associated with MR images. The algorithm assumes a simple parametric model (Gaussian) for the bias field and does not require tissue class segmentation. In addition, there are only a couple of parameters to tune with the default values performing quite well. N3 has been publicly available as a set of perl scripts (http://www.bic.mni.mcgill.ca/ServicesSoftwareAdvancedImageProcessingTools/HomePage)
 The N4 algorithm, encapsulated with this class, is a variation of the original N3 algorithm with the additional benefits of an improved B-spline fitting routine which allows for multiple resolutions to be used during the correction process. We also modify the iterative update component of algorithm such that the residual bias field is continually updated
@@ -2964,9 +2964,9 @@ par REFERENCE
 J.G. Sled, A.P. Zijdenbos and A.C. Evans. A Nonparametric Method for Automatic Correction of Intensity Nonuniformity in MRI Data IEEE Transactions on Medical Imaging, Vol 17, No 1. Feb 1998.
 N.J. Tustison, B.B. Avants, P.A. Cook, Y. Zheng, A. Egan, P.A. Yushkevich, and J.C. Gee. N4ITK: Improved N3 Bias Correction IEEE Transactions on Medical Imaging, 29(6):1310-1320, June 2010.
 "
-%feature("docstring") itk::simple::N4MRIBiasFieldCorrectionImageFilter::Execute "Implementation of the N4 MRI bias field correction algorithm.
+%feature("docstring") itk::simple::N4BiasFieldCorrectionImageFilter::Execute "Implementation of the N4 MRI bias field correction algorithm.
 "
-%feature("docstring") itk::simple::N4MRIBiasFieldCorrection "Implementation of the N4 MRI bias field correction algorithm.
+%feature("docstring") itk::simple::N4BiasFieldCorrection "Implementation of the N4 MRI bias field correction algorithm.
 
 The nonparametric nonuniform intensity normalization (N3) algorithm, as introduced by Sled et al. in 1998 is a method for correcting nonuniformity associated with MR images. The algorithm assumes a simple parametric model (Gaussian) for the bias field and does not require tissue class segmentation. In addition, there are only a couple of parameters to tune with the default values performing quite well. N3 has been publicly available as a set of perl scripts (http://www.bic.mni.mcgill.ca/ServicesSoftwareAdvancedImageProcessingTools/HomePage)
 The N4 algorithm, encapsulated with this class, is a variation of the original N3 algorithm with the additional benefits of an improved B-spline fitting routine which allows for multiple resolutions to be used during the correction process. We also modify the iterative update component of algorithm such that the residual bias field is continually updated
@@ -2978,72 +2978,72 @@ par REFERENCE
 J.G. Sled, A.P. Zijdenbos and A.C. Evans. A Nonparametric Method for Automatic Correction of Intensity Nonuniformity in MRI Data IEEE Transactions on Medical Imaging, Vol 17, No 1. Feb 1998.
 N.J. Tustison, B.B. Avants, P.A. Cook, Y. Zheng, A. Egan, P.A. Yushkevich, and J.C. Gee. N4ITK: Improved N3 Bias Correction IEEE Transactions on Medical Imaging, 29(6):1310-1320, June 2010.
 "
-%feature("docstring") itk::simple::N4MRIBiasFieldCorrectionImageFilter::SetConvergenceThreshold "virtual void itk::N4MRIBiasFieldCorrectionImageFilter::SetConvergenceThreshold(RealType _arg)
+%feature("docstring") itk::simple::N4BiasFieldCorrectionImageFilter::SetConvergenceThreshold "virtual void itk::N4BiasFieldCorrectionImageFilter::SetConvergenceThreshold(RealType _arg)
 
 Set the convergence threshold. Convergence is determined by the coefficient of variation of the difference image between the current bias field estimate and the previous estimate. If this value is less than the specified threshold, the algorithm proceeds to the next fitting level or terminates if it is at the last level.
 "
 
-%feature("docstring") itk::simple::N4MRIBiasFieldCorrectionImageFilter::GetConvergenceThreshold "virtual RealType itk::N4MRIBiasFieldCorrectionImageFilter::GetConvergenceThreshold() const
+%feature("docstring") itk::simple::N4BiasFieldCorrectionImageFilter::GetConvergenceThreshold "virtual RealType itk::N4BiasFieldCorrectionImageFilter::GetConvergenceThreshold() const
 
 Get the convergence threshold. Convergence is determined by the coefficient of variation of the difference image between the current bias field estimate and the previous estimate. If this value is less than the specified threshold, the algorithm proceeds to the next fitting level or terminates if it is at the last level.
 "
 
-%feature("docstring") itk::simple::N4MRIBiasFieldCorrectionImageFilter::SetMaximumNumberOfIterations "virtual void itk::N4MRIBiasFieldCorrectionImageFilter::SetMaximumNumberOfIterations(VariableSizeArrayType _arg)
+%feature("docstring") itk::simple::N4BiasFieldCorrectionImageFilter::SetMaximumNumberOfIterations "virtual void itk::N4BiasFieldCorrectionImageFilter::SetMaximumNumberOfIterations(VariableSizeArrayType _arg)
 
 Set the maximum number of iterations specified at each fitting level. Default = 50.
 "
 
-%feature("docstring") itk::simple::N4MRIBiasFieldCorrectionImageFilter::GetMaximumNumberOfIterations "virtual VariableSizeArrayType itk::N4MRIBiasFieldCorrectionImageFilter::GetMaximumNumberOfIterations() const
+%feature("docstring") itk::simple::N4BiasFieldCorrectionImageFilter::GetMaximumNumberOfIterations "virtual VariableSizeArrayType itk::N4BiasFieldCorrectionImageFilter::GetMaximumNumberOfIterations() const
 
 Get the maximum number of iterations specified at each fitting level. Default = 50.
 "
 
-%feature("docstring") itk::simple::N4MRIBiasFieldCorrectionImageFilter::SetBiasFieldFullWidthAtHalfMaximum "virtual void itk::N4MRIBiasFieldCorrectionImageFilter::SetBiasFieldFullWidthAtHalfMaximum(RealType _arg)
+%feature("docstring") itk::simple::N4BiasFieldCorrectionImageFilter::SetBiasFieldFullWidthAtHalfMaximum "virtual void itk::N4BiasFieldCorrectionImageFilter::SetBiasFieldFullWidthAtHalfMaximum(RealType _arg)
 
 Set the full width at half maximum parameter characterizing the width of the Gaussian deconvolution. Default = 0.15.
 "
 
-%feature("docstring") itk::simple::N4MRIBiasFieldCorrectionImageFilter::GetBiasFieldFullWidthAtHalfMaximum "virtual RealType itk::N4MRIBiasFieldCorrectionImageFilter::GetBiasFieldFullWidthAtHalfMaximum() const
+%feature("docstring") itk::simple::N4BiasFieldCorrectionImageFilter::GetBiasFieldFullWidthAtHalfMaximum "virtual RealType itk::N4BiasFieldCorrectionImageFilter::GetBiasFieldFullWidthAtHalfMaximum() const
 
 Get the full width at half maximum parameter characterizing the width of the Gaussian deconvolution. Default = 0.15.
 "
 
-%feature("docstring") itk::simple::N4MRIBiasFieldCorrectionImageFilter::SetWienerFilterNoise "virtual void itk::N4MRIBiasFieldCorrectionImageFilter::SetWienerFilterNoise(RealType _arg)
+%feature("docstring") itk::simple::N4BiasFieldCorrectionImageFilter::SetWienerFilterNoise "virtual void itk::N4BiasFieldCorrectionImageFilter::SetWienerFilterNoise(RealType _arg)
 
 Set the noise estimate defining the Wiener filter. Default = 0.01.
 "
 
-%feature("docstring") itk::simple::N4MRIBiasFieldCorrectionImageFilter::GetWienerFilterNoise "virtual RealType itk::N4MRIBiasFieldCorrectionImageFilter::GetWienerFilterNoise() const
+%feature("docstring") itk::simple::N4BiasFieldCorrectionImageFilter::GetWienerFilterNoise "virtual RealType itk::N4BiasFieldCorrectionImageFilter::GetWienerFilterNoise() const
 
 Get the noise estimate defining the Wiener filter. Default = 0.01.
 "
 
-%feature("docstring") itk::simple::N4MRIBiasFieldCorrectionImageFilter::SetNumberOfHistogramBins "virtual void itk::N4MRIBiasFieldCorrectionImageFilter::SetNumberOfHistogramBins(unsigned int _arg)
+%feature("docstring") itk::simple::N4BiasFieldCorrectionImageFilter::SetNumberOfHistogramBins "virtual void itk::N4BiasFieldCorrectionImageFilter::SetNumberOfHistogramBins(unsigned int _arg)
 
 Set number of bins defining the log input intensity histogram. Default = 200.
 "
 
-%feature("docstring") itk::simple::N4MRIBiasFieldCorrectionImageFilter::GetNumberOfHistogramBins "virtual unsigned int itk::N4MRIBiasFieldCorrectionImageFilter::GetNumberOfHistogramBins() const
+%feature("docstring") itk::simple::N4BiasFieldCorrectionImageFilter::GetNumberOfHistogramBins "virtual unsigned int itk::N4BiasFieldCorrectionImageFilter::GetNumberOfHistogramBins() const
 
 Get number of bins defining the log input intensity histogram. Default = 200.
 "
 
-%feature("docstring") itk::simple::N4MRIBiasFieldCorrectionImageFilter::SetNumberOfControlPoints "virtual void itk::N4MRIBiasFieldCorrectionImageFilter::SetNumberOfControlPoints(ArrayType _arg)
+%feature("docstring") itk::simple::N4BiasFieldCorrectionImageFilter::SetNumberOfControlPoints "virtual void itk::N4BiasFieldCorrectionImageFilter::SetNumberOfControlPoints(ArrayType _arg)
 
 Set the control point grid size definining the B-spline estimate of the scalar bias field. In each dimension, the B-spline mesh size is equal to the number of control points in that dimension minus the spline order. Default = 4 control points in each dimension for a mesh size of 1 in each dimension.
 "
 
-%feature("docstring") itk::simple::N4MRIBiasFieldCorrectionImageFilter::GetNumberOfControlPoints "virtual ArrayType itk::N4MRIBiasFieldCorrectionImageFilter::GetNumberOfControlPoints() const
+%feature("docstring") itk::simple::N4BiasFieldCorrectionImageFilter::GetNumberOfControlPoints "virtual ArrayType itk::N4BiasFieldCorrectionImageFilter::GetNumberOfControlPoints() const
 
 Get the control point grid size definining the B-spline estimate of the scalar bias field. In each dimension, the B-spline mesh size is equal to the number of control points in that dimension minus the spline order. Default = 4 control points in each dimension for a mesh size of 1 in each dimension.
 "
 
-%feature("docstring") itk::simple::N4MRIBiasFieldCorrectionImageFilter::SetSplineOrder "virtual void itk::N4MRIBiasFieldCorrectionImageFilter::SetSplineOrder(unsigned int _arg)
+%feature("docstring") itk::simple::N4BiasFieldCorrectionImageFilter::SetSplineOrder "virtual void itk::N4BiasFieldCorrectionImageFilter::SetSplineOrder(unsigned int _arg)
 
 Set the spline order defining the bias field estimate. Default = 3.
 "
 
-%feature("docstring") itk::simple::N4MRIBiasFieldCorrectionImageFilter::GetSplineOrder "virtual unsigned int itk::N4MRIBiasFieldCorrectionImageFilter::GetSplineOrder() const
+%feature("docstring") itk::simple::N4BiasFieldCorrectionImageFilter::GetSplineOrder "virtual unsigned int itk::N4BiasFieldCorrectionImageFilter::GetSplineOrder() const
 
 Get the spline order defining the bias field estimate. Default = 3.
 "


### PR DESCRIPTION
Fixed the instances where the erroneous name N4MRIBiasCorrection occurred.  The ITK filter has been renamed without the "MRI" element and building SimpleITK against the latest ITK failed trying to link against the non-existant file.
