### PR TITLE
UseCSharp.cmake: fix list expansion to string

### DIFF
--- a/CMake/UseCSharp.cmake
+++ b/CMake/UseCSharp.cmake
@@ -89,9 +89,9 @@ macro( CSHARP_ADD_PROJECT type name )
 
   # Perform platform specific actions
   if (WIN32)
-    string( REPLACE "/" "\\" sources ${sources} )
+    string( REPLACE "/" "\\" sources "${sources}" )
   else (UNIX)
-    string( REPLACE "\\" "/" sources ${sources} )
+    string( REPLACE "\\" "/" sources "${sources}" )
   endif (WIN32)
 
   # Add custom target and command


### PR DESCRIPTION
I've noticed a problem in `UseCSharp.cmake` that doesn't let a list to expand properly at command execution after string slash replacement. Here's the fix.