### PR TITLE
BUG: Wrong metric value returned from Exhaustive optimizer.

### DIFF
--- a/Code/Registration/src/sitkImageRegistrationMethod_CreateOptimizer.cxx
+++ b/Code/Registration/src/sitkImageRegistrationMethod_CreateOptimizer.cxx
@@ -34,10 +34,10 @@ namespace {
 
 template <typename T>
 void UpdateWithBestValueExhaustive(itk::ExhaustiveOptimizerv4<T> *exhaustiveOptimizer,
-                                   double &outValue,
+                                   double *outValue,
                                    itk::TransformBase *outTransform)
 {
-  outValue = exhaustiveOptimizer->GetMinimumMetricValue();
+  *outValue = exhaustiveOptimizer->GetMinimumMetricValue();
   if (outTransform)
     {
     outTransform->SetParameters(exhaustiveOptimizer->GetMinimumMetricValuePosition());
@@ -246,7 +246,7 @@ namespace simple
 
       this->m_pfUpdateWithBestValue = nsstd::bind(&UpdateWithBestValueExhaustive<double>,
                                                   optimizer,
-                                                  this->m_MetricValue,
+                                                  &(this->m_MetricValue),
                                                   nsstd::placeholders::_1);
 
 

--- a/Testing/Unit/sitkImageRegistrationMethodTests.cxx
+++ b/Testing/Unit/sitkImageRegistrationMethodTests.cxx
@@ -737,6 +737,7 @@ TEST_F(sitkRegistrationMethodTest, Optimizer_Exhaustive)
 
   R.SetMetricAsMeanSquares();
 
+  // Search grid of size 11x11
   R.SetOptimizerAsExhaustive(std::vector<unsigned int>(2,5), 0.5);
 
   IterationUpdate cmd(R);
@@ -750,6 +751,14 @@ TEST_F(sitkRegistrationMethodTest, Optimizer_Exhaustive)
   std::cout << "Optimizer stop condition: " << R.GetOptimizerStopConditionDescription() << std::endl;
   std::cout << " Iteration: " << R.GetOptimizerIteration() << std::endl;
   std::cout << " Metric value: " << R.GetMetricValue() << std::endl;
+
+  // We expect the returned metric value after registration to
+  // correspond to the best value and not necessarily to the last value
+  double metric_value = R.GetMetricValue();
+  R.SetInitialTransform(outTx);
+  EXPECT_DOUBLE_EQ(R.MetricEvaluate(image,image), metric_value);
+  //final metric value is expected to be zero as this is the same image
+  EXPECT_DOUBLE_EQ(0.0, metric_value);
 
   EXPECT_VECTOR_DOUBLE_NEAR(v2(0.0,0.0), outTx.GetParameters(), 1e-3);
   EXPECT_EQ(0u, cmd.scales.size());


### PR DESCRIPTION
Metric value returned from the Exhaustive optimizer after registration
was the last evaluation and not the best metric value. Fixed to return
the best value.

Change-Id: I429b01da158b9c9d84f4ea5fc2dbc93b0c97d9c3