### PR TITLE
Removed font from Doxygen

### DIFF
--- a/Utilities/Doxygen/doxygen.config.in
+++ b/Utilities/Doxygen/doxygen.config.in
@@ -2132,7 +2132,7 @@ DOT_NUM_THREADS        = 0
 # The default value is: Helvetica.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_FONTNAME           = FreeSans.ttf
+DOT_FONTNAME           =
 
 # The DOT_FONTSIZE tag can be used to set the size (in points) of the font of
 # dot graphs.


### PR DESCRIPTION
The font FreeSans.ttf is no longer included in doxygen.  DOT_FONTNAME
is set to null to remove the warning.