### PR TITLE
Respect SITK_FORBID_DOWNLOADS for Doxygen

### DIFF
--- a/Utilities/Doxygen/Doxygen.cmake
+++ b/Utilities/Doxygen/Doxygen.cmake
@@ -14,18 +14,21 @@ if (BUILD_DOXYGEN)
   #
 
   option(USE_ITK_DOXYGEN_TAGS "Download ITK's Doxygen tags" ON)
-  if (SITK_FORBID_DOWNLOADS)
-    SET(USE_ITK_DOXYGEN_TAGS OFF)
-  endif()
 
   if (USE_ITK_DOXYGEN_TAGS)
-    add_custom_command( OUTPUT "${PROJECT_BINARY_DIR}/Documentation/Doxygen/InsightDoxygen.tag"
-      COMMAND ${CMAKE_COMMAND} -D "PROJECT_SOURCE_DIR:PATH=${PROJECT_SOURCE_DIR}"
-      -D "OUTPUT_PATH:PATH=${PROJECT_BINARY_DIR}/Documentation/Doxygen"
-      -P "${PROJECT_SOURCE_DIR}/Utilities/Doxygen/ITKDoxygenTags.cmake"
-      DEPENDS "${PROJECT_SOURCE_DIR}/Utilities/Doxygen/ITKDoxygenTags.cmake"
-      )
-    set(DOXYGEN_TAGFILES_PARAMETER "${PROJECT_BINARY_DIR}/Documentation/Doxygen/InsightDoxygen.tag=https://www.itk.org/Doxygen/html/")
+    if (NOT SITK_FORBID_DOWNLOADS)
+      add_custom_command( OUTPUT "${PROJECT_BINARY_DIR}/Documentation/Doxygen/InsightDoxygen.tag"
+        COMMAND ${CMAKE_COMMAND} -D "PROJECT_SOURCE_DIR:PATH=${PROJECT_SOURCE_DIR}"
+        -D "OUTPUT_PATH:PATH=${PROJECT_BINARY_DIR}/Documentation/Doxygen"
+        -P "${PROJECT_SOURCE_DIR}/Utilities/Doxygen/ITKDoxygenTags.cmake"
+        DEPENDS "${PROJECT_SOURCE_DIR}/Utilities/Doxygen/ITKDoxygenTags.cmake"
+        )
+      set(DOXYGEN_TAGFILES_PARAMETER "${PROJECT_BINARY_DIR}/Documentation/Doxygen/InsightDoxygen.tag=https://www.itk.org/Doxygen/html/")
+      set(ITK_DOXYGEN_TAGFILE CACHE PATH "${PROJECT_BINARY_DIR}/Utilities/Doxygen/InsightDoxygen.tag")
+    else()
+      set(ITK_DOXYGEN_TAGFILE CACHE PATH "" )
+    endif()
+
   endif()
 
   #
@@ -49,7 +52,7 @@ if (BUILD_DOXYGEN)
     )
 
   if (USE_ITK_DOXYGEN_TAGS)
-    set(TAGS_DEPENDS DEPENDS ${PROJECT_BINARY_DIR}/Documentation/Doxygen/InsightDoxygen.tag)
+    set(TAGS_DEPENDS DEPENDS ${ITK_DOXYGEN_TAGFILE})
   endif ()
 
   add_custom_target(Documentation ALL

--- a/Utilities/Doxygen/Doxygen.cmake
+++ b/Utilities/Doxygen/Doxygen.cmake
@@ -14,6 +14,9 @@ if (BUILD_DOXYGEN)
   #
 
   option(USE_ITK_DOXYGEN_TAGS "Download ITK's Doxygen tags" ON)
+  if (SITK_FORBID_DOWNLOADS)
+    SET(USE_ITK_DOXYGEN_TAGS OFF)
+  endif()
 
   if (USE_ITK_DOXYGEN_TAGS)
     add_custom_command( OUTPUT "${PROJECT_BINARY_DIR}/Documentation/Doxygen/InsightDoxygen.tag"

--- a/Utilities/Doxygen/doxygen.config.in
+++ b/Utilities/Doxygen/doxygen.config.in
@@ -2041,7 +2041,7 @@ TAGFILES               = @DOXYGEN_TAGFILES_PARAMETER@
 # tag file that is based on the input files it reads. See section "Linking to
 # external documentation" for more information about the usage of tag files.
 
-GENERATE_TAGFILE       = @ITK_DOXYGEN_TAGFILE@
+GENERATE_TAGFILE       = @SIMPLEITK_DOXYGEN_TAGFILE@
 
 # If the ALLEXTERNALS tag is set to YES, all external class will be listed in
 # the class index. If set to NO, only the inherited external classes will be

--- a/Utilities/Doxygen/doxygen.config.in
+++ b/Utilities/Doxygen/doxygen.config.in
@@ -2041,7 +2041,7 @@ TAGFILES               = @DOXYGEN_TAGFILES_PARAMETER@
 # tag file that is based on the input files it reads. See section "Linking to
 # external documentation" for more information about the usage of tag files.
 
-GENERATE_TAGFILE       = @PROJECT_BINARY_DIR@/Utilities/Doxygen/InsightDoxygen.tag
+GENERATE_TAGFILE       = @ITK_DOXYGEN_TAGFILE@
 
 # If the ALLEXTERNALS tag is set to YES, all external class will be listed in
 # the class index. If set to NO, only the inherited external classes will be


### PR DESCRIPTION
When building the Documentation, it was downloading the file
InsightDoxygen.tag from the ITK web site, even when the
SITK_FORBID_DOWNLOADS cmake flag was on.  Now it will not
do the download.