### PR TITLE
BUG: removed the loadPrivateTags parameter from GetGDCMSeriesFileNames.

### DIFF
--- a/Code/IO/include/sitkImageSeriesReader.h
+++ b/Code/IO/include/sitkImageSeriesReader.h
@@ -56,7 +56,7 @@ namespace itk {
        *
        * \param directory         Set the directory that contains the DICOM data set.
        * \param recursive         Recursively parse the input directory.
-       * \param seriesID          Set the name that identifies a particular series.
+       * \param seriesID          Set the name that identifies a particular series. Default value is an empty string which will return the file names associated with the first series found in the directory.
        * \param useSeriesDetails  Use additional series information such as ProtocolName and SeriesName to identify when a single SeriesUID contains multiple 3D volumes - as can occur with perfusion and DTI imaging.
        * \param loadSequences     Parse any sequences in the DICOM data set. Loading DICOM files is faster when sequences are not needed.
        *

--- a/Code/IO/include/sitkImageSeriesReader.h
+++ b/Code/IO/include/sitkImageSeriesReader.h
@@ -45,31 +45,6 @@ namespace itk {
       /** return user readable name fo the filter */
       virtual std::string GetName() const { return std::string("ImageSeriesReader"); }
 
-      /** \brief Generate a sequence of filenames from a directory with a DICOM data set.
-       *
-       * This method generates a sequence of filenames whose filenames
-       * point to DICOM files. The ordering is based of one of
-       * several strategies, which will read all images in the
-       * directory ( assuming there is only one study/series ).
-       *
-       * \param directory         Set the directory that contains the DICOM data set.
-       * \param recursive         Recursively parse the input directory.
-       * \param useSeriesDetails  Use additional series information such as ProtocolName and SeriesName to identify when a single SeriesUID contains multiple 3D volumes - as can occur with perfusion and DTI imaging.
-       * \param loadSequences     Parse any sequences in the DICOM data set. Loading DICOM files is faster when sequences are not needed.
-       * \param loadPrivateTags   Parse any private tags in the DICOM data set. Defaults to false to skip private tags. Loading DICOM files faster is when private tags are not needed.
-       *
-       * \sa itk::GDCMSeriesFileNames
-       **/
-      static std::vector<std::string> GetGDCMSeriesFileNames( const std::string &directory,
-                                                              bool useSeriesDetails = false,
-                                                              bool recursive = false,
-                                                              bool loadSequences = false,
-                                                              bool loadPrivateTags = false )
-        {
-        return ImageSeriesReader::GetGDCMSeriesFileNames( directory, "", useSeriesDetails, recursive, loadSequences, loadPrivateTags );
-        }
-
-
       /** \brief Generate a sequence of filenames from a directory with a DICOM data set and a series ID.
        *
        * This method generates a sequence of filenames whose filenames
@@ -84,16 +59,14 @@ namespace itk {
        * \param seriesID          Set the name that identifies a particular series.
        * \param useSeriesDetails  Use additional series information such as ProtocolName and SeriesName to identify when a single SeriesUID contains multiple 3D volumes - as can occur with perfusion and DTI imaging.
        * \param loadSequences     Parse any sequences in the DICOM data set. Loading DICOM files is faster when sequences are not needed.
-       * \param loadPrivateTags   Parse any private tags in the DICOM data set. Defaults to false to skip private tags. Loading DICOM files is faster when private tags are not needed.
        *
        * \sa itk::GDCMSeriesFileNames
        **/
       static std::vector<std::string> GetGDCMSeriesFileNames( const std::string &directory,
-                                                              const std::string &seriesID,
+                                                              const std::string &seriesID = "",
                                                               bool useSeriesDetails = false,
                                                               bool recursive = false,
-                                                              bool loadSequences = false,
-                                                              bool loadPrivateTags = false );
+                                                              bool loadSequences = false );
 
       /** \brief Get all the seriesIDs from a DICOM data set
        *

--- a/Code/IO/src/sitkImageSeriesReader.cxx
+++ b/Code/IO/src/sitkImageSeriesReader.cxx
@@ -40,8 +40,7 @@ namespace itk {
                                                                       const std::string &seriesID,
                                                                       bool useSeriesDetails,
                                                                       bool recursive,
-                                                                      bool loadSequences,
-                                                                      bool loadPrivateTags )
+                                                                      bool loadSequences )
     {
     GDCMSeriesFileNames::Pointer gdcmSeries = GDCMSeriesFileNames::New();
 
@@ -49,7 +48,8 @@ namespace itk {
     gdcmSeries->SetUseSeriesDetails( useSeriesDetails );
     gdcmSeries->SetRecursive( recursive );
     gdcmSeries->SetLoadSequences( loadSequences );
-    gdcmSeries->SetLoadPrivateTags( loadPrivateTags );
+    //Skip private tags. Loading DICOM files is faster when private tags are not needed.
+    gdcmSeries->SetLoadPrivateTags( false );
 
     gdcmSeries->Update();
 


### PR DESCRIPTION
This parameter was not relevant for users, we always want to skip
reading the private tags when getting the series file names. Also got
rid of the separate functions in which one received a series and the
other did not (added a default value of empty string as the series).

Change-Id: Ie9f7d6119b26b8f1a1681199c9c035306eb48b57