### PR TITLE
Derive default package dir from library dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,7 +187,7 @@ if(NOT SimpleITK_INSTALL_DOC_DIR)
   set(SimpleITK_INSTALL_DOC_DIR share/doc/SimpleITK-${SimpleITK_VERSION_MAJOR}.${SimpleITK_VERSION_MINOR})
 endif()
 if(NOT SimpleITK_INSTALL_PACKAGE_DIR)
-  set(SimpleITK_INSTALL_PACKAGE_DIR "lib/cmake/SimpleITK-${SimpleITK_VERSION_MAJOR}.${SimpleITK_VERSION_MINOR}")
+  set(SimpleITK_INSTALL_PACKAGE_DIR "${SimpleITK_INSTALL_LIBRARY_DIR}/cmake/SimpleITK-${SimpleITK_VERSION_MAJOR}.${SimpleITK_VERSION_MINOR}")
 endif()
 
 function(sitk_install_exported_target tgt)


### PR DESCRIPTION
This commit will ease with packaging on mutli-arch envionments such as Debian. The multi-arch specific path now needs to be injected only once via `-DSimpleITK_INSTALL_LIBRARY_DIR=$(MULTIARCH_PATH)` in the packaging build script.