### PR TITLE
Simplify if() conditions on check result variables

### DIFF
--- a/CMake/sitkCheckCXX11.cmake
+++ b/CMake/sitkCheckCXX11.cmake
@@ -21,7 +21,7 @@ function(sitkCXX11Test VARIABLE)
   # cache the results.
   string(MD5 cmake_cxx_flags_hash "${CMAKE_CXX_FLAGS}")
   set(cache_var "${VARIABLE}_${hash_cmake_cxx_flags_hash}")
-  if("${cache_var}" MATCHES "^${cache_var}$")
+  if(NOT DEFINED "${cache_var}")
     message(STATUS "Performing Test ${VARIABLE}")
     set(requred_definitions "${CMAKE_REQUIRED_DEFINITIONS} -D${VARIABLE}")
     try_compile(${VARIABLE}


### PR DESCRIPTION
Remove use of an old hack that takes advantage of the auto-dereference
behavior of the if() command to detect if a variable is defined.  The
hack has the form:

 if("${VAR} MATCHES "^${VAR}$")

where "${VAR}" is a macro argument reference.  Use if(NOT DEFINED) instead.
This also avoids warnings for CMake Policy CMP0054.