### PR TITLE
BUG: Fix Java 1.8 javadoc linting breaking the java build

### DIFF
--- a/Wrapping/Java/CMakeLists.txt
+++ b/Wrapping/Java/CMakeLists.txt
@@ -29,6 +29,18 @@ sitk_strip_target( ${SWIG_MODULE_SimpleITKJava_TARGET_NAME} )
 add_custom_target(org_itk_simple_jar ALL DEPENDS ${JAR_FILE})
 set(JAVA_SOURCE_CODE ${JAVA_SOURCE_DIRECTORY}/org/itk/simple/*.java)
 
+# Java 1.8 javadoc treats linting errors as build errors by default 
+# so linting should be opt-in for this version
+if( ${Java_VERSION_STRING} VERSION_EQUAL 1.8 OR ${Java_VERSION_STRING} VERSION_GREATER 1.8 )
+  mark_as_advanced( Java_JAVADOC_LINTING )
+  option( Java_JAVADOC_LINTING "Enable javadoc linting for Java 1.8" OFF )
+  if( Java_JAVADOC_LINTING )
+    set( Java_JAVADOC_LINTING_CMD "-Xdoclint:none" )
+  else()
+    set( Java_JAVADOC_LINTING_CMD "-Xdoclint:all" )
+  endif()
+endif()
+
 # Add custom command and target to compile the generated files and put them in a jar file
 # Make sure the commands depend on the output library from SWIG
 add_custom_command(
@@ -36,7 +48,7 @@ add_custom_command(
   COMMENT "Creating jar file..."
   COMMAND ${Java_JAVAC_EXECUTABLE} -d ${JAVA_BINARY_DIRECTORY} ${JAVA_SOURCE_CODE}
   COMMAND ${Java_JAR_EXECUTABLE} cf ${CMAKE_CURRENT_BINARY_DIR}/${JAR_FILE} -C ${JAVA_BINARY_DIRECTORY} org
-  COMMAND ${Java_JAVADOC_EXECUTABLE} -quiet -d ${JAVA_BINARY_DIRECTORY}/javadoc -sourcepath ${JAVA_SOURCE_DIRECTORY} org.itk.simple
+  COMMAND ${Java_JAVADOC_EXECUTABLE} ${Java_JAVADOC_LINTING_CMD} -quiet -d ${JAVA_BINARY_DIRECTORY}/javadoc -sourcepath ${JAVA_SOURCE_DIRECTORY} org.itk.simple
   COMMAND ${Java_JAR_EXECUTABLE} cf ${CMAKE_CURRENT_BINARY_DIR}/${JAVADOC_FILE} -C ${JAVA_BINARY_DIRECTORY}/javadoc org
   COMMAND ${Java_JAR_EXECUTABLE} cf ${CMAKE_CURRENT_BINARY_DIR}/${JAVA_SOURCE_FILE} org
   DEPENDS ${SWIG_MODULE_SimpleITKJava_TARGET_NAME}


### PR DESCRIPTION
Java 1.8 javadoc treats linting errors as build errors by default so linting should be opt-in for this version.