### PR TITLE
COMP: Using SimpleITK from C++ need operators

### DIFF
--- a/Code/Common/include/SimpleITK.h
+++ b/Code/Common/include/SimpleITK.h
@@ -72,6 +72,20 @@
 
 #include "sitkAdditionalProcedures.h"
 
+/* 
+ * An intentional design choice to have to explicitly include the Image
+ * operators and not get them by with the basic "SimpleITK.h".
+ * The addition of these convenience mathematical operators
+ * in C++ can be a source of confusion.
+ *
+ * Either:
+ *   1) explicity include "sitkImageOperators.h" (Recommended)
+ *   2) or define USE_SimpleITK_ImageOperators BEFORE including SimpleITK.h
+ */
+#ifdef USE_SimpleITK_ImageOperators
+#include "sitkImageOperators.h"
+#endif
+
 #include "sitkImageRegistrationMethod.h"
 
 // These headers are auto-generated

--- a/Code/Common/include/sitkImage.h
+++ b/Code/Common/include/sitkImage.h
@@ -188,6 +188,7 @@ namespace simple
     std::vector< double > TransformContinuousIndexToPhysicalPoint( const std::vector< double > &index) const;
 
     std::vector< unsigned int > GetSize( void ) const;
+    unsigned int GetNumberOfPixels( void ) const;
 
     unsigned int GetHeight( void ) const;
     unsigned int GetWidth( void ) const;

--- a/Code/Common/include/sitkImage.h
+++ b/Code/Common/include/sitkImage.h
@@ -57,6 +57,16 @@ namespace simple
   public:
     typedef Image              Self;
 
+    //Utility typedefs for commonly used concepts used
+    //in manipulating SimpleITK images
+    typedef std::vector<uint32_t> IndexType;
+    typedef std::vector<int64_t>  SignedIndexType;
+    typedef std::vector<uint32_t> SizeType;
+    typedef std::vector<double>   OriginType;
+    typedef std::vector<double>   PointType;
+    typedef std::vector<double>   SpacingType;
+    typedef std::vector<double>   DirectionType;
+
     virtual ~Image( );
 
     /** \brief Default constructor, creates an image of size 0 */

--- a/Code/Common/src/sitkImage.cxx
+++ b/Code/Common/src/sitkImage.cxx
@@ -143,6 +143,13 @@ namespace itk
       return this->m_PimpleImage->GetSize();
     }
 
+    unsigned int Image::GetNumberOfPixels( void ) const
+    {
+      assert( m_PimpleImage );
+      return this->m_PimpleImage->GetNumberOfPixels();
+    }
+
+
     unsigned int Image::GetWidth( void ) const
     {
       assert( m_PimpleImage );

--- a/Code/Common/src/sitkPimpleImageBase.h
+++ b/Code/Common/src/sitkPimpleImageBase.h
@@ -58,6 +58,8 @@ namespace itk
     virtual std::vector< unsigned int > GetSize( void ) const = 0;
     virtual unsigned int GetSize( unsigned int dimension ) const = 0;
 
+    virtual unsigned int GetNumberOfPixels( void ) const = 0;
+
     virtual std::vector<double> GetOrigin( void ) const = 0;
     virtual void SetOrigin( const std::vector<double> &orgn ) = 0;
     virtual std::vector<double> GetSpacing( void ) const = 0;

--- a/Code/Common/src/sitkPimpleImageBase.hxx
+++ b/Code/Common/src/sitkPimpleImageBase.hxx
@@ -261,16 +261,28 @@ namespace itk
           return 0;
           }
 
-        typename ImageType::RegionType largestRegion = this->m_Image->GetLargestPossibleRegion();
+        const typename ImageType::RegionType & largestRegion = this->m_Image->GetLargestPossibleRegion();
         return largestRegion.GetSize(dimension);
       }
 
     virtual std::vector<unsigned int> GetSize( void ) const
       {
-        typename ImageType::RegionType largestRegion = this->m_Image->GetLargestPossibleRegion();
+        const typename ImageType::RegionType & largestRegion = this->m_Image->GetLargestPossibleRegion();
         std::vector<unsigned int> size( ImageType::ImageDimension );
 
         return sitkITKVectorToSTL<unsigned int>( largestRegion.GetSize() );
+      }
+
+    virtual unsigned int GetNumberOfPixels( void ) const
+      {
+        const typename ImageType::RegionType & largestRegion = this->m_Image->GetLargestPossibleRegion();
+        const typename ImageType::SizeType & size = largestRegion.GetSize();
+        unsigned int numPixels = 0;
+        for( size_t i=0; i < ImageType::ImageDimension; ++i )
+          {
+          numPixels += size[i];
+          }
+        return numPixels;
       }
 
     std::string ToString( void ) const


### PR DESCRIPTION
After #include <SimpleITK.h>, the ability to manipulate
images with operators should be in place.

The missing headers were added to SimpleITK.h so that
the expected behavior is supported.

for i in SimpleITK/Code/BasicFilters/include/sitk*.h; do
  nn=$(basename $i);
  grep  $nn SimpleITK/Code/Common/include/SimpleITK.h;
done