### PR TITLE
Pass ITK module options into Superbuild

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -14,7 +14,7 @@ endif()
 get_cmake_property( _varNames VARIABLES )
 
 foreach (_varName ${_varNames})
-  if(_varName MATCHES "^ITK_" OR _varName MATCHES "FFTW")
+  if(_varName MATCHES "^ITK_" OR _varName MATCHES "FFTW" OR _varName MATCHES "^Module_ITK")
     message( STATUS "Passing variable \"${_varName}=${${_varName}}\" to ITK external project.")
     list(APPEND ITK_VARS ${_varName})
   endif()


### PR DESCRIPTION
This allows specification of Module_ITK on the superbuild command line to enable modules not enabled by default.