### PR TITLE
COMP: Allow building with clang c++11

### DIFF
--- a/CMake/has_tr1_namespace.cxx
+++ b/CMake/has_tr1_namespace.cxx
@@ -1,0 +1,29 @@
+
+#if defined SITK_HAS_STLTR1_TR1_UNORDERED_MAP
+#include <tr1/unordered_map>
+#elif defined SITK_HAS_STLTR1_UNORDERED_MAP
+#include <unordered_map>
+#endif
+
+#if defined SITK_HAS_STLTR1_TR1_FUNCTIONAL
+#include <tr1/functional>
+#elif defined SITK_HAS_STLTR1_FUNCTIONAL
+#include <functional>
+#else
+#error "No system tr1 functional available"
+#endif
+
+int dummy(void)
+{
+  return 1;
+}
+
+int main()
+{
+
+  std::tr1::unordered_map<int,int> s;
+  const std::tr1::unordered_map<int, int> &c_ref = s;
+
+  typedef std::tr1::function<  dummy() > FunctionObjectType;
+  return 0;
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,6 +241,11 @@ try_compile(SITK_SUPPORTS_STATIC_ASSERT
 
 include(CheckIncludeFileCXX)
 
+try_compile(SITK_HAS_TR1_NAMESPACE
+  ${SimpleITK_BINARY_DIR}/CMakeTmp
+  ${SimpleITK_SOURCE_DIR}/CMake/has_tr1_namespace.cxx
+  OUTPUT_VARIABLE out )
+
 # check for the required tr1/functional header
 check_include_file_cxx( tr1/functional SITK_HAS_STLTR1_TR1_FUNCTIONAL )
 check_include_file_cxx( functional SITK_HAS_STLTR1_FUNCTIONAL )
@@ -266,6 +271,7 @@ if ( ${SITK_HAS_STLTR1_UNORDERED_MAP} )
 elseif ( ${SITK_HAS_STLTR1_TR1_UNORDERED_MAP} )
   set( SITK_UNORDERED_MAP_FUNCTIONAL_DEFINITIONS "-DSITK_HAS_STLTR1_TR1_UNORDERED_MAP" )
 endif()
+
 try_compile(SITK_UNORDERED_MAP_FUNCTIONAL
   ${SimpleITK_BINARY_DIR}/CMakeTmp
   ${SimpleITK_SOURCE_DIR}/CMake/tr1_unordered_map.cxx

--- a/Code/BasicFilters/src/sitkLabelStatisticsImageFilter.hxx
+++ b/Code/BasicFilters/src/sitkLabelStatisticsImageFilter.hxx
@@ -53,8 +53,8 @@ Image LabelStatisticsImageFilter::DualExecuteInternal ( const Image& inImage1, c
   filter->UseHistogramsOn(); //Needed to get Median value
 
   typedef typename TImageType::PixelType PixelType;
-  if( std::tr1::is_same< PixelType, uint8_t >::value ||
-      std::tr1::is_same< PixelType, int8_t >::value )
+  if( sitk_tr1::is_same< PixelType, uint8_t >::value ||
+      sitk_tr1::is_same< PixelType, int8_t >::value )
     {
     //NOTE:  This is a heuristic that works exact median only for
     //(unsigned) char images.

--- a/Code/Common/include/sitkConditional.h
+++ b/Code/Common/include/sitkConditional.h
@@ -48,8 +48,8 @@ struct Conditional<false, TIfTrue, TIfFalse> { typedef TIfFalse Type; };
 template <bool VCond, int TIfTrue, int TIfFalse>
 struct ConditionalValue
   : public itk::simple::Conditional<VCond,
-                                    std::tr1::integral_constant<int, TIfTrue>,
-                                    std::tr1::integral_constant<int, TIfFalse> >::Type
+                                    sitk_tr1::integral_constant<int, TIfTrue>,
+                                    sitk_tr1::integral_constant<int, TIfFalse> >::Type
 {
 private:
   typedef ConditionalValue Self;

--- a/Code/Common/include/sitkImage.h
+++ b/Code/Common/include/sitkImage.h
@@ -412,11 +412,11 @@ namespace simple
      * @{
      */
     template<int VPixelIDValue, typename TImageType>
-    typename DisableIf<std::tr1::is_same<TImageType, void>::value>::Type
+    typename DisableIf<sitk_tr1::is_same<TImageType, void>::value>::Type
     ConditionalInternalInitialization( TImageType *i);
 
     template<int VPixelIDValue, typename TImageType>
-    typename EnableIf<std::tr1::is_same<TImageType, void>::value>::Type
+    typename EnableIf<sitk_tr1::is_same<TImageType, void>::value>::Type
     ConditionalInternalInitialization( TImageType *) { assert( false ); }
      /**@}*/
 

--- a/Code/Common/include/sitkMemberFunctionFactoryBase.h
+++ b/Code/Common/include/sitkMemberFunctionFactoryBase.h
@@ -55,7 +55,7 @@ namespace detail {
 
 #if defined SITK_HAS_UNORDERED_MAP
 
-template <typename T> struct hash : public std::tr1::hash<T>{};
+template <typename T> struct hash : public sitk_tr1::hash<T>{};
 
 /** \brief A specialization of the hash function.
  */
@@ -63,7 +63,7 @@ template <>
 struct hash< std::pair<int, int> >
   : public std::unary_function<std::pair<int,int>, std::size_t> {
   std::size_t operator()( const std::pair<int, int > &p ) const
-    { return std::tr1::hash<size_t>()( size_t(p.first) * prime + p.second ); }
+    { return sitk_tr1::hash<size_t>()( size_t(p.first) * prime + p.second ); }
 private:
   static const std::size_t prime = 16777619u;
 };
@@ -103,7 +103,7 @@ public:
 
   /**  the pointer MemberFunctionType redefined ad a tr1::function
    * object */
-  typedef std::tr1::function< MemberFunctionResultType ( ) > FunctionObjectType;
+  typedef sitk_tr1::function< MemberFunctionResultType ( ) > FunctionObjectType;
 
 
 protected:
@@ -120,13 +120,13 @@ protected:
       // this is really only needed because std::bind1st does not work
       // with tr1::function... that is with tr1::bind, we need to
       // specify the other arguments, and can't just bind the first
-      return std::tr1::bind( pfunc,objectPointer );
+      return sitk_tr1::bind( pfunc,objectPointer );
     }
 
   // maps of Keys to pointers to member functions
 #if defined SITK_HAS_UNORDERED_MAP
-  std::tr1::unordered_map< TKey, FunctionObjectType, hash<TKey> > m_PFunction3;
-  std::tr1::unordered_map< TKey, FunctionObjectType, hash<TKey> > m_PFunction2;
+  sitk_tr1::unordered_map< TKey, FunctionObjectType, hash<TKey> > m_PFunction3;
+  sitk_tr1::unordered_map< TKey, FunctionObjectType, hash<TKey> > m_PFunction2;
 #else
   std::map<TKey, FunctionObjectType> m_PFunction3;
   std::map<TKey, FunctionObjectType> m_PFunction2;
@@ -164,7 +164,7 @@ public:
 
   /**  the pointer MemberFunctionType redefined ad a tr1::function
    * object */
-  typedef std::tr1::function< MemberFunctionResultType ( MemberFunctionArgumentType ) > FunctionObjectType;
+  typedef sitk_tr1::function< MemberFunctionResultType ( MemberFunctionArgumentType ) > FunctionObjectType;
 
 
 protected:
@@ -178,19 +178,19 @@ protected:
   static FunctionObjectType  BindObject( MemberFunctionType pfunc, ObjectType *objectPointer)
     {
       // needed for _1 place holder
-      using namespace std::tr1::placeholders;
+      using namespace sitk_tr1::placeholders;
 
       // this is really only needed because std::bind1st does not work
       // with tr1::function... that is with tr1::bind, we need to
       // specify the other arguments, and can't just bind the first
-      return std::tr1::bind( pfunc,objectPointer, _1 );
+      return sitk_tr1::bind( pfunc,objectPointer, _1 );
     }
 
 
   // maps of Keys to pointers to member functions
 #if defined SITK_HAS_UNORDERED_MAP
-  std::tr1::unordered_map< TKey, FunctionObjectType, hash<TKey> > m_PFunction3;
-  std::tr1::unordered_map< TKey, FunctionObjectType, hash<TKey> > m_PFunction2;
+  sitk_tr1::unordered_map< TKey, FunctionObjectType, hash<TKey> > m_PFunction3;
+  sitk_tr1::unordered_map< TKey, FunctionObjectType, hash<TKey> > m_PFunction2;
 #else
   std::map<TKey, FunctionObjectType> m_PFunction3;
   std::map<TKey, FunctionObjectType> m_PFunction2;
@@ -224,7 +224,7 @@ public:
   /**  the pointer MemberFunctionType redefined ad a tr1::function
    * object
    */
-  typedef std::tr1::function< MemberFunctionResultType ( MemberFunctionArgument0Type,  MemberFunctionArgument1Type) > FunctionObjectType;
+  typedef sitk_tr1::function< MemberFunctionResultType ( MemberFunctionArgument0Type,  MemberFunctionArgument1Type) > FunctionObjectType;
 
 
 protected:
@@ -238,19 +238,19 @@ protected:
   static FunctionObjectType  BindObject( MemberFunctionType pfunc, ObjectType *objectPointer)
     {
       // needed for _1 place holder
-      using namespace std::tr1::placeholders;
+      using namespace sitk_tr1::placeholders;
 
       // this is really only needed because std::bind1st does not work
       // with tr1::function... that is with tr1::bind, we need to
       // specify the other arguments, and can't just bind the first
-      return std::tr1::bind( pfunc, objectPointer, _1, _2 );
+      return sitk_tr1::bind( pfunc, objectPointer, _1, _2 );
     }
 
 
   // maps of Keys to pointers to member functions
 #if defined SITK_HAS_UNORDERED_MAP
-  std::tr1::unordered_map< TKey, FunctionObjectType, hash<TKey> > m_PFunction3;
-  std::tr1::unordered_map< TKey, FunctionObjectType, hash<TKey> > m_PFunction2;
+  sitk_tr1::unordered_map< TKey, FunctionObjectType, hash<TKey> > m_PFunction3;
+  sitk_tr1::unordered_map< TKey, FunctionObjectType, hash<TKey> > m_PFunction2;
 #else
   std::map<TKey, FunctionObjectType> m_PFunction3;
   std::map<TKey, FunctionObjectType> m_PFunction2;
@@ -284,7 +284,7 @@ public:
 
   /**  the pointer MemberFunctionType redefined ad a tr1::function
    * object */
-  typedef std::tr1::function< MemberFunctionResultType ( MemberFunctionArgument0Type, MemberFunctionArgument1Type,  MemberFunctionArgument1Type) > FunctionObjectType;
+  typedef sitk_tr1::function< MemberFunctionResultType ( MemberFunctionArgument0Type, MemberFunctionArgument1Type,  MemberFunctionArgument1Type) > FunctionObjectType;
 
 
 protected:
@@ -298,19 +298,19 @@ protected:
   static FunctionObjectType  BindObject( MemberFunctionType pfunc, ObjectType *objectPointer)
     {
       // needed for _1 place holder
-      using namespace std::tr1::placeholders;
+      using namespace sitk_tr1::placeholders;
 
       // this is really only needed because std::bind1st does not work
       // with tr1::function... that is with tr1::bind, we need to
       // specify the other arguments, and can't just bind the first
-      return std::tr1::bind( pfunc, objectPointer, _1, _2, _3 );
+      return sitk_tr1::bind( pfunc, objectPointer, _1, _2, _3 );
     }
 
 
   // maps of Keys to pointers to member functions
 #if defined SITK_HAS_UNORDERED_MAP
-  std::tr1::unordered_map< TKey, FunctionObjectType, hash<TKey> > m_PFunction3;
-  std::tr1::unordered_map< TKey, FunctionObjectType, hash<TKey> > m_PFunction2;
+  sitk_tr1::unordered_map< TKey, FunctionObjectType, hash<TKey> > m_PFunction3;
+  sitk_tr1::unordered_map< TKey, FunctionObjectType, hash<TKey> > m_PFunction2;
 #else
   std::map<TKey, FunctionObjectType> m_PFunction3;
   std::map<TKey, FunctionObjectType> m_PFunction2;
@@ -345,7 +345,7 @@ public:
 
   /**  the pointer MemberFunctionType redefined ad a tr1::function
    * object */
-  typedef std::tr1::function< MemberFunctionResultType ( MemberFunctionArgument0Type, MemberFunctionArgument1Type, MemberFunctionArgument2Type,  MemberFunctionArgument3Type) > FunctionObjectType;
+  typedef sitk_tr1::function< MemberFunctionResultType ( MemberFunctionArgument0Type, MemberFunctionArgument1Type, MemberFunctionArgument2Type,  MemberFunctionArgument3Type) > FunctionObjectType;
 
 
 protected:
@@ -359,19 +359,19 @@ protected:
   static FunctionObjectType  BindObject( MemberFunctionType pfunc, ObjectType *objectPointer)
     {
       // needed for _1 place holder
-      using namespace std::tr1::placeholders;
+      using namespace sitk_tr1::placeholders;
 
       // this is really only needed because std::bind1st does not work
       // with tr1::function... that is with tr1::bind, we need to
       // specify the other arguments, and can't just bind the first
-      return std::tr1::bind( pfunc, objectPointer, _1, _2, _3, _4 );
+      return sitk_tr1::bind( pfunc, objectPointer, _1, _2, _3, _4 );
     }
 
 
   // maps of Keys to pointers to member functions
 #if defined SITK_HAS_UNORDERED_MAP
-  std::tr1::unordered_map< TKey, FunctionObjectType, hash<TKey> > m_PFunction3;
-  std::tr1::unordered_map< TKey, FunctionObjectType, hash<TKey> > m_PFunction2;
+  sitk_tr1::unordered_map< TKey, FunctionObjectType, hash<TKey> > m_PFunction3;
+  sitk_tr1::unordered_map< TKey, FunctionObjectType, hash<TKey> > m_PFunction2;
 #else
   std::map<TKey, FunctionObjectType> m_PFunction3;
   std::map<TKey, FunctionObjectType> m_PFunction2;

--- a/Code/Common/include/sitkPixelIDTokens.h
+++ b/Code/Common/include/sitkPixelIDTokens.h
@@ -36,8 +36,8 @@ namespace itk
 namespace simple
 {
 
-typedef std::tr1::true_type  TrueType;
-typedef std::tr1::false_type FalseType;
+typedef sitk_tr1::true_type  TrueType;
+typedef sitk_tr1::false_type FalseType;
 
 template <typename TPixelIDType>
 struct IsBasic
@@ -103,8 +103,8 @@ template <typename TPixelIDType>
 struct IsInstantiated
 {
   static const bool Value = ((int)PixelIDToPixelIDValue<TPixelIDType>::Result != (int)sitkUnknown);
-  typedef typename std::tr1::integral_constant<bool, Value>::value_type ValueType;
-  typedef typename std::tr1::integral_constant<bool, Value>::type       Type;
+  typedef typename sitk_tr1::integral_constant<bool, Value>::value_type ValueType;
+  typedef typename sitk_tr1::integral_constant<bool, Value>::type       Type;
 };
 template <typename TPixelType, unsigned int VImageDimension>
 struct IsInstantiated< itk::Image< TPixelType, VImageDimension> >

--- a/Code/Common/src/sitkConfigure.h.in
+++ b/Code/Common/src/sitkConfigure.h.in
@@ -46,6 +46,13 @@
 // defined if the system has <type_traits> header
 #cmakedefine SITK_HAS_STLTR1_TYPE_TRAITS
 
+// define if new features added from TR1 c++11 are in TR1 namespace
+#cmakedefine SITK_HAS_TR1_NAMESPACE
+#if SITK_HAS_TR1_NAMESPACE
+namespace sitk_tr1 = std::tr1;
+#else
+namespace sitk_tr1 = std;
+#endif
 
 
 // defined if the system has <tr1/unordered_map> header

--- a/Code/Common/src/sitkImage.hxx
+++ b/Code/Common/src/sitkImage.hxx
@@ -59,7 +59,7 @@ namespace itk
   }
 
   template<int VPixelIDValue, typename TImageType>
-  typename DisableIf<std::tr1::is_same<TImageType, void>::value>::Type
+  typename DisableIf<sitk_tr1::is_same<TImageType, void>::value>::Type
   Image::ConditionalInternalInitialization( TImageType *image )
   {
     // no need to check if null

--- a/Code/Common/src/sitkPimpleImageBase.hxx
+++ b/Code/Common/src/sitkPimpleImageBase.hxx
@@ -603,7 +603,7 @@ namespace itk
   protected:
 
     template < typename TPixelIDType >
-    typename EnableIf<std::tr1::is_same<TPixelIDType, typename ImageTypeToPixelID<ImageType>::PixelIDType>::value
+    typename EnableIf<sitk_tr1::is_same<TPixelIDType, typename ImageTypeToPixelID<ImageType>::PixelIDType>::value
                       && !IsLabel<TPixelIDType>::Value
                       && !IsVector<TPixelIDType>::Value,
                       typename ImageType::PixelType >::Type
@@ -618,7 +618,7 @@ namespace itk
       }
 
     template < typename TPixelIDType >
-    typename EnableIf<std::tr1::is_same<TPixelIDType, typename ImageTypeToPixelID<ImageType>::PixelIDType>::value
+    typename EnableIf<sitk_tr1::is_same<TPixelIDType, typename ImageTypeToPixelID<ImageType>::PixelIDType>::value
                       && IsLabel<TPixelIDType>::Value
                       && !IsVector<TPixelIDType>::Value,
                       typename ImageType::PixelType >::Type
@@ -633,7 +633,7 @@ namespace itk
       }
 
     template < typename TPixelIDType >
-    typename EnableIf<std::tr1::is_same<TPixelIDType, typename ImageTypeToPixelID<ImageType>::PixelIDType>::value
+    typename EnableIf<sitk_tr1::is_same<TPixelIDType, typename ImageTypeToPixelID<ImageType>::PixelIDType>::value
                       && !IsLabel<TPixelIDType>::Value
                       && IsVector<TPixelIDType>::Value,
                       std::vector<typename MakeDependentOn<TPixelIDType, ImageType>::InternalPixelType> >::Type
@@ -649,7 +649,7 @@ namespace itk
       }
 
     template < typename TPixelIDType >
-    typename DisableIf<std::tr1::is_same<TPixelIDType, typename ImageTypeToPixelID<ImageType>::PixelIDType>::value,
+    typename DisableIf<sitk_tr1::is_same<TPixelIDType, typename ImageTypeToPixelID<ImageType>::PixelIDType>::value,
                        typename Conditional< IsVector<TPixelIDType>::Value,
                                              std::vector< typename itk::NumericTraits<typename PixelIDToImageType<TPixelIDType,ImageType::ImageDimension>::ImageType::PixelType >::ValueType >,
                                              typename PixelIDToImageType<TPixelIDType,ImageType::ImageDimension>::ImageType::PixelType >::Type >::Type
@@ -663,7 +663,7 @@ namespace itk
       }
 
     template < typename TPixelIDType >
-    typename EnableIf<std::tr1::is_same<TPixelIDType, typename ImageTypeToPixelID<ImageType>::PixelIDType>::value
+    typename EnableIf<sitk_tr1::is_same<TPixelIDType, typename ImageTypeToPixelID<ImageType>::PixelIDType>::value
                       && !IsLabel<TPixelIDType>::Value
                       && !IsVector<TPixelIDType>::Value,
                       typename ImageType::PixelType *>::Type
@@ -673,7 +673,7 @@ namespace itk
       }
 
     template < typename TPixelIDType >
-    typename EnableIf<std::tr1::is_same<TPixelIDType, typename ImageTypeToPixelID<ImageType>::PixelIDType>::value
+    typename EnableIf<sitk_tr1::is_same<TPixelIDType, typename ImageTypeToPixelID<ImageType>::PixelIDType>::value
                       && IsLabel<TPixelIDType>::Value
                       && !IsVector<TPixelIDType>::Value,
                       typename ImageType::PixelType *>::Type
@@ -683,7 +683,7 @@ namespace itk
       }
 
     template < typename TPixelIDType >
-    typename EnableIf<std::tr1::is_same<TPixelIDType, typename ImageTypeToPixelID<ImageType>::PixelIDType>::value
+    typename EnableIf<sitk_tr1::is_same<TPixelIDType, typename ImageTypeToPixelID<ImageType>::PixelIDType>::value
                       && !IsLabel<TPixelIDType>::Value
                       && IsVector<TPixelIDType>::Value,
                       typename MakeDependentOn<TPixelIDType, ImageType>::InternalPixelType * >::Type
@@ -693,7 +693,7 @@ namespace itk
       }
 
     template < typename TPixelIDType >
-    typename DisableIf<std::tr1::is_same<TPixelIDType, typename ImageTypeToPixelID<ImageType>::PixelIDType>::value,
+    typename DisableIf<sitk_tr1::is_same<TPixelIDType, typename ImageTypeToPixelID<ImageType>::PixelIDType>::value,
                        typename NumericTraits<typename PixelIDToImageType<TPixelIDType,2>::ImageType::PixelType>::ValueType *>::Type
     InternalGetBuffer( void )
       {
@@ -705,7 +705,7 @@ namespace itk
 
 
     template < typename TPixelIDType, typename TPixelType >
-    typename EnableIf<std::tr1::is_same<TPixelIDType, typename ImageTypeToPixelID<ImageType>::PixelIDType>::value
+    typename EnableIf<sitk_tr1::is_same<TPixelIDType, typename ImageTypeToPixelID<ImageType>::PixelIDType>::value
                       && !IsLabel<TPixelIDType>::Value
                       && !IsVector<TPixelIDType>::Value >::Type
     InternalSetPixel( const std::vector<uint32_t> &idx, const TPixelType v ) const
@@ -719,7 +719,7 @@ namespace itk
       }
 
     template < typename TPixelIDType, typename TPixelType >
-    typename EnableIf<std::tr1::is_same<TPixelIDType, typename ImageTypeToPixelID<ImageType>::PixelIDType>::value
+    typename EnableIf<sitk_tr1::is_same<TPixelIDType, typename ImageTypeToPixelID<ImageType>::PixelIDType>::value
                       && IsLabel<TPixelIDType>::Value
                       && !IsVector<TPixelIDType>::Value >::Type
     InternalSetPixel( const std::vector<uint32_t> &idx, const TPixelType v ) const
@@ -733,7 +733,7 @@ namespace itk
       }
 
     template < typename TPixelIDType, typename TPixelValueType >
-    typename EnableIf<std::tr1::is_same<TPixelIDType, typename ImageTypeToPixelID<ImageType>::PixelIDType>::value
+    typename EnableIf<sitk_tr1::is_same<TPixelIDType, typename ImageTypeToPixelID<ImageType>::PixelIDType>::value
                       && !IsLabel<TPixelIDType>::Value
                       && IsVector<TPixelIDType>::Value >::Type
     InternalSetPixel( const std::vector<uint32_t> &idx, const std::vector<TPixelValueType> & v  ) const
@@ -758,7 +758,7 @@ namespace itk
 
 
     template < typename TPixelIDType, typename TPixelType >
-    typename DisableIf<std::tr1::is_same<TPixelIDType, typename ImageTypeToPixelID<ImageType>::PixelIDType>::value >::Type
+    typename DisableIf<sitk_tr1::is_same<TPixelIDType, typename ImageTypeToPixelID<ImageType>::PixelIDType>::value >::Type
     InternalSetPixel( const std::vector<uint32_t> &idx, const TPixelType &v ) const
       {
         Unused( idx );

--- a/Code/Common/src/sitkTransform.cxx
+++ b/Code/Common/src/sitkTransform.cxx
@@ -249,10 +249,10 @@ public:
       typename CompositeTransformType::TransformType* base =
         dynamic_cast< typename CompositeTransformType::TransformType*>( t.GetITKBase() );
 
-      return this->AddTransform( base, typename std::tr1::is_same<TTransformType, CompositeTransformType>::type() );
+      return this->AddTransform( base, typename sitk_tr1::is_same<TTransformType, CompositeTransformType>::type() );
     }
 
-  PimpleTransformBase* AddTransform( typename CompositeTransformType::TransformType* t, std::tr1::true_type isCompositeTransform )
+  PimpleTransformBase* AddTransform( typename CompositeTransformType::TransformType* t, sitk_tr1::true_type isCompositeTransform )
     {
       Unused( isCompositeTransform );
       assert( t->GetInputSpaceDimension() == TransformType::InputSpaceDimension );
@@ -261,7 +261,7 @@ public:
       return this;
     }
 
-  PimpleTransformBase* AddTransform( typename CompositeTransformType::TransformType* t, std::tr1::false_type isNotCompositeTransform )
+  PimpleTransformBase* AddTransform( typename CompositeTransformType::TransformType* t, sitk_tr1::false_type isNotCompositeTransform )
     {
       Unused( isNotCompositeTransform );
 

--- a/Testing/Unit/GoogleTest/gtest/gtest.h
+++ b/Testing/Unit/GoogleTest/gtest/gtest.h
@@ -688,7 +688,7 @@ template <typename T>
 struct ByRef<T&> { typedef T& type; };  // NOLINT
 
 // A handy wrapper for ByRef.
-#define GTEST_BY_REF_(T) typename ::std::tr1::gtest_internal::ByRef<T>::type
+#define GTEST_BY_REF_(T) typename ::sitk_tr1::gtest_internal::ByRef<T>::type
 
 // AddRef<T>::type is T if T is a reference; otherwise it's T&.  This
 // is the same as tr1::add_reference<T>::type.
@@ -698,7 +698,7 @@ template <typename T>
 struct AddRef<T&> { typedef T& type; };  // NOLINT
 
 // A handy wrapper for AddRef.
-#define GTEST_ADD_REF_(T) typename ::std::tr1::gtest_internal::AddRef<T>::type
+#define GTEST_ADD_REF_(T) typename ::sitk_tr1::gtest_internal::AddRef<T>::type
 
 // A helper for implementing get<k>().
 template <int k> class Get;
@@ -1208,7 +1208,7 @@ class tuple {
 // 6.1.3.2 Tuple creation functions.
 
 // Known limitations: we don't support passing an
-// std::tr1::reference_wrapper<T> to make_tuple().  And we don't
+// sitk_tr1::reference_wrapper<T> to make_tuple().  And we don't
 // implement tie().
 
 inline tuple<> make_tuple() { return tuple<>(); }
@@ -1481,7 +1481,7 @@ struct SameSizeTuplePrefixComparator<k, k> {
   template <class Tuple1, class Tuple2>
   static bool Eq(const Tuple1& t1, const Tuple2& t2) {
     return SameSizeTuplePrefixComparator<k - 1, k - 1>::Eq(t1, t2) &&
-        ::std::tr1::get<k - 1>(t1) == ::std::tr1::get<k - 1>(t2);
+        ::sitk_tr1::get<k - 1>(t1) == ::sitk_tr1::get<k - 1>(t2);
   }
 };
 
@@ -9674,7 +9674,7 @@ inline void PrintTo(const ::std::wstring& s, ::std::ostream* os) {
 #endif  // GTEST_HAS_STD_WSTRING
 
 #if GTEST_HAS_TR1_TUPLE
-// Overload for ::std::tr1::tuple.  Needed for printing function arguments,
+// Overload for ::sitk_tr1::tuple.  Needed for printing function arguments,
 // which are packed as tuples.
 
 // Helper function for printing a tuple.  T must be instantiated with
@@ -9687,60 +9687,60 @@ void PrintTupleTo(const T& t, ::std::ostream* os);
 // regardless of whether tr1::tuple is implemented using the
 // non-standard variadic template feature or not.
 
-inline void PrintTo(const ::std::tr1::tuple<>& t, ::std::ostream* os) {
+inline void PrintTo(const ::sitk_tr1::tuple<>& t, ::std::ostream* os) {
   PrintTupleTo(t, os);
 }
 
 template <typename T1>
-void PrintTo(const ::std::tr1::tuple<T1>& t, ::std::ostream* os) {
+void PrintTo(const ::sitk_tr1::tuple<T1>& t, ::std::ostream* os) {
   PrintTupleTo(t, os);
 }
 
 template <typename T1, typename T2>
-void PrintTo(const ::std::tr1::tuple<T1, T2>& t, ::std::ostream* os) {
+void PrintTo(const ::sitk_tr1::tuple<T1, T2>& t, ::std::ostream* os) {
   PrintTupleTo(t, os);
 }
 
 template <typename T1, typename T2, typename T3>
-void PrintTo(const ::std::tr1::tuple<T1, T2, T3>& t, ::std::ostream* os) {
+void PrintTo(const ::sitk_tr1::tuple<T1, T2, T3>& t, ::std::ostream* os) {
   PrintTupleTo(t, os);
 }
 
 template <typename T1, typename T2, typename T3, typename T4>
-void PrintTo(const ::std::tr1::tuple<T1, T2, T3, T4>& t, ::std::ostream* os) {
+void PrintTo(const ::sitk_tr1::tuple<T1, T2, T3, T4>& t, ::std::ostream* os) {
   PrintTupleTo(t, os);
 }
 
 template <typename T1, typename T2, typename T3, typename T4, typename T5>
-void PrintTo(const ::std::tr1::tuple<T1, T2, T3, T4, T5>& t,
+void PrintTo(const ::sitk_tr1::tuple<T1, T2, T3, T4, T5>& t,
              ::std::ostream* os) {
   PrintTupleTo(t, os);
 }
 
 template <typename T1, typename T2, typename T3, typename T4, typename T5,
           typename T6>
-void PrintTo(const ::std::tr1::tuple<T1, T2, T3, T4, T5, T6>& t,
+void PrintTo(const ::sitk_tr1::tuple<T1, T2, T3, T4, T5, T6>& t,
              ::std::ostream* os) {
   PrintTupleTo(t, os);
 }
 
 template <typename T1, typename T2, typename T3, typename T4, typename T5,
           typename T6, typename T7>
-void PrintTo(const ::std::tr1::tuple<T1, T2, T3, T4, T5, T6, T7>& t,
+void PrintTo(const ::sitk_tr1::tuple<T1, T2, T3, T4, T5, T6, T7>& t,
              ::std::ostream* os) {
   PrintTupleTo(t, os);
 }
 
 template <typename T1, typename T2, typename T3, typename T4, typename T5,
           typename T6, typename T7, typename T8>
-void PrintTo(const ::std::tr1::tuple<T1, T2, T3, T4, T5, T6, T7, T8>& t,
+void PrintTo(const ::sitk_tr1::tuple<T1, T2, T3, T4, T5, T6, T7, T8>& t,
              ::std::ostream* os) {
   PrintTupleTo(t, os);
 }
 
 template <typename T1, typename T2, typename T3, typename T4, typename T5,
           typename T6, typename T7, typename T8, typename T9>
-void PrintTo(const ::std::tr1::tuple<T1, T2, T3, T4, T5, T6, T7, T8, T9>& t,
+void PrintTo(const ::sitk_tr1::tuple<T1, T2, T3, T4, T5, T6, T7, T8, T9>& t,
              ::std::ostream* os) {
   PrintTupleTo(t, os);
 }
@@ -9748,7 +9748,7 @@ void PrintTo(const ::std::tr1::tuple<T1, T2, T3, T4, T5, T6, T7, T8, T9>& t,
 template <typename T1, typename T2, typename T3, typename T4, typename T5,
           typename T6, typename T7, typename T8, typename T9, typename T10>
 void PrintTo(
-    const ::std::tr1::tuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>& t,
+    const ::sitk_tr1::tuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>& t,
     ::std::ostream* os) {
   PrintTupleTo(t, os);
 }
@@ -9908,8 +9908,8 @@ struct TuplePrefixPrinter {
   static void PrintPrefixTo(const Tuple& t, ::std::ostream* os) {
     TuplePrefixPrinter<N - 1>::PrintPrefixTo(t, os);
     *os << ", ";
-    UniversalPrinter<typename ::std::tr1::tuple_element<N - 1, Tuple>::type>
-        ::Print(::std::tr1::get<N - 1>(t), os);
+    UniversalPrinter<typename ::sitk_tr1::tuple_element<N - 1, Tuple>::type>
+        ::Print(::sitk_tr1::get<N - 1>(t), os);
   }
 
   // Tersely prints the first N fields of a tuple to a string vector,
@@ -9918,7 +9918,7 @@ struct TuplePrefixPrinter {
   static void TersePrintPrefixToStrings(const Tuple& t, Strings* strings) {
     TuplePrefixPrinter<N - 1>::TersePrintPrefixToStrings(t, strings);
     ::std::stringstream ss;
-    UniversalTersePrint(::std::tr1::get<N - 1>(t), &ss);
+    UniversalTersePrint(::sitk_tr1::get<N - 1>(t), &ss);
     strings->push_back(ss.str());
   }
 };
@@ -9941,14 +9941,14 @@ template <>
 struct TuplePrefixPrinter<1> {
   template <typename Tuple>
   static void PrintPrefixTo(const Tuple& t, ::std::ostream* os) {
-    UniversalPrinter<typename ::std::tr1::tuple_element<0, Tuple>::type>::
-        Print(::std::tr1::get<0>(t), os);
+    UniversalPrinter<typename ::sitk_tr1::tuple_element<0, Tuple>::type>::
+        Print(::sitk_tr1::get<0>(t), os);
   }
 
   template <typename Tuple>
   static void TersePrintPrefixToStrings(const Tuple& t, Strings* strings) {
     ::std::stringstream ss;
-    UniversalTersePrint(::std::tr1::get<0>(t), &ss);
+    UniversalTersePrint(::sitk_tr1::get<0>(t), &ss);
     strings->push_back(ss.str());
   }
 };
@@ -9958,7 +9958,7 @@ struct TuplePrefixPrinter<1> {
 template <typename T>
 void PrintTupleTo(const T& t, ::std::ostream* os) {
   *os << "(";
-  TuplePrefixPrinter< ::std::tr1::tuple_size<T>::value>::
+  TuplePrefixPrinter< ::sitk_tr1::tuple_size<T>::value>::
       PrintPrefixTo(t, os);
   *os << ")";
 }
@@ -9969,7 +9969,7 @@ void PrintTupleTo(const T& t, ::std::ostream* os) {
 template <typename Tuple>
 Strings UniversalTersePrintTupleFieldsToStrings(const Tuple& value) {
   Strings result;
-  TuplePrefixPrinter< ::std::tr1::tuple_size<Tuple>::value>::
+  TuplePrefixPrinter< ::sitk_tr1::tuple_size<Tuple>::value>::
       TersePrintPrefixToStrings(value, &result);
   return result;
 }
@@ -13395,9 +13395,9 @@ class ValueArray50 {
 //
 template <typename T1, typename T2>
 class CartesianProductGenerator2
-    : public ParamGeneratorInterface< ::std::tr1::tuple<T1, T2> > {
+    : public ParamGeneratorInterface< ::sitk_tr1::tuple<T1, T2> > {
  public:
-  typedef ::std::tr1::tuple<T1, T2> ParamType;
+  typedef ::sitk_tr1::tuple<T1, T2> ParamType;
 
   CartesianProductGenerator2(const ParamGenerator<T1>& g1,
       const ParamGenerator<T2>& g2)
@@ -13510,9 +13510,9 @@ class CartesianProductGenerator2
 
 template <typename T1, typename T2, typename T3>
 class CartesianProductGenerator3
-    : public ParamGeneratorInterface< ::std::tr1::tuple<T1, T2, T3> > {
+    : public ParamGeneratorInterface< ::sitk_tr1::tuple<T1, T2, T3> > {
  public:
-  typedef ::std::tr1::tuple<T1, T2, T3> ParamType;
+  typedef ::sitk_tr1::tuple<T1, T2, T3> ParamType;
 
   CartesianProductGenerator3(const ParamGenerator<T1>& g1,
       const ParamGenerator<T2>& g2, const ParamGenerator<T3>& g3)
@@ -13642,9 +13642,9 @@ class CartesianProductGenerator3
 
 template <typename T1, typename T2, typename T3, typename T4>
 class CartesianProductGenerator4
-    : public ParamGeneratorInterface< ::std::tr1::tuple<T1, T2, T3, T4> > {
+    : public ParamGeneratorInterface< ::sitk_tr1::tuple<T1, T2, T3, T4> > {
  public:
-  typedef ::std::tr1::tuple<T1, T2, T3, T4> ParamType;
+  typedef ::sitk_tr1::tuple<T1, T2, T3, T4> ParamType;
 
   CartesianProductGenerator4(const ParamGenerator<T1>& g1,
       const ParamGenerator<T2>& g2, const ParamGenerator<T3>& g3,
@@ -13793,9 +13793,9 @@ class CartesianProductGenerator4
 
 template <typename T1, typename T2, typename T3, typename T4, typename T5>
 class CartesianProductGenerator5
-    : public ParamGeneratorInterface< ::std::tr1::tuple<T1, T2, T3, T4, T5> > {
+    : public ParamGeneratorInterface< ::sitk_tr1::tuple<T1, T2, T3, T4, T5> > {
  public:
-  typedef ::std::tr1::tuple<T1, T2, T3, T4, T5> ParamType;
+  typedef ::sitk_tr1::tuple<T1, T2, T3, T4, T5> ParamType;
 
   CartesianProductGenerator5(const ParamGenerator<T1>& g1,
       const ParamGenerator<T2>& g2, const ParamGenerator<T3>& g3,
@@ -13961,10 +13961,10 @@ class CartesianProductGenerator5
 template <typename T1, typename T2, typename T3, typename T4, typename T5,
     typename T6>
 class CartesianProductGenerator6
-    : public ParamGeneratorInterface< ::std::tr1::tuple<T1, T2, T3, T4, T5,
+    : public ParamGeneratorInterface< ::sitk_tr1::tuple<T1, T2, T3, T4, T5,
         T6> > {
  public:
-  typedef ::std::tr1::tuple<T1, T2, T3, T4, T5, T6> ParamType;
+  typedef ::sitk_tr1::tuple<T1, T2, T3, T4, T5, T6> ParamType;
 
   CartesianProductGenerator6(const ParamGenerator<T1>& g1,
       const ParamGenerator<T2>& g2, const ParamGenerator<T3>& g3,
@@ -14147,10 +14147,10 @@ class CartesianProductGenerator6
 template <typename T1, typename T2, typename T3, typename T4, typename T5,
     typename T6, typename T7>
 class CartesianProductGenerator7
-    : public ParamGeneratorInterface< ::std::tr1::tuple<T1, T2, T3, T4, T5, T6,
+    : public ParamGeneratorInterface< ::sitk_tr1::tuple<T1, T2, T3, T4, T5, T6,
         T7> > {
  public:
-  typedef ::std::tr1::tuple<T1, T2, T3, T4, T5, T6, T7> ParamType;
+  typedef ::sitk_tr1::tuple<T1, T2, T3, T4, T5, T6, T7> ParamType;
 
   CartesianProductGenerator7(const ParamGenerator<T1>& g1,
       const ParamGenerator<T2>& g2, const ParamGenerator<T3>& g3,
@@ -14350,10 +14350,10 @@ class CartesianProductGenerator7
 template <typename T1, typename T2, typename T3, typename T4, typename T5,
     typename T6, typename T7, typename T8>
 class CartesianProductGenerator8
-    : public ParamGeneratorInterface< ::std::tr1::tuple<T1, T2, T3, T4, T5, T6,
+    : public ParamGeneratorInterface< ::sitk_tr1::tuple<T1, T2, T3, T4, T5, T6,
         T7, T8> > {
  public:
-  typedef ::std::tr1::tuple<T1, T2, T3, T4, T5, T6, T7, T8> ParamType;
+  typedef ::sitk_tr1::tuple<T1, T2, T3, T4, T5, T6, T7, T8> ParamType;
 
   CartesianProductGenerator8(const ParamGenerator<T1>& g1,
       const ParamGenerator<T2>& g2, const ParamGenerator<T3>& g3,
@@ -14572,10 +14572,10 @@ class CartesianProductGenerator8
 template <typename T1, typename T2, typename T3, typename T4, typename T5,
     typename T6, typename T7, typename T8, typename T9>
 class CartesianProductGenerator9
-    : public ParamGeneratorInterface< ::std::tr1::tuple<T1, T2, T3, T4, T5, T6,
+    : public ParamGeneratorInterface< ::sitk_tr1::tuple<T1, T2, T3, T4, T5, T6,
         T7, T8, T9> > {
  public:
-  typedef ::std::tr1::tuple<T1, T2, T3, T4, T5, T6, T7, T8, T9> ParamType;
+  typedef ::sitk_tr1::tuple<T1, T2, T3, T4, T5, T6, T7, T8, T9> ParamType;
 
   CartesianProductGenerator9(const ParamGenerator<T1>& g1,
       const ParamGenerator<T2>& g2, const ParamGenerator<T3>& g3,
@@ -14811,10 +14811,10 @@ class CartesianProductGenerator9
 template <typename T1, typename T2, typename T3, typename T4, typename T5,
     typename T6, typename T7, typename T8, typename T9, typename T10>
 class CartesianProductGenerator10
-    : public ParamGeneratorInterface< ::std::tr1::tuple<T1, T2, T3, T4, T5, T6,
+    : public ParamGeneratorInterface< ::sitk_tr1::tuple<T1, T2, T3, T4, T5, T6,
         T7, T8, T9, T10> > {
  public:
-  typedef ::std::tr1::tuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> ParamType;
+  typedef ::sitk_tr1::tuple<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> ParamType;
 
   CartesianProductGenerator10(const ParamGenerator<T1>& g1,
       const ParamGenerator<T2>& g2, const ParamGenerator<T3>& g3,
@@ -15076,8 +15076,8 @@ class CartesianProductHolder2 {
 CartesianProductHolder2(const Generator1& g1, const Generator2& g2)
       : g1_(g1), g2_(g2) {}
   template <typename T1, typename T2>
-  operator ParamGenerator< ::std::tr1::tuple<T1, T2> >() const {
-    return ParamGenerator< ::std::tr1::tuple<T1, T2> >(
+  operator ParamGenerator< ::sitk_tr1::tuple<T1, T2> >() const {
+    return ParamGenerator< ::sitk_tr1::tuple<T1, T2> >(
         new CartesianProductGenerator2<T1, T2>(
         static_cast<ParamGenerator<T1> >(g1_),
         static_cast<ParamGenerator<T2> >(g2_)));
@@ -15098,8 +15098,8 @@ CartesianProductHolder3(const Generator1& g1, const Generator2& g2,
     const Generator3& g3)
       : g1_(g1), g2_(g2), g3_(g3) {}
   template <typename T1, typename T2, typename T3>
-  operator ParamGenerator< ::std::tr1::tuple<T1, T2, T3> >() const {
-    return ParamGenerator< ::std::tr1::tuple<T1, T2, T3> >(
+  operator ParamGenerator< ::sitk_tr1::tuple<T1, T2, T3> >() const {
+    return ParamGenerator< ::sitk_tr1::tuple<T1, T2, T3> >(
         new CartesianProductGenerator3<T1, T2, T3>(
         static_cast<ParamGenerator<T1> >(g1_),
         static_cast<ParamGenerator<T2> >(g2_),
@@ -15123,8 +15123,8 @@ CartesianProductHolder4(const Generator1& g1, const Generator2& g2,
     const Generator3& g3, const Generator4& g4)
       : g1_(g1), g2_(g2), g3_(g3), g4_(g4) {}
   template <typename T1, typename T2, typename T3, typename T4>
-  operator ParamGenerator< ::std::tr1::tuple<T1, T2, T3, T4> >() const {
-    return ParamGenerator< ::std::tr1::tuple<T1, T2, T3, T4> >(
+  operator ParamGenerator< ::sitk_tr1::tuple<T1, T2, T3, T4> >() const {
+    return ParamGenerator< ::sitk_tr1::tuple<T1, T2, T3, T4> >(
         new CartesianProductGenerator4<T1, T2, T3, T4>(
         static_cast<ParamGenerator<T1> >(g1_),
         static_cast<ParamGenerator<T2> >(g2_),
@@ -15150,8 +15150,8 @@ CartesianProductHolder5(const Generator1& g1, const Generator2& g2,
     const Generator3& g3, const Generator4& g4, const Generator5& g5)
       : g1_(g1), g2_(g2), g3_(g3), g4_(g4), g5_(g5) {}
   template <typename T1, typename T2, typename T3, typename T4, typename T5>
-  operator ParamGenerator< ::std::tr1::tuple<T1, T2, T3, T4, T5> >() const {
-    return ParamGenerator< ::std::tr1::tuple<T1, T2, T3, T4, T5> >(
+  operator ParamGenerator< ::sitk_tr1::tuple<T1, T2, T3, T4, T5> >() const {
+    return ParamGenerator< ::sitk_tr1::tuple<T1, T2, T3, T4, T5> >(
         new CartesianProductGenerator5<T1, T2, T3, T4, T5>(
         static_cast<ParamGenerator<T1> >(g1_),
         static_cast<ParamGenerator<T2> >(g2_),
@@ -15181,8 +15181,8 @@ CartesianProductHolder6(const Generator1& g1, const Generator2& g2,
       : g1_(g1), g2_(g2), g3_(g3), g4_(g4), g5_(g5), g6_(g6) {}
   template <typename T1, typename T2, typename T3, typename T4, typename T5,
       typename T6>
-  operator ParamGenerator< ::std::tr1::tuple<T1, T2, T3, T4, T5, T6> >() const {
-    return ParamGenerator< ::std::tr1::tuple<T1, T2, T3, T4, T5, T6> >(
+  operator ParamGenerator< ::sitk_tr1::tuple<T1, T2, T3, T4, T5, T6> >() const {
+    return ParamGenerator< ::sitk_tr1::tuple<T1, T2, T3, T4, T5, T6> >(
         new CartesianProductGenerator6<T1, T2, T3, T4, T5, T6>(
         static_cast<ParamGenerator<T1> >(g1_),
         static_cast<ParamGenerator<T2> >(g2_),
@@ -15214,9 +15214,9 @@ CartesianProductHolder7(const Generator1& g1, const Generator2& g2,
       : g1_(g1), g2_(g2), g3_(g3), g4_(g4), g5_(g5), g6_(g6), g7_(g7) {}
   template <typename T1, typename T2, typename T3, typename T4, typename T5,
       typename T6, typename T7>
-  operator ParamGenerator< ::std::tr1::tuple<T1, T2, T3, T4, T5, T6,
+  operator ParamGenerator< ::sitk_tr1::tuple<T1, T2, T3, T4, T5, T6,
       T7> >() const {
-    return ParamGenerator< ::std::tr1::tuple<T1, T2, T3, T4, T5, T6, T7> >(
+    return ParamGenerator< ::sitk_tr1::tuple<T1, T2, T3, T4, T5, T6, T7> >(
         new CartesianProductGenerator7<T1, T2, T3, T4, T5, T6, T7>(
         static_cast<ParamGenerator<T1> >(g1_),
         static_cast<ParamGenerator<T2> >(g2_),
@@ -15252,9 +15252,9 @@ CartesianProductHolder8(const Generator1& g1, const Generator2& g2,
           g8_(g8) {}
   template <typename T1, typename T2, typename T3, typename T4, typename T5,
       typename T6, typename T7, typename T8>
-  operator ParamGenerator< ::std::tr1::tuple<T1, T2, T3, T4, T5, T6, T7,
+  operator ParamGenerator< ::sitk_tr1::tuple<T1, T2, T3, T4, T5, T6, T7,
       T8> >() const {
-    return ParamGenerator< ::std::tr1::tuple<T1, T2, T3, T4, T5, T6, T7, T8> >(
+    return ParamGenerator< ::sitk_tr1::tuple<T1, T2, T3, T4, T5, T6, T7, T8> >(
         new CartesianProductGenerator8<T1, T2, T3, T4, T5, T6, T7, T8>(
         static_cast<ParamGenerator<T1> >(g1_),
         static_cast<ParamGenerator<T2> >(g2_),
@@ -15293,9 +15293,9 @@ CartesianProductHolder9(const Generator1& g1, const Generator2& g2,
           g9_(g9) {}
   template <typename T1, typename T2, typename T3, typename T4, typename T5,
       typename T6, typename T7, typename T8, typename T9>
-  operator ParamGenerator< ::std::tr1::tuple<T1, T2, T3, T4, T5, T6, T7, T8,
+  operator ParamGenerator< ::sitk_tr1::tuple<T1, T2, T3, T4, T5, T6, T7, T8,
       T9> >() const {
-    return ParamGenerator< ::std::tr1::tuple<T1, T2, T3, T4, T5, T6, T7, T8,
+    return ParamGenerator< ::sitk_tr1::tuple<T1, T2, T3, T4, T5, T6, T7, T8,
         T9> >(
         new CartesianProductGenerator9<T1, T2, T3, T4, T5, T6, T7, T8, T9>(
         static_cast<ParamGenerator<T1> >(g1_),
@@ -15337,9 +15337,9 @@ CartesianProductHolder10(const Generator1& g1, const Generator2& g2,
           g9_(g9), g10_(g10) {}
   template <typename T1, typename T2, typename T3, typename T4, typename T5,
       typename T6, typename T7, typename T8, typename T9, typename T10>
-  operator ParamGenerator< ::std::tr1::tuple<T1, T2, T3, T4, T5, T6, T7, T8,
+  operator ParamGenerator< ::sitk_tr1::tuple<T1, T2, T3, T4, T5, T6, T7, T8,
       T9, T10> >() const {
-    return ParamGenerator< ::std::tr1::tuple<T1, T2, T3, T4, T5, T6, T7, T8,
+    return ParamGenerator< ::sitk_tr1::tuple<T1, T2, T3, T4, T5, T6, T7, T8,
         T9, T10> >(
         new CartesianProductGenerator10<T1, T2, T3, T4, T5, T6, T7, T8, T9,
             T10>(


### PR DESCRIPTION
The c++ expanded std:: library features are moved
from tr1 to the main library.  Issues were found
when compiling with "clang++ -stdlib=libc++ -std=c++11".
