### PR TITLE
BUG: Check for undefined varName variable

### DIFF
--- a/CMake/sitkCheckRequiredFlags.cmake
+++ b/CMake/sitkCheckRequiredFlags.cmake
@@ -30,7 +30,9 @@ if(MSVC)
       CMAKE_MODULE_LINKER_FLAGS_RELWITHDEBINFO
       CMAKE_SHARED_LINKER_FLAGS_DEBUG
       CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO )
-    STRING(REGEX REPLACE "INCREMENTAL(:[a-zA-Z]+)?" "INCREMENTAL:NO" ${_varName} ${${_varName}})
+    if(DEFINED ${_varName})
+      STRING(REGEX REPLACE "INCREMENTAL(:[a-zA-Z]+)?" "INCREMENTAL:NO" ${_varName} ${${_varName}})
+    endif()
   endforeach()
 
 endif()


### PR DESCRIPTION
On Windows we need to check that varName is defined before trying
to do a string replace operation on it.

Change-Id: I787db3b5266fcb47365e7ef7480d9c0d3ec38938