### PR TITLE
add CastImageFilter to make writing easier

### DIFF
--- a/Examples/SimpleGaussian.cs
+++ b/Examples/SimpleGaussian.cs
@@ -34,12 +34,19 @@ namespace itk.simple.examples {
                 // Execute Gaussian smoothing filter
                 SmoothingRecursiveGaussianImageFilter gaussian = new SmoothingRecursiveGaussianImageFilter();
                 gaussian.SetSigma(Double.Parse(args[1]));
-                image = gaussian.Execute(image);
+                Image blurredImage = gaussian.Execute(image);
+                
+                // Covert the real output image back to the original pixel type , to
+                // make writing easier , as many file formats don 't support real
+                // pixels .
+                CastImageFilter castFilter = new CastImageFilter();
+                castFilter.SetOutputPixelType(image.GetPixelIDValue());
+                Image destImage = castFilter.Execute(blurredImage);
 
                 // Write output image
                 ImageFileWriter writer = new ImageFileWriter();
                 writer.SetFileName(args[2]);
-                writer.Execute(image);
+                writer.Execute(destImage);
 
             } catch (Exception ex) {
                 Console.WriteLine(ex);


### PR DESCRIPTION
Covert the real output image back to the original pixel type , to make writing easier, as many file formats don 't support real pixels.
See issue #35 .