### PR TITLE
ENH: Add GetNumberOfPixels to Images

### DIFF
--- a/Code/Common/include/sitkImage.h
+++ b/Code/Common/include/sitkImage.h
@@ -149,6 +149,17 @@ namespace simple
      * number of components for each pixel is returned.
      */
     unsigned int GetNumberOfComponentsPerPixel( void ) const;
+    /** \brief Get the number of pixels in each image
+     *
+     *  Some pixels may have more than one component, so
+     *  GetNumberOfPixels should be multiplied by
+     *  GetNumberOfComponentsPerPixel in order to calculate the
+     *  the total number of values stored congituously for the image.
+     *
+     * The GetNumberOfPixels produces the same result
+     * as GetWidth()*GetHeight()*GetDepth().  This value
+     */
+    uint64_t GetNumberOfPixels( void ) const;
 
     /** Get/Set the Origin
      * @{

--- a/Code/Common/src/sitkImage.cxx
+++ b/Code/Common/src/sitkImage.cxx
@@ -126,6 +126,12 @@ namespace itk
       return this->m_PimpleImage->GetNumberOfComponentsPerPixel();
     }
 
+    uint64_t Image::GetNumberOfPixels( void ) const
+    {
+      assert( m_PimpleImage );
+      return this->m_PimpleImage->GetNumberOfPixels();
+    }
+
     std::string Image::GetPixelIDTypeAsString( void ) const
     {
       return std::string( GetPixelIDValueAsString( this->GetPixelIDValue() ) );

--- a/Code/Common/src/sitkPimpleImageBase.h
+++ b/Code/Common/src/sitkPimpleImageBase.h
@@ -44,6 +44,7 @@ namespace itk
 
     virtual PixelIDValueEnum GetPixelID(void) const = 0;
     virtual unsigned int GetDimension( void ) const  = 0;
+    virtual uint64_t GetNumberOfPixels( void ) const = 0;
     virtual unsigned int GetNumberOfComponentsPerPixel( void ) const = 0;
 
     virtual PimpleImageBase *ShallowCopy(void) const = 0;
@@ -57,6 +58,7 @@ namespace itk
 
     virtual std::vector< unsigned int > GetSize( void ) const = 0;
     virtual unsigned int GetSize( unsigned int dimension ) const = 0;
+
 
     virtual std::vector<double> GetOrigin( void ) const = 0;
     virtual void SetOrigin( const std::vector<double> &orgn ) = 0;

--- a/Code/Common/src/sitkPimpleImageBase.hxx
+++ b/Code/Common/src/sitkPimpleImageBase.hxx
@@ -261,16 +261,21 @@ namespace itk
           return 0;
           }
 
-        typename ImageType::RegionType largestRegion = this->m_Image->GetLargestPossibleRegion();
+        const typename ImageType::RegionType & largestRegion = this->m_Image->GetLargestPossibleRegion();
         return largestRegion.GetSize(dimension);
       }
 
     virtual std::vector<unsigned int> GetSize( void ) const
       {
-        typename ImageType::RegionType largestRegion = this->m_Image->GetLargestPossibleRegion();
+        const typename ImageType::RegionType & largestRegion = this->m_Image->GetLargestPossibleRegion();
         std::vector<unsigned int> size( ImageType::ImageDimension );
 
         return sitkITKVectorToSTL<unsigned int>( largestRegion.GetSize() );
+      }
+
+    virtual uint64_t GetNumberOfPixels( void ) const
+      {
+        return this->m_Image->GetLargestPossibleRegion().GetNumberOfPixels();
       }
 
     std::string ToString( void ) const


### PR DESCRIPTION
This can assist with integration with other libraries,
and in simple cases it allows for using the std algorithms
more easily.

float * imgdata = img.GetDataAsFloat();
float total = std::accumulate(imgdata, imgdata+img.GetNumberOfPixels, 0);