### PR TITLE
Support for downloading archive of R documentation from midas

### DIFF
--- a/Wrapping/R/CMakeLists.txt
+++ b/Wrapping/R/CMakeLists.txt
@@ -63,20 +63,33 @@ configure_file(
     "${CMAKE_CURRENT_BINARY_DIR}/Packaging/SimpleITK/DESCRIPTION"
     @ONLY )
 
-# download sample images, if allowed
+# download sample images and tar of Rd files, if allowed
 if(NOT SimpleITK_FORBID_DOWNLOADS)
   include(sitkExternalData)
 
-  file( GLOB_RECURSE content_links RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "Packaging/SimpleITK/data/*.md5" )
+  file( GLOB_RECURSE image_links RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/Packaging/SimpleITK/data/*.md5" )
 
-  foreach(link ${content_links})
+  file( GLOB_RECURSE doc_links RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/Packaging/SimpleITK/man/*.md5" )
+
+  foreach(link ${image_links})
     string( REGEX REPLACE "\\.md5$" "" link ${link} )
     ExternalData_Expand_Arguments(  SimpleITKRpackageData
-      link_location
+      image_location
       DATA{${link}}
       )
-    set( COPY_DATA_COMMAND ${COPY_DATA_COMMAND} COMMAND ${CMAKE_COMMAND} -E copy ${link_location} ${CMAKE_CURRENT_BINARY_DIR}/Packaging/SimpleITK/data/ )
+    set( COPY_DATA_COMMAND ${COPY_DATA_COMMAND} COMMAND ${CMAKE_COMMAND} -E copy ${image_location} ${CMAKE_CURRENT_BINARY_DIR}/Packaging/SimpleITK/data/ )
   endforeach()
+
+  foreach(link ${doc_links})
+    string( REGEX REPLACE "\\.md5$" "" link ${link} )
+    ExternalData_Expand_Arguments(  SimpleITKRpackageData
+      doc_location
+      DATA{${link}}
+      )
+    set( EXTRACT_RMAN_COMMAND  ${EXTRACT_RMAN_COMMAND} COMMAND ${CMAKE_COMMAND} -E tar xzf ${doc_location}
+      WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/Packaging/SimpleITK/man/" )
+  endforeach()
+
 
   if(COMMAND ExternalData_Add_Target )
     ExternalData_Add_Target( SimpleITKRpackageData )
@@ -89,36 +102,12 @@ if(NOT SimpleITK_FORBID_DOWNLOADS)
     PRE_BUILD
     ${COPY_DATA_COMMAND}
     )
-
-endif()
-# Download tar of Rd files
-if(NOT SimpleITK_FORBID_DOWNLOADS)
-  include(sitkExternalData)
-
-  file( GLOB_RECURSE content_links RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "Packaging/SimpleITK/man/*.md5" )
-
-  foreach(link ${content_links})
-    string( REGEX REPLACE "\\.md5$" "" link ${link} )
-    ExternalData_Expand_Arguments(  SimpleITKRpackageDocs
-      link_location
-      DATA{${link}}
-      )
-    set( EXTRACT_RMAN_COMMAND  ${EXTRACT_RMAN_COMMAND} COMMAND ${CMAKE_COMMAND} -E tar xzf ${link_location}
-      WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/Packaging/SimpleITK/man/" )
-  endforeach()
-
-  if(COMMAND ExternalData_Add_Target )
-    ExternalData_Add_Target( SimpleITKRpackageDocs )
-  endif()
-  add_dependencies( ${SWIG_MODULE_SimpleITK_TARGET_NAME} SimpleITKRpackageDocs )
-
   add_custom_command( TARGET ${SWIG_MODULE_SimpleITK_TARGET_NAME}
     PRE_BUILD
     ${EXTRACT_RMAN_COMMAND}
     )
 
 endif()
-
 
 add_custom_command( TARGET ${SWIG_MODULE_SimpleITK_TARGET_NAME}
   POST_BUILD

--- a/Wrapping/R/CMakeLists.txt
+++ b/Wrapping/R/CMakeLists.txt
@@ -101,9 +101,7 @@ if(NOT SimpleITK_FORBID_DOWNLOADS)
   add_custom_command( TARGET ${SWIG_MODULE_SimpleITK_TARGET_NAME}
     PRE_BUILD
     ${COPY_DATA_COMMAND}
-    )
-  add_custom_command( TARGET ${SWIG_MODULE_SimpleITK_TARGET_NAME}
-    PRE_BUILD
+    COMMAND
     ${EXTRACT_RMAN_COMMAND}
     )
 

--- a/Wrapping/R/CMakeLists.txt
+++ b/Wrapping/R/CMakeLists.txt
@@ -67,7 +67,7 @@ configure_file(
 if(NOT SimpleITK_FORBID_DOWNLOADS)
   include(sitkExternalData)
 
-  file( GLOB_RECURSE content_links RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "*.md5" )
+  file( GLOB_RECURSE content_links RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "Packaging/SimpleITK/data/*.md5" )
 
   foreach(link ${content_links})
     string( REGEX REPLACE "\\.md5$" "" link ${link} )
@@ -88,6 +88,33 @@ if(NOT SimpleITK_FORBID_DOWNLOADS)
   add_custom_command( TARGET ${SWIG_MODULE_SimpleITK_TARGET_NAME}
     PRE_BUILD
     ${COPY_DATA_COMMAND}
+    )
+
+endif()
+# Download tar of Rd files
+if(NOT SimpleITK_FORBID_DOWNLOADS)
+  include(sitkExternalData)
+
+  file( GLOB_RECURSE content_links RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "Packaging/SimpleITK/man/*.md5" )
+
+  foreach(link ${content_links})
+    string( REGEX REPLACE "\\.md5$" "" link ${link} )
+    ExternalData_Expand_Arguments(  SimpleITKRpackageDocs
+      link_location
+      DATA{${link}}
+      )
+    set( EXTRACT_RMAN_COMMAND  ${EXTRACT_RMAN_COMMAND} COMMAND ${CMAKE_COMMAND} -E tar xzf ${link_location}
+      WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/Packaging/SimpleITK/man/" )
+  endforeach()
+
+  if(COMMAND ExternalData_Add_Target )
+    ExternalData_Add_Target( SimpleITKRpackageDocs )
+  endif()
+  add_dependencies( ${SWIG_MODULE_SimpleITK_TARGET_NAME} SimpleITKRpackageDocs )
+
+  add_custom_command( TARGET ${SWIG_MODULE_SimpleITK_TARGET_NAME}
+    PRE_BUILD
+    ${EXTRACT_RMAN_COMMAND}
     )
 
 endif()

--- a/Wrapping/R/Packaging/SimpleITK/man/sitkRdfiles.tar.gz.md5
+++ b/Wrapping/R/Packaging/SimpleITK/man/sitkRdfiles.tar.gz.md5
@@ -1,0 +1,1 @@
+a3a0acaeba6877ebf40f866d9e1c54ac


### PR DESCRIPTION
Change-Id: Ib713a817839e5122d0f8ccdf3cbcd808c2ec4d8d

This change fetches a tar.gz of automatically generated R documentation files and extracts them into the package build hierarchy.