### PR TITLE
Enforce SITK_FORBID_DOWNLOADS

### DIFF
--- a/Utilities/Doxygen/Doxygen.cmake
+++ b/Utilities/Doxygen/Doxygen.cmake
@@ -15,15 +15,30 @@ if (BUILD_DOXYGEN)
 
   option(USE_ITK_DOXYGEN_TAGS "Download ITK's Doxygen tags" ON)
 
+  set(DOXYGEN_TAGFILES_PARAMETER "")
+
   if (USE_ITK_DOXYGEN_TAGS)
-    add_custom_command( OUTPUT "${PROJECT_BINARY_DIR}/Documentation/Doxygen/InsightDoxygen.tag"
-      COMMAND ${CMAKE_COMMAND} -D "PROJECT_SOURCE_DIR:PATH=${PROJECT_SOURCE_DIR}"
-      -D "OUTPUT_PATH:PATH=${PROJECT_BINARY_DIR}/Documentation/Doxygen"
-      -P "${PROJECT_SOURCE_DIR}/Utilities/Doxygen/ITKDoxygenTags.cmake"
-      DEPENDS "${PROJECT_SOURCE_DIR}/Utilities/Doxygen/ITKDoxygenTags.cmake"
-      )
-    set(DOXYGEN_TAGFILES_PARAMETER "${PROJECT_BINARY_DIR}/Documentation/Doxygen/InsightDoxygen.tag=https://www.itk.org/Doxygen/html/")
+    set(ITK_DOXYGEN_TAGFILE "" CACHE PATH "ITK Doxygen tag file location. Empty string automatically downloads." )
+
+    if ("${ITK_DOXYGEN_TAGFILE}" STREQUAL "")
+      sitk_enforce_forbid_downloads("InsightDoxygen.tag")
+      set(ITK_DOXYGEN_TAGFILE "${PROJECT_BINARY_DIR}/Documentation/Doxygen/InsightDoxygen.tag")
+      add_custom_command( OUTPUT "${ITK_DOXYGEN_TAGFILE}"
+        COMMAND ${CMAKE_COMMAND} -D "PROJECT_SOURCE_DIR:PATH=${PROJECT_SOURCE_DIR}"
+        -D "OUTPUT_PATH:PATH=${PROJECT_BINARY_DIR}/Documentation/Doxygen"
+        -P "${PROJECT_SOURCE_DIR}/Utilities/Doxygen/ITKDoxygenTags.cmake"
+        DEPENDS "${PROJECT_SOURCE_DIR}/Utilities/Doxygen/ITKDoxygenTags.cmake"
+        )
+    endif()
+ 
+    set(ITK_DOXYGEN_ROOT_URL "https://www.itk.org/Doxygen/html/" CACHE STRING "URL for the ITK Doxygen web root")
+    if (NOT DOXYGEN_TAGFILES_PARAMETER STREQUAL "")
+      set(DOXYGEN_TAGFILES_PARAMETER "${ITK_DOXYGEN_TAGFILE}=${ITK_DOXYGEN_ROOT_URL}")
+    endif()
+
   endif()
+
+  set(SIMPLEITK_DOXYGEN_TAGFILE "${PROJECT_BINARY_DIR}/Utilities/Doxygen/SimpleITKDoxygen.tag")
 
   #
   # Configure the script and the doxyfile, then add target
@@ -46,7 +61,7 @@ if (BUILD_DOXYGEN)
     )
 
   if (USE_ITK_DOXYGEN_TAGS)
-    set(TAGS_DEPENDS DEPENDS ${PROJECT_BINARY_DIR}/Documentation/Doxygen/InsightDoxygen.tag)
+    set(TAGS_DEPENDS DEPENDS ${ITK_DOXYGEN_TAGFILE})
   endif ()
 
   add_custom_target(Documentation ALL
@@ -57,6 +72,7 @@ if (BUILD_DOXYGEN)
     ${TAGS_DEPENDS}
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/Utilities/Doxygen
     )
+
 
 
   message( STATUS

--- a/Utilities/Doxygen/doxygen.config.in
+++ b/Utilities/Doxygen/doxygen.config.in
@@ -2041,7 +2041,7 @@ TAGFILES               = @DOXYGEN_TAGFILES_PARAMETER@
 # tag file that is based on the input files it reads. See section "Linking to
 # external documentation" for more information about the usage of tag files.
 
-GENERATE_TAGFILE       = @PROJECT_BINARY_DIR@/Utilities/Doxygen/InsightDoxygen.tag
+GENERATE_TAGFILE       = @SIMPLEITK_DOXYGEN_TAGFILE@
 
 # If the ALLEXTERNALS tag is set to YES, all external class will be listed in
 # the class index. If set to NO, only the inherited external classes will be


### PR DESCRIPTION
Previously, when building Documentation, if the USE_ITK_DOXYGEN_TAGS
flag was set in cmake, it would download the InsightDoxygen.tag file
from the ITK web site.  This would happen even if the
SITK_FORBID_DOWNLOADS flag was set.

This patch ensure the download will not happen if SITK_FORBID_DOWNLOADS
is set.  Also ITK_DOXYGEN_TAGFILE and ITK_DOXYGEN_ROOT_URL have been
added as cmake cache variables.  ITK_DOXYGEN_TAGFILE allows the user
to specify a local InsightDoxygen.tag file.  ITK_DOXYGEN_ROOT_URL
allows the user to specify a file or web location for the ITK Doxygen
documentation, where links to ITK from SimpleITK's documentation will
point.