### PR TITLE
WIP: Add scalar op vector operations.

### DIFF
--- a/Code/BasicFilters/json/AddImageFilter.json
+++ b/Code/BasicFilters/json/AddImageFilter.json
@@ -5,7 +5,7 @@
   "constant_type" : "double",
   "number_of_inputs" : 2,
   "doc" : "Some global documentation",
-  "pixel_types" : "NonLabelPixelIDTypeList",
+  "pixel_types" : "typelist::Append< BasicPixelIDTypeList, VectorPixelIDTypeList >::Type",
   "members" : [],
   "tests" : [
     {

--- a/Code/BasicFilters/json/MultiplyImageFilter.json
+++ b/Code/BasicFilters/json/MultiplyImageFilter.json
@@ -6,6 +6,7 @@
   "number_of_inputs" : 2,
   "doc" : "Some global documentation",
   "pixel_types" : "typelist::Append<BasicPixelIDTypeList, ComplexPixelIDTypeList>::Type",
+  "pixel_types_scalar_only" : "VectorPixelIDTypeList",
   "members" : [],
   "tests" : [
     {

--- a/Code/BasicFilters/json/PowImageFilter.json
+++ b/Code/BasicFilters/json/PowImageFilter.json
@@ -5,7 +5,7 @@
   "constant_type" : "double",
   "number_of_inputs" : 2,
   "doc" : "Some global documentation",
-  "pixel_types" : "typelist::Append<BasicPixelIDTypeList, ComplexPixelIDTypeList>::Type",
+  "pixel_types" : "BasicPixelIDTypeList",
   "members" : [],
   "tests" : [
     {

--- a/Code/BasicFilters/templates/sitkBinaryFunctorFilterTemplate.cxx.in
+++ b/Code/BasicFilters/templates/sitkBinaryFunctorFilterTemplate.cxx.in
@@ -44,7 +44,17 @@ $(include ConstructorVectorPixels.cxx.in)
   this->m_MemberFactory2.reset( new detail::MemberFunctionFactory<MemberFunction2Type>( this ) );
   this->m_MemberFactory2->RegisterMemberFunctions< PixelIDTypeList, 3 > ();
   this->m_MemberFactory2->RegisterMemberFunctions< PixelIDTypeList, 2 > ();
-}
+
+$(if pixel_types_scalar_only then
+
+  OUT=OUT..[[
+  // Scalar Only
+  this->m_MemberFactory1->RegisterMemberFunctions< ${pixel_types_scalar_only}, 3 > ();
+  this->m_MemberFactory1->RegisterMemberFunctions< ${pixel_types_scalar_only}, 2 > ();
+  this->m_MemberFactory2->RegisterMemberFunctions< ${pixel_types_scalar_only}, 3 > ();
+  this->m_MemberFactory2->RegisterMemberFunctions< ${pixel_types_scalar_only}, 2 > ();
+]]
+end)}
 
 
 $(include DesctuctorDefinition.cxx.in)
@@ -138,7 +148,20 @@ $(include ExecuteInternalUpdateAndReturn.cxx.in)
 template <class TImageType>
 Image ${name}::ExecuteInternal ( ${constant_type} constant, const Image& inImage2 )
 {
-$(include ExecuteInternalTypedefs.cxx.in)
+
+  // Define the input and output image types
+  typedef itk::Image<typename itk::NumericTraits<typename TImageType::PixelType>::ValueType, TImageType::ImageDimension >   InputImageType;
+  typedef TImageType     InputImageType2;
+
+  $(if output_image_type then
+  OUT=[[//Define output image type
+  typedef ${output_image_type} OutputImageType;]]
+  elseif output_pixel_type then
+  OUT=[[// Define output image type
+  typedef itk::Image< ${output_pixel_type}, InputImageType::ImageDimension > OutputImageType;]]
+  else
+  OUT=[[typedef TImageType OutputImageType;]]
+  end)
 
   // Get the pointer to the ITK image contained in image2
   typename InputImageType2::ConstPointer image2 = this->CastImageToITK<InputImageType2>( inImage2 );
@@ -146,7 +169,6 @@ $(include ExecuteInternalTypedefs.cxx.in)
 $(include ExecuteInternalITKFilter.cxx.in)
 
   typename InputImageType::PixelType c;
-  NumericTraits<typename InputImageType2::PixelType>::SetLength( c, image2->GetNumberOfComponentsPerPixel() );
   ToPixelType( constant, c );
   filter->SetConstant1( c );
   filter->SetInput2( image2 );
@@ -158,7 +180,20 @@ $(include ExecuteInternalUpdateAndReturn.cxx.in)
 template <class TImageType>
 Image ${name}::ExecuteInternal ( const Image& inImage1, ${constant_type} constant )
 {
-$(include ExecuteInternalTypedefs.cxx.in)
+
+  // Define the input and output image types
+  typedef TImageType     InputImageType;
+  typedef itk::Image<typename itk::NumericTraits<typename TImageType::PixelType>::ValueType, TImageType::ImageDimension >   InputImageType2;
+
+  $(if output_image_type then
+  OUT=[[//Define output image type
+  typedef ${output_image_type} OutputImageType;]]
+  elseif output_pixel_type then
+  OUT=[[// Define output image type
+  typedef itk::Image< ${output_pixel_type}, InputImageType::ImageDimension > OutputImageType;]]
+  else
+  OUT=[[typedef TImageType OutputImageType;]]
+  end)
 
   // Get the pointer to the ITK image contained in image1
   typename InputImageType::ConstPointer image1 = this->CastImageToITK<InputImageType>( inImage1 );
@@ -166,7 +201,6 @@ $(include ExecuteInternalTypedefs.cxx.in)
 $(include ExecuteInternalITKFilter.cxx.in)
 
   typename InputImageType2::PixelType c;
-  NumericTraits<typename InputImageType::PixelType>::SetLength( c, image1->GetNumberOfComponentsPerPixel() );
   ToPixelType( constant, c );
   filter->SetInput1( image1 );
   filter->SetConstant2( c );


### PR DESCRIPTION
Add support for multiplying a vector image by a constant scalar. This
patch changes the itk filter instantiated for all filters which use
the BinaryFunctorFilter template, from just the same binary type
for both images and scalars, to using a "ValueType" scalar image and
image type. This is the same as the pixel type for scalar images. For
VectorImages it is the same as the component type and for complex
images it is the same as the value_type.

WIP:  This has caused some problems for the complex pixel type with
the pow and add image filters. Specifically, the Add functor type use
the NumericTraits::AccumulatorType for std::complex<float> this is
std::complex<double>, but complex<double>+complex<float> is not
supported!!!

WIP: This now instantiates the BinaryOperator filters with the
combination of ScalarImages and VectorImages. The creates bigger
object files and libraries. But it does not exposed being able to
multiply scalar images with vector images.

Restores features that were provided by the MultipleByConstanst and
similarly named filters, before they were deprecated and removed.

Change-Id: I68143cf2a03d160136c030d5c7781d1f4db47308