### PR TITLE
PythonDocstrings.i regenerated to update docs

### DIFF
--- a/Wrapping/Python/PythonDocstrings.i
+++ b/Wrapping/Python/PythonDocstrings.i
@@ -1,5 +1,33 @@
 
 
+%feature("docstring") CastImageFilter "
+
+Generates a hash string from an image.
+
+
+
+This class utlizes low level buffer pointer access, to work with itk::Image and itk::VectorImage. It is modeled after the access an ImageFileWriter provides to an
+ImageIO.
+Todo
+complete documentation
+
+Update in-place on to default after fixing bug in InPlaceImageFilter
+
+
+C++ includes: itkHashImageFilter.h
+";
+
+
+%feature("docstring") itk::CompositeTransform "
+C++ includes: sitkTransform.h
+";
+
+
+%feature("docstring") itk::DefaultImageToImageMetricTraitsv4 "
+C++ includes: sitkImageRegistrationMethod.h
+";
+
+
 %feature("docstring") itk::Functor::BitwiseNot "
 
 Performs the C++ unary bitwise NOT operator.
@@ -76,11 +104,49 @@ Runtime information support.
 ";
 
 
+%feature("docstring") itk::Image "
+C++ includes: sitkPixelIDTypes.h
+";
+
+
 %feature("docstring") itk::ImageIOFactoryRegisterManager "
 C++ includes: itkImageIOFactoryRegisterManager.h
 ";
 
 %feature("docstring")  itk::ImageIOFactoryRegisterManager::ImageIOFactoryRegisterManager "
+";
+
+%feature("docstring")  itk::ImageIOFactoryRegisterManager::ImageIOFactoryRegisterManager "
+";
+
+
+%feature("docstring") itk::ImageRegion "
+C++ includes: sitkTemplateFunctions.h
+";
+
+
+%feature("docstring") itk::ImageToImageMetricv4 "
+C++ includes: sitkImageRegistrationMethod.h
+";
+
+
+%feature("docstring") itk::LabelMap "
+C++ includes: sitkPixelIDTypes.h
+";
+
+
+%feature("docstring") itk::LabelObject "
+C++ includes: sitkPixelIDTypes.h
+";
+
+
+%feature("docstring") itk::ObjectToObjectOptimizerBaseTemplate "
+C++ includes: sitkImageRegistrationMethod.h
+";
+
+
+%feature("docstring") itk::RegistrationParameterScalesEstimator "
+C++ includes: sitkImageRegistrationMethod.h
 ";
 
 
@@ -127,7 +193,7 @@ C++ includes: itkSliceImageFilter.h
 SliceImageFilter produces an image which is a different resolution and with a
 different pixel spacing than its input image.
 See:
-ProcessObject::GenerateOutputInformaton()
+ ProcessObject::GenerateOutputInformaton()
 
 
 ";
@@ -192,11 +258,39 @@ Run-time type information (and related methods).
 ";
 
 
+%feature("docstring") itk::SmartPointer "
+C++ includes: sitkImage.h
+";
+
+
+%feature("docstring") itk::SpatialObject "
+C++ includes: sitkImageRegistrationMethod.h
+";
+
+
+%feature("docstring") itk::TransformBaseTemplate "
+C++ includes: sitkTransform.h
+";
+
+
 %feature("docstring") itk::TransformIOFactoryRegisterManager "
 C++ includes: itkTransformIOFactoryRegisterManager.h
 ";
 
 %feature("docstring")  itk::TransformIOFactoryRegisterManager::TransformIOFactoryRegisterManager "
+";
+
+%feature("docstring")  itk::TransformIOFactoryRegisterManager::TransformIOFactoryRegisterManager "
+";
+
+
+%feature("docstring") itk::Vector "
+C++ includes: sitkImageConvert.h
+";
+
+
+%feature("docstring") itk::VectorImage "
+C++ includes: sitkPixelIDTypes.h
 ";
 
 
@@ -292,7 +386,8 @@ in two images
 See:
  itk::simple::AbsoluteValueDifference for the procedural interface
 
- itk::AbsoluteValueDifferenceImageFilter for the Doxygen on the original ITK class.
+ itk::AbsoluteValueDifferenceImageFilter for the Doxygen on the
+original ITK class.
 
 
 
@@ -444,7 +539,8 @@ Adaptive histogram equalization
 See:
  itk::simple::AdaptiveHistogramEqualization for the procedural interface
 
- itk::AdaptiveHistogramEqualizationImageFilter for the Doxygen on the original ITK class.
+ itk::AdaptiveHistogramEqualizationImageFilter for the Doxygen on the
+original ITK class.
 
 
 
@@ -498,7 +594,7 @@ Name of this class
 %feature("docstring")  itk::simple::AdaptiveHistogramEqualizationImageFilter::GetUseLookupTable "
 
 Set/Get whether an optimized lookup table for the intensity mapping
-function is used. Default is off.Deprecated
+function is used. Default is off. Deprecated
 
 ";
 
@@ -530,7 +626,7 @@ Set the values of the Radius vector all to value
 %feature("docstring")  itk::simple::AdaptiveHistogramEqualizationImageFilter::SetUseLookupTable "
 
 Set/Get whether an optimized lookup table for the intensity mapping
-function is used. Default is off.Deprecated
+function is used. Default is off. Deprecated
 
 ";
 
@@ -647,8 +743,18 @@ Destructor
 
 %feature("docstring") itk::simple::AdditiveGaussianNoiseImageFilter "
 
-Alter an image with additive gaussian white noise.
+Alter an image with additive Gaussian white noise.
 
+
+Additive Gaussian white noise can be modeled as:
+
+
+$ I = I_0 + N $
+
+where $ I $ is the observed image, $ I_0 $ is the noise-free image and $ N $ is a normally distributed random variable of mean $ \\\\mu $ and variance $ \\\\sigma^2 $ :
+
+$ N \\\\sim \\\\mathcal{N}(\\\\mu, \\\\sigma^2) $
+ The noise is independent of the pixel intensities.
 
 
 Gaetan Lehmann
@@ -657,7 +763,8 @@ Simulation\". https://hdl.handle.net/10380/3158
 See:
  itk::simple::AdditiveGaussianNoise for the procedural interface
 
- itk::AdditiveGaussianNoiseImageFilter for the Doxygen on the original ITK class.
+ itk::AdditiveGaussianNoiseImageFilter for the Doxygen on the original
+ITK class.
 
 
 C++ includes: sitkAdditiveGaussianNoiseImageFilter.h
@@ -683,6 +790,9 @@ Execute the filter on the input image with the given parameters
 ";
 
 %feature("docstring")  itk::simple::AdditiveGaussianNoiseImageFilter::GetMean "
+
+Set/Get the mean of the Gaussian distribution. Defaults to 0.0.
+
 ";
 
 %feature("docstring")  itk::simple::AdditiveGaussianNoiseImageFilter::GetName "
@@ -695,15 +805,26 @@ Name of this class
 ";
 
 %feature("docstring")  itk::simple::AdditiveGaussianNoiseImageFilter::GetStandardDeviation "
+
+Set/Get the standard deviation of the Gaussian distribution. Defaults
+to 1.0.
+
 ";
 
 %feature("docstring")  itk::simple::AdditiveGaussianNoiseImageFilter::SetMean "
+
+Set/Get the mean of the Gaussian distribution. Defaults to 0.0.
+
 ";
 
 %feature("docstring")  itk::simple::AdditiveGaussianNoiseImageFilter::SetSeed "
 ";
 
 %feature("docstring")  itk::simple::AdditiveGaussianNoiseImageFilter::SetStandardDeviation "
+
+Set/Get the standard deviation of the Gaussian distribution. Defaults
+to 1.0.
+
 ";
 
 %feature("docstring")  itk::simple::AdditiveGaussianNoiseImageFilter::ToString "
@@ -815,7 +936,8 @@ See:
 
  itk::simple::AggregateLabelMapFilter for the procedural interface
 
- itk::AggregateLabelMapFilter for the Doxygen on the original ITK class.
+ itk::AggregateLabelMapFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkAggregateLabelMapFilter.h
@@ -969,8 +1091,8 @@ a specified number of iterations.
 INPUT
 The input is an N-dimensional image of any type. It is assumed to be a
 binary image. The filter will use an isosurface value that is halfway
-between the min and max values in the image. A signed data type
-isnotnecessary for the input.
+between the min and max values in the image. A signed data type is not
+necessary for the input.
 OUTPUT
 The filter will output a level set image of real, signed values. The
 zero crossings of this (N-dimensional) image represent the position of
@@ -994,7 +1116,8 @@ Anti alias a binary image
 See:
  itk::simple::AntiAliasBinary for the procedural interface
 
- itk::AntiAliasBinaryImageFilter for the Doxygen on the original ITK class.
+ itk::AntiAliasBinaryImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -1112,15 +1235,11 @@ This filter uses the FastChamferDistanceImageFilter and the IsoContourDistanceIm
 See:
  DanielssonDistanceMapImageFilter
 
-
  SignedDanielssonDistanceMapImageFilter
-
 
  SignedMaurerDistanceMapImageFilter
 
-
  FastChamferDistanceImageFilter
-
 
  IsoContourDistanceImageFilter
 
@@ -1133,7 +1252,8 @@ Compute a distance map from objects in a binary image
 See:
  itk::simple::ApproximateSignedDistanceMap for the procedural interface
 
- itk::ApproximateSignedDistanceMapImageFilter for the Doxygen on the original ITK class.
+ itk::ApproximateSignedDistanceMapImageFilter for the Doxygen on the
+original ITK class.
 
 
 
@@ -1273,8 +1393,8 @@ Computes two argument inverse tangent.
 
 
 The first argument to the atan function is provided by a pixel in the
-first input image ( SetInput1() ) and the corresponding pixel in the
-second input image ( SetInput2() ) is used as the second argument.
+first input image (SetInput1() ) and the corresponding pixel in the
+second input image (SetInput2() ) is used as the second argument.
 
 This class is templated over the types of the two input images and the
 type of the output image. Numeric conversions (castings) are done by
@@ -1489,7 +1609,8 @@ Luis Ibanez
 See:
  itk::simple::BSplineTransformInitializer for the procedural interface
 
- itk::BSplineTransformInitializer for the Doxygen on the original ITK class.
+ itk::BSplineTransformInitializer for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkBSplineTransformInitializerFilter.h
@@ -1583,24 +1704,20 @@ The bilateral operator used here was described by Tomasi and Manduchi
 See:
  GaussianOperator
 
-
  RecursiveGaussianImageFilter
-
 
  DiscreteGaussianImageFilter
 
-
  AnisotropicDiffusionImageFilter
-
 
  Image
 
-
  Neighborhood
 
+ NeighborhoodOperator
+ TodoSupport color images
 
- NeighborhoodOperator TodoSupport color images
- Support vector images
+Support vector images
 
 Wiki Examples:
 
@@ -1718,7 +1835,7 @@ This filter is implemented so that the starting extent of the first
 pixel of the output matches that of the input.
 
 The change in image geometry from a 5x5 image binned by a factor of
-2x2.This code was contributed in the Insight Journal paper:
+2x2. This code was contributed in the Insight Journal paper:
 \"BinShrink: A multi-resolution filter with cache efficient
 averaging\" by Lowekamp B., Chen D. https://hdl.handle.net/10380/3450
 See:
@@ -1811,7 +1928,8 @@ See:
 
  itk::simple::BinaryClosingByReconstruction for the procedural interface
 
- itk::BinaryClosingByReconstructionImageFilter for the Doxygen on the original ITK class.
+ itk::BinaryClosingByReconstructionImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkBinaryClosingByReconstructionImageFilter.h
@@ -1957,7 +2075,8 @@ Extract the inner and outer boundaries of blobs in a binary image
 See:
  itk::simple::BinaryContour for the procedural interface
 
- itk::BinaryContourImageFilter for the Doxygen on the original ITK class.
+ itk::BinaryContourImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -2096,7 +2215,8 @@ Dilate a binary image
 See:
  itk::simple::BinaryDilate for the procedural interface
 
- itk::BinaryDilateImageFilter for the Doxygen on the original ITK class.
+ itk::BinaryDilateImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -2362,7 +2482,8 @@ See:
 
  itk::simple::BinaryFillhole for the procedural interface
 
- itk::BinaryFillholeImageFilter for the Doxygen on the original ITK class.
+ itk::BinaryFillholeImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkBinaryFillholeImageFilter.h
@@ -2469,7 +2590,8 @@ See:
 
  itk::simple::BinaryGrindPeak for the procedural interface
 
- itk::BinaryGrindPeakImageFilter for the Doxygen on the original ITK class.
+ itk::BinaryGrindPeakImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkBinaryGrindPeakImageFilter.h
@@ -2595,7 +2717,8 @@ Label binary regions in an image
 See:
  itk::simple::BinaryImageToLabelMapFilter for the procedural interface
 
- itk::BinaryImageToLabelMapFilter for the Doxygen on the original ITK class.
+ itk::BinaryImageToLabelMapFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -2727,7 +2850,8 @@ store the cast value into the output image.
 See:
  itk::simple::BinaryMagnitude for the procedural interface
 
- itk::BinaryMagnitudeImageFilter for the Doxygen on the original ITK class.
+ itk::BinaryMagnitudeImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkBinaryMagnitudeImageFilter.h
@@ -2786,18 +2910,16 @@ to smooth an image without being biased by outliers or shot noise.
 See:
  Image
 
-
  Neighborhood
 
-
  NeighborhoodOperator
-
 
  NeighborhoodIterator
 
  itk::simple::BinaryMedian for the procedural interface
 
- itk::BinaryMedianImageFilter for the Doxygen on the original ITK class.
+ itk::BinaryMedianImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkBinaryMedianImageFilter.h
@@ -2910,8 +3032,9 @@ The threshold value $ T_{threshold} $ is a user specified value which discrimina
 classes.
 
 This filter make use of the multi-threaded finite difference solver
-hierarchy. Updates are computed using a BinaryMinMaxCurvatureFlowFunction object. A zero flux Neumann boundary condition is used when computing
-derivatives near the data boundary.
+hierarchy. Updates are computed using a
+BinaryMinMaxCurvatureFlowFunction object. A zero flux Neumann boundary
+condition is used when computing derivatives near the data boundary.
 
 
 WARNING:
@@ -2925,15 +3048,14 @@ Sethian, Cambridge Press, Chapter 16, Second edition, 1999.
 See:
  BinaryMinMaxCurvatureFlowFunction
 
-
  CurvatureFlowImageFilter
-
 
  MinMaxCurvatureFlowImageFilter
 
  itk::simple::BinaryMinMaxCurvatureFlow for the procedural interface
 
- itk::BinaryMinMaxCurvatureFlowImageFilter for the Doxygen on the original ITK class.
+ itk::BinaryMinMaxCurvatureFlowImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkBinaryMinMaxCurvatureFlowImageFilter.h
@@ -3033,7 +3155,8 @@ See:
 
  itk::simple::BinaryMorphologicalClosing for the procedural interface
 
- itk::BinaryMorphologicalClosingImageFilter for the Doxygen on the original ITK class.
+ itk::BinaryMorphologicalClosingImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkBinaryMorphologicalClosingImageFilter.h
@@ -3170,7 +3293,8 @@ See:
 
  itk::simple::BinaryMorphologicalOpening for the procedural interface
 
- itk::BinaryMorphologicalOpeningImageFilter for the Doxygen on the original ITK class.
+ itk::BinaryMorphologicalOpeningImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkBinaryMorphologicalOpeningImageFilter.h
@@ -3327,7 +3451,8 @@ Execute the filter on the input image with the given parameters
 
 %feature("docstring")  itk::simple::BinaryNotImageFilter::GetBackgroundValue "
 
-Get the value used as \"background\". Defaults to NumericTraits<PixelType>::NonpositiveMin() .
+Get the value used as \"background\". Defaults to
+NumericTraits<PixelType>::NonpositiveMin() .
 
 ";
 
@@ -3346,7 +3471,8 @@ Name of this class
 
 %feature("docstring")  itk::simple::BinaryNotImageFilter::SetBackgroundValue "
 
-Set the value used as \"background\". Defaults to NumericTraits<PixelType>::NonpositiveMin() .
+Set the value used as \"background\". Defaults to
+NumericTraits<PixelType>::NonpositiveMin() .
 
 ";
 
@@ -3394,7 +3520,8 @@ See:
 
  itk::simple::BinaryOpeningByReconstruction for the procedural interface
 
- itk::BinaryOpeningByReconstructionImageFilter for the Doxygen on the original ITK class.
+ itk::BinaryOpeningByReconstructionImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkBinaryOpeningByReconstructionImageFilter.h
@@ -3536,30 +3663,24 @@ de Jouy-en-Josas, France.
 See:
  ProjectionImageFilter
 
-
  MedianProjectionImageFilter
 
-
  MeanProjectionImageFilter
 
-
  MeanProjectionImageFilter
-
 
  MaximumProjectionImageFilter
 
-
  MinimumProjectionImageFilter
 
-
  StandardDeviationProjectionImageFilter
-
 
  SumProjectionImageFilter
 
  itk::simple::BinaryProjection for the procedural interface
 
- itk::BinaryProjectionImageFilter for the Doxygen on the original ITK class.
+ itk::BinaryProjectionImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkBinaryProjectionImageFilter.h
@@ -3588,7 +3709,8 @@ Execute the filter on the input image with the given parameters
 
 Get the value used as \"background\". Any pixel value which is not
 DilateValue is considered background. BackgroundValue is used for
-defining boundary conditions. Defaults to NumericTraits<PixelType>::NonpositiveMin() .
+defining boundary conditions. Defaults to
+NumericTraits<PixelType>::NonpositiveMin() .
 
 ";
 
@@ -3612,7 +3734,8 @@ Name of this class
 
 Set the value used as \"background\". Any pixel value which is not
 DilateValue is considered background. BackgroundValue is used for
-defining boundary conditions. Defaults to NumericTraits<PixelType>::NonpositiveMin() .
+defining boundary conditions. Defaults to
+NumericTraits<PixelType>::NonpositiveMin() .
 
 ";
 
@@ -3664,7 +3787,8 @@ See:
 
  itk::simple::BinaryReconstructionByDilation for the procedural interface
 
- itk::BinaryReconstructionByDilationImageFilter for the Doxygen on the original ITK class.
+ itk::BinaryReconstructionByDilationImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkBinaryReconstructionByDilationImageFilter.h
@@ -3787,7 +3911,8 @@ See:
 
  itk::simple::BinaryReconstructionByErosion for the procedural interface
 
- itk::BinaryReconstructionByErosionImageFilter for the Doxygen on the original ITK class.
+ itk::BinaryReconstructionByErosionImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkBinaryReconstructionByErosionImageFilter.h
@@ -3920,7 +4045,8 @@ Skeletonize/thin an image
 See:
  itk::simple::BinaryThinning for the procedural interface
 
- itk::BinaryThinningImageFilter for the Doxygen on the original ITK class.
+ itk::BinaryThinningImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -3980,9 +4106,10 @@ image type.
 The filter expect both images to have the same number of dimensions.
 
 The default values for LowerThreshold and UpperThreshold are:
-LowerThreshold = NumericTraits<TInput>::NonpositiveMin() ; UpperThreshold = NumericTraits<TInput>::max() ; Therefore, generally only one of these needs to be set, depending
-on whether the user wants to threshold above or below the desired
-threshold.
+LowerThreshold = NumericTraits<TInput>::NonpositiveMin() ;
+UpperThreshold = NumericTraits<TInput>::max() ; Therefore, generally
+only one of these needs to be set, depending on whether the user wants
+to threshold above or below the desired threshold.
 
 Wiki Examples:
 
@@ -3992,7 +4119,8 @@ Threshold an image
 See:
  itk::simple::BinaryThreshold for the procedural interface
 
- itk::BinaryThresholdImageFilter for the Doxygen on the original ITK class.
+ itk::BinaryThresholdImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -4047,7 +4175,8 @@ Get the threshold values.
 
 %feature("docstring")  itk::simple::BinaryThresholdImageFilter::SetInsideValue "
 
-Set the \"inside\" pixel value. The default value NumericTraits<OutputPixelType>::max()
+Set the \"inside\" pixel value. The default value
+NumericTraits<OutputPixelType>::max()
 
 ";
 
@@ -4056,14 +4185,17 @@ Set the \"inside\" pixel value. The default value NumericTraits<OutputPixelType>
 
 %feature("docstring")  itk::simple::BinaryThresholdImageFilter::SetOutsideValue "
 
-Set the \"outside\" pixel value. The default value NumericTraits<OutputPixelType>::ZeroValue() .
+Set the \"outside\" pixel value. The default value
+NumericTraits<OutputPixelType>::ZeroValue() .
 
 ";
 
 %feature("docstring")  itk::simple::BinaryThresholdImageFilter::SetUpperThreshold "
 
-Set the thresholds. The default lower threshold is NumericTraits<InputPixelType>::NonpositiveMin() . The default upper threshold is NumericTraits<InputPixelType>::max . An execption is thrown if the lower threshold is greater than the
-upper threshold.
+Set the thresholds. The default lower threshold is
+NumericTraits<InputPixelType>::NonpositiveMin() . The default upper
+threshold is NumericTraits<InputPixelType>::max . An execption is
+thrown if the lower threshold is greater than the upper threshold.
 
 ";
 
@@ -4095,30 +4227,24 @@ de Jouy-en-Josas, France.
 See:
  ProjectionImageFilter
 
-
  MedianProjectionImageFilter
 
-
  MeanProjectionImageFilter
 
-
  MeanProjectionImageFilter
-
 
  MaximumProjectionImageFilter
 
-
  MinimumProjectionImageFilter
 
-
  StandardDeviationProjectionImageFilter
-
 
  SumProjectionImageFilter
 
  itk::simple::BinaryThresholdProjection for the procedural interface
 
- itk::BinaryThresholdProjectionImageFilter for the Doxygen on the original ITK class.
+ itk::BinaryThresholdProjectionImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkBinaryThresholdProjectionImageFilter.h
@@ -4145,7 +4271,8 @@ Execute the filter on the input image with the given parameters
 
 %feature("docstring")  itk::simple::BinaryThresholdProjectionImageFilter::GetBackgroundValue "
 
-Set/Get the output value used as \"background\". Defaults to NumericTraits<PixelType>::NonpositiveMin() .
+Set/Get the output value used as \"background\". Defaults to
+NumericTraits<PixelType>::NonpositiveMin() .
 
 ";
 
@@ -4167,13 +4294,15 @@ Name of this class
 
 %feature("docstring")  itk::simple::BinaryThresholdProjectionImageFilter::GetThresholdValue "
 
-Set/Get the input value consider as \"threshold\". Defaults to NumericTraits<InputPixelType>::max()
+Set/Get the input value consider as \"threshold\". Defaults to
+NumericTraits<InputPixelType>::max()
 
 ";
 
 %feature("docstring")  itk::simple::BinaryThresholdProjectionImageFilter::SetBackgroundValue "
 
-Set/Get the output value used as \"background\". Defaults to NumericTraits<PixelType>::NonpositiveMin() .
+Set/Get the output value used as \"background\". Defaults to
+NumericTraits<PixelType>::NonpositiveMin() .
 
 ";
 
@@ -4189,7 +4318,8 @@ value of PixelType.
 
 %feature("docstring")  itk::simple::BinaryThresholdProjectionImageFilter::SetThresholdValue "
 
-Set/Get the input value consider as \"threshold\". Defaults to NumericTraits<InputPixelType>::max()
+Set/Get the input value consider as \"threshold\". Defaults to
+NumericTraits<InputPixelType>::max()
 
 ";
 
@@ -4223,7 +4353,8 @@ Blur an image
 See:
  itk::simple::BinomialBlur for the procedural interface
 
- itk::BinomialBlurImageFilter for the Doxygen on the original ITK class.
+ itk::BinomialBlurImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -4289,8 +4420,9 @@ This class is parameterized over the type of the input image and the
 type of the output image. It is also parameterized by the operation to
 be applied, using a Functor style.
 
-UnaryFunctorImageFilter allows the output dimension of the filter to be larger than the input
-dimension. Thus subclasses of the UnaryFunctorImageFilter (like the CastImageFilter ) can be used to promote a 2D image to a 3D image, etc.
+UnaryFunctorImageFilter allows the output dimension of the filter to
+be larger than the input dimension. Thus subclasses of the
+UnaryFunctorImageFilter (like the CastImageFilter ) can be used to promote a 2D image to a 3D image, etc.
 
 
 See:
@@ -4303,7 +4435,8 @@ Apply a custom operation to each pixel in an image
 See:
  itk::simple::BitwiseNot for the procedural interface
 
- itk::UnaryFunctorImageFilter for the Doxygen on the original ITK class.
+ itk::UnaryFunctorImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -4470,7 +4603,8 @@ number of dimensions, and both of a scalar image type.
 See:
  itk::simple::BoundedReciprocal for the procedural interface
 
- itk::BoundedReciprocalImageFilter for the Doxygen on the original ITK class.
+ itk::BoundedReciprocalImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkBoundedReciprocalImageFilter.h
@@ -4690,15 +4824,14 @@ labeling algorithm is available.
 See:
  DiscreteGaussianImageFilter
 
-
  ZeroCrossingImageFilter
-
 
  ThresholdImageFilter
 
  itk::simple::CannyEdgeDetection for the procedural interface
 
- itk::CannyEdgeDetectionImageFilter for the Doxygen on the original ITK class.
+ itk::CannyEdgeDetectionImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkCannyEdgeDetectionImageFilter.h
@@ -4874,12 +5007,7 @@ passes as the initial translation to the transform. This second
 approach assumes that the moments of the anatomical objects are
 similar for both images and hence the best initial guess for
 registration is to superimpose both mass centers. Note that this
-assumption will probably not hold in multi-modality registration.
-
-
-See:
- itk::CenteredTransformInitializer
-
+assumption will probably not hold in multi-modality registration.   \\\\sa itk::CenteredTransformInitializer
 
 C++ includes: sitkCenteredTransformInitializerFilter.h
 ";
@@ -4955,7 +5083,8 @@ Versorrepresenting rotation.
 
 
 See:
- itk::CenteredVersorTransformInitializer for the Doxygen on the original ITK class.
+ itk::CenteredVersorTransformInitializer for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkCenteredVersorTransformInitializerFilter.h
@@ -5119,7 +5248,8 @@ See:
 
  itk::simple::ChangeLabelLabelMapFilter for the procedural interface
 
- itk::ChangeLabelLabelMapFilter for the Doxygen on the original ITK class.
+ itk::ChangeLabelLabelMapFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkChangeLabelLabelMapFilter.h
@@ -5192,7 +5322,8 @@ Combine two images by alternating blocks of a checkerboard pattern
 See:
  itk::simple::CheckerBoard for the procedural interface
 
- itk::CheckerBoardImageFilter for the Doxygen on the original ITK class.
+ itk::CheckerBoardImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -5220,7 +5351,8 @@ Execute the filter on the input images with the given parameters
 
 %feature("docstring")  itk::simple::CheckerBoardImageFilter::GetCheckerPattern "
 
-Set array with number of checks to make per image dimension
+Set/Get the checker pattern array, i.e. the number of checker boxes
+per image dimension.
 
 ";
 
@@ -5232,7 +5364,8 @@ Name of this class
 
 %feature("docstring")  itk::simple::CheckerBoardImageFilter::SetCheckerPattern "
 
-Set array with number of checks to make per image dimension
+Set/Get the checker pattern array, i.e. the number of checker boxes
+per image dimension.
 
 ";
 
@@ -5273,7 +5406,6 @@ de Jouy-en-Josas, France.
 
 See:
  UnaryFunctorImageFilter
-
 
  CastImageFilter
 Wiki Examples:
@@ -5379,7 +5511,8 @@ See:
 
  itk::simple::ClosingByReconstruction for the procedural interface
 
- itk::ClosingByReconstructionImageFilter for the Doxygen on the original ITK class.
+ itk::ClosingByReconstructionImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkClosingByReconstructionImageFilter.h
@@ -5542,7 +5675,8 @@ Department, Mario Negri Institute, Italy.
 See:
  itk::simple::CollidingFronts for the procedural interface
 
- itk::CollidingFrontsImageFilter for the Doxygen on the original ITK class.
+ itk::CollidingFrontsImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkCollidingFrontsImageFilter.h
@@ -5644,7 +5778,8 @@ Seed points are represented as a VectorContainer of LevelSetNodes.
 %feature("docstring")  itk::simple::CollidingFrontsImageFilter::SetSeedPoints2 "
 
 Set the container of Seed Points representing the second initial
-front. Seed points are represented as a VectorContainer of LevelSetNodes.
+front. Seed points are represented as a VectorContainer of
+LevelSetNodes.
 
 ";
 
@@ -5725,7 +5860,8 @@ Computes pixel-wise the imaginary part of a complex image.
 See:
  itk::simple::ComplexToImaginary for the procedural interface
 
- itk::ComplexToImaginaryImageFilter for the Doxygen on the original ITK class.
+ itk::ComplexToImaginaryImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkComplexToImaginaryImageFilter.h
@@ -5772,7 +5908,8 @@ Computes pixel-wise the Modulus of a complex image.
 See:
  itk::simple::ComplexToModulus for the procedural interface
 
- itk::ComplexToModulusImageFilter for the Doxygen on the original ITK class.
+ itk::ComplexToModulusImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkComplexToModulusImageFilter.h
@@ -5819,7 +5956,8 @@ Computes pixel-wise the modulus of a complex image.
 See:
  itk::simple::ComplexToPhase for the procedural interface
 
- itk::ComplexToPhaseImageFilter for the Doxygen on the original ITK class.
+ itk::ComplexToPhaseImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkComplexToPhaseImageFilter.h
@@ -5866,7 +6004,8 @@ Computes pixel-wise the real(x) part of a complex image.
 See:
  itk::simple::ComplexToReal for the procedural interface
 
- itk::ComplexToRealImageFilter for the Doxygen on the original ITK class.
+ itk::ComplexToRealImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkComplexToRealImageFilter.h
@@ -5917,7 +6056,6 @@ and have the same size and origin.
 
 See:
  VectorImage
-
 
  VectorIndexSelectionCastImageFilter
 Wiki Examples:
@@ -6023,7 +6161,8 @@ Segment pixels with similar statistics using connectivity
 See:
  itk::simple::ConfidenceConnected for the procedural interface
 
- itk::ConfidenceConnectedImageFilter for the Doxygen on the original ITK class.
+ itk::ConfidenceConnectedImageFilter for the Doxygen on the original
+ITK class.
 
 
 
@@ -6202,7 +6341,8 @@ Label connected components in a binary image
 See:
  itk::simple::ConnectedComponent for the procedural interface
 
- itk::ConnectedComponentImageFilter for the Doxygen on the original ITK class.
+ itk::ConnectedComponentImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -6292,7 +6432,8 @@ AND lie within a Lower and Upper threshold range.
 See:
  itk::simple::ConnectedThreshold for the procedural interface
 
- itk::ConnectedThresholdImageFilter for the Doxygen on the original ITK class.
+ itk::ConnectedThresholdImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkConnectedThresholdImageFilter.h
@@ -6332,11 +6473,14 @@ Execute the filter on the input image with the given parameters
 %feature("docstring")  itk::simple::ConnectedThresholdImageFilter::GetConnectivity "
 
 Type of connectivity to use (fully connected OR 4(2D), 6(3D), 2*N(ND)
-connectivity)
+connectivity).
 
 ";
 
 %feature("docstring")  itk::simple::ConnectedThresholdImageFilter::GetLower "
+
+Get Upper and Lower Threshold inputs as values.
+
 ";
 
 %feature("docstring")  itk::simple::ConnectedThresholdImageFilter::GetName "
@@ -6361,14 +6505,14 @@ Get SeedList
 
 %feature("docstring")  itk::simple::ConnectedThresholdImageFilter::GetUpper "
 
-Get Upper and Lower Threshold inputs as values
+Get Upper and Lower Threshold inputs as values.
 
 ";
 
 %feature("docstring")  itk::simple::ConnectedThresholdImageFilter::SetConnectivity "
 
 Type of connectivity to use (fully connected OR 4(2D), 6(3D), 2*N(ND)
-connectivity)
+connectivity).
 
 ";
 
@@ -6426,7 +6570,7 @@ ConstantPadImageFilter changes the output image region. If the output image regi
 than the input image region, the extra pixels are filled in by a
 constant value. The output image region must be specified.
 
-Visual explanation of padding regions.This filter is implemented as a
+Visual explanation of padding regions. This filter is implemented as a
 multithreaded filter. It provides a ThreadedGenerateData() method for
 its implementation.
 
@@ -6687,7 +6831,8 @@ Destructor
 
 %feature("docstring") itk::simple::CropImageFilter "
 
-Decrease the image size by cropping the image by an itk::Size at both the upper and lower bounds of the largest possible region.
+Decrease the image size by cropping the image by an itk::Size at both
+the upper and lower bounds of the largest possible region.
 
 
 CropImageFilter changes the image boundary of an image by removing pixels outside the
@@ -6786,7 +6931,9 @@ The input and output to this filter must be a scalar itk::Image with numerical p
 which correctly defines arithmetic operations with floating point
 accuracy should also give correct results.
 Parameters
-Please first read all the documentation found in AnisotropicDiffusionImageFilter and AnisotropicDiffusionFunction . Also see CurvatureNDAnisotropicDiffusionFunction .
+Please first read all the documentation found in
+AnisotropicDiffusionImageFilter and AnisotropicDiffusionFunction .
+Also see CurvatureNDAnisotropicDiffusionFunction .
  The default time step for this filter is set to the maximum
 theoretically stable value: 0.5 / 2^N, where N is the dimensionality
 of the image. For a 2D image, this means valid time steps are below
@@ -6796,15 +6943,14 @@ of the image. For a 2D image, this means valid time steps are below
 See:
  AnisotropicDiffusionImageFilter
 
-
  AnisotropicDiffusionFunction
-
 
  CurvatureNDAnisotropicDiffusionFunction
 
  itk::simple::CurvatureAnisotropicDiffusion for the procedural interface
 
- itk::CurvatureAnisotropicDiffusionImageFilter for the Doxygen on the original ITK class.
+ itk::CurvatureAnisotropicDiffusionImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkCurvatureAnisotropicDiffusionImageFilter.h
@@ -6912,8 +7058,9 @@ timestep. In the literature, the timestep is typically user specified
 and have to manually tuned to the application.
 
 This filter make use of the multi-threaded finite difference solver
-hierarchy. Updates are computed using a CurvatureFlowFunction object. A zero flux Neumann boundary condition when computing
-derivatives near the data boundary.
+hierarchy. Updates are computed using a CurvatureFlowFunction object.
+A zero flux Neumann boundary condition when computing derivatives near
+the data boundary.
 
 This filter may be streamed. To support streaming this filter produces
 a padded output which takes into account edge effects. The size of the
@@ -6933,19 +7080,16 @@ Sethian, Cambridge Press, Chapter 16, Second edition, 1999.
 See:
  DenseFiniteDifferenceImageFilter
 
-
  CurvatureFlowFunction
-
 
  MinMaxCurvatureFlowImageFilter
 
-
- BinaryMinMaxCurvatureFlowImageFilter Input/Output Restrictions: TInputImage and TOutputImage must have the
-same dimension. TOutputImage's pixel type must be a real number type.
+ BinaryMinMaxCurvatureFlowImageFilter
 
  itk::simple::CurvatureFlow for the procedural interface
 
- itk::CurvatureFlowImageFilter for the Doxygen on the original ITK class.
+ itk::CurvatureFlowImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkCurvatureFlowImageFilter.h
@@ -7096,26 +7240,33 @@ This filter computes the distance map of the input image as an
 approximation with pixel accuracy to the Euclidean distance.
 
 
-TInputImageInput Image Type
+TInputImage
 
-TOutputImageOutput Image Type
+Input Image Type
 
-TVoronoiImageVoronoi Image Type. Note the default value is TInputImage.
+TOutputImage
+
+Output Image Type
+
+TVoronoiImage
+
+Voronoi Image Type. Note the default value is TInputImage.
 
 The input is assumed to contain numeric codes defining objects. The
 filter will produce as output the following images:
 
 
-AVoronoi partitionusing the same numeric codes as the input.
+A Voronoi partition using the same numeric codes as the input.
 
-Adistance mapwith the approximation to the euclidean distance. from a
-particular pixel to the nearest object to this pixel in the input
+A distance map with the approximation to the euclidean distance. from
+a particular pixel to the nearest object to this pixel in the input
 image.
 
-Avector mapcontaining the component of the vector relating the current
-pixel with the closest point of the closest object to this pixel.
-Given that the components of the distance are computed in \"pixels\",
-the vector is represented by an itk::Offset . That is, physical coordinates are not used.
+A vector map containing the component of the vector relating the
+current pixel with the closest point of the closest object to this
+pixel. Given that the components of the distance are computed in
+\"pixels\", the vector is represented by an itk::Offset . That is,
+physical coordinates are not used.
  This filter is N-dimensional and known to be efficient in
 computational time. The algorithm is the N-dimensional version of the
 4SED algorithm given for two dimensions in:
@@ -7125,7 +7276,8 @@ and Image Processing 14, 227-248 (1980).
 See:
  itk::simple::DanielssonDistanceMap for the procedural interface
 
- itk::DanielssonDistanceMapImageFilter for the Doxygen on the original ITK class.
+ itk::DanielssonDistanceMapImageFilter for the Doxygen on the original
+ITK class.
 
 
 C++ includes: sitkDanielssonDistanceMapImageFilter.h
@@ -7276,7 +7428,8 @@ displacement field type all have the same number of dimensions.
 See:
  DemonsRegistrationFunction
 
- itk::DemonsRegistrationFilter for the Doxygen on the original ITK class.
+ itk::DemonsRegistrationFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkDemonsRegistrationFilter.h
@@ -7561,12 +7714,9 @@ the coordinate axes of the image.
 See:
  Image
 
-
  Neighborhood
 
-
  NeighborhoodOperator
-
 
  NeighborhoodIterator
 Wiki Examples:
@@ -7721,10 +7871,10 @@ deformation field type all have the same number of dimensions.
 See:
  DemonsRegistrationFilter
 
-
  DemonsRegistrationFunction
 
- itk::DiffeomorphicDemonsRegistrationFilter for the Doxygen on the original ITK class.
+ itk::DiffeomorphicDemonsRegistrationFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkDiffeomorphicDemonsRegistrationFilter.h
@@ -8030,12 +8180,12 @@ be composed of binary values (zero or one).
 See:
  ObjectMorphologyImageFilter , ErodeObjectMorphologyImageFilter
 
-
  BinaryDilateImageFilter
 
  itk::simple::DilateObjectMorphology for the procedural interface
 
- itk::DilateObjectMorphologyImageFilter for the Doxygen on the original ITK class.
+ itk::DilateObjectMorphologyImageFilter for the Doxygen on the original
+ITK class.
 
 
 C++ includes: sitkDilateObjectMorphologyImageFilter.h
@@ -8144,18 +8294,16 @@ Ivan Macia, VICOMTech, Spain, http://www.vicomtech.es
 See:
  GaussianDerivativeOperator
 
-
  Image
 
-
  Neighborhood
-
 
  NeighborhoodOperator
 
  itk::simple::DiscreteGaussianDerivative for the procedural interface
 
- itk::DiscreteGaussianDerivativeImageFilter for the Doxygen on the original ITK class.
+ itk::DiscreteGaussianDerivativeImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkDiscreteGaussianDerivativeImageFilter.h
@@ -8343,15 +8491,11 @@ than itk::RecursiveGaussianImageFilter .
 See:
  GaussianOperator
 
-
  Image
-
 
  Neighborhood
 
-
  NeighborhoodOperator
-
 
  RecursiveGaussianImageFilter
 Wiki Examples:
@@ -8362,7 +8506,8 @@ Smooth an image with a discrete Gaussian filter
 See:
  itk::simple::DiscreteGaussian for the procedural interface
 
- itk::DiscreteGaussianImageFilter for the Doxygen on the original ITK class.
+ itk::DiscreteGaussianImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -8490,10 +8635,10 @@ dx/dz ; dy/dx (1.0+dy/dy) dy/dz; dz/dx dz/dy (1.0+dz/dz) ])
 Template Parameters (Input and Output)
 This filter has one required template parameter which defines the
 input image type. The pixel type of the input image is assumed to be a
-vector (e.g., itk::Vector , itk::RGBPixel , itk::FixedArray ). The scalar type of the vector components must be castable to
-floating point. Instantiating with an image of RGBPixel<unsigned
-short>, for example, is allowed, but the filter will convert it to an
-image of Vector<float,3> for processing.
+vector (e.g., itk::Vector , itk::RGBPixel , itk::FixedArray ). The scalar type of the vector
+components must be castable to floating point. Instantiating with an
+image of RGBPixel<unsigned short>, for example, is allowed, but the
+filter will convert it to an image of Vector<float,3> for processing.
  The second template parameter, TRealType, can be optionally specified
 to define the scalar numerical type used in calculations. This is the
 component type of the output image, which will be of
@@ -8539,12 +8684,9 @@ operations defined sufficient to compute derivatives.
 See:
  Image
 
-
  Neighborhood
 
-
  NeighborhoodOperator
-
 
  NeighborhoodIterator
 
@@ -8557,7 +8699,8 @@ Torsten Rohlfing, Neuroscience Program, SRI International.
 See:
  itk::simple::DisplacementFieldJacobianDeterminantFilter for the procedural interface
 
- itk::DisplacementFieldJacobianDeterminantFilter for the Doxygen on the original ITK class.
+ itk::DisplacementFieldJacobianDeterminantFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkDisplacementFieldJacobianDeterminantFilter.h
@@ -8746,7 +8889,8 @@ the type of the output image. It is also parameterized by the
 operation to be applied. A Functor style is used.
 
 The constant must be of the same type than the pixel type of the
-corresponding image. It is wrapped in a SimpleDataObjectDecorator so it can be updated through the pipeline. The SetConstant() and
+corresponding image. It is wrapped in a SimpleDataObjectDecorator so
+it can be updated through the pipeline. The SetConstant() and
 GetConstant() methods are provided as shortcuts to set or get the
 constant value without manipulating the decorator.
 
@@ -8763,7 +8907,8 @@ Apply a custom operation to corresponding pixels in two images
 See:
  itk::simple::DivideFloor for the procedural interface
 
- itk::BinaryFunctorImageFilter for the Doxygen on the original ITK class.
+ itk::BinaryFunctorImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -8889,7 +9034,8 @@ the type of the output image. It is also parameterized by the
 operation to be applied. A Functor style is used.
 
 The constant must be of the same type than the pixel type of the
-corresponding image. It is wrapped in a SimpleDataObjectDecorator so it can be updated through the pipeline. The SetConstant() and
+corresponding image. It is wrapped in a SimpleDataObjectDecorator so
+it can be updated through the pipeline. The SetConstant() and
 GetConstant() methods are provided as shortcuts to set or get the
 constant value without manipulating the decorator.
 
@@ -8906,7 +9052,8 @@ Apply a custom operation to corresponding pixels in two images
 See:
  itk::simple::DivideReal for the procedural interface
 
- itk::BinaryFunctorImageFilter for the Doxygen on the original ITK class.
+ itk::BinaryFunctorImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -8981,12 +9128,12 @@ image as they would have if the wide threshold was used.
 See:
  GrayscaleGeodesicDilateImageFilter
 
-
  MorphologyImageFilter , GrayscaleDilateImageFilter , GrayscaleFunctionDilateImageFilter , BinaryDilateImageFilter
 
  itk::simple::DoubleThreshold for the procedural interface
 
- itk::DoubleThresholdImageFilter for the Doxygen on the original ITK class.
+ itk::DoubleThresholdImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkDoubleThresholdImageFilter.h
@@ -9082,41 +9229,51 @@ FullyConnectedOn.
 
 %feature("docstring")  itk::simple::DoubleThresholdImageFilter::SetInsideValue "
 
-Set the \"inside\" pixel value. The default value NumericTraits<OutputPixelType>::max()
+Set the \"inside\" pixel value. The default value
+NumericTraits<OutputPixelType>::max()
 
 ";
 
 %feature("docstring")  itk::simple::DoubleThresholdImageFilter::SetOutsideValue "
 
-Set the \"outside\" pixel value. The default value NumericTraits<OutputPixelType>::ZeroValue() .
+Set the \"outside\" pixel value. The default value
+NumericTraits<OutputPixelType>::ZeroValue() .
 
 ";
 
 %feature("docstring")  itk::simple::DoubleThresholdImageFilter::SetThreshold1 "
 
 Set the thresholds. Four thresholds should be specified. The two lower
-thresholds default to NumericTraits<InputPixelType>::NonpositiveMin() . The two upper thresholds default NumericTraits<InputPixelType>::max . Threshold1 <= Threshold2 <= Threshold3 <= Threshold4.
+thresholds default to NumericTraits<InputPixelType>::NonpositiveMin()
+. The two upper thresholds default NumericTraits<InputPixelType>::max
+. Threshold1 <= Threshold2 <= Threshold3 <= Threshold4.
 
 ";
 
 %feature("docstring")  itk::simple::DoubleThresholdImageFilter::SetThreshold2 "
 
 Set the thresholds. Four thresholds should be specified. The two lower
-thresholds default to NumericTraits<InputPixelType>::NonpositiveMin() . The two upper thresholds default NumericTraits<InputPixelType>::max . Threshold1 <= Threshold2 <= Threshold3 <= Threshold4.
+thresholds default to NumericTraits<InputPixelType>::NonpositiveMin()
+. The two upper thresholds default NumericTraits<InputPixelType>::max
+. Threshold1 <= Threshold2 <= Threshold3 <= Threshold4.
 
 ";
 
 %feature("docstring")  itk::simple::DoubleThresholdImageFilter::SetThreshold3 "
 
 Set the thresholds. Four thresholds should be specified. The two lower
-thresholds default to NumericTraits<InputPixelType>::NonpositiveMin() . The two upper thresholds default NumericTraits<InputPixelType>::max . Threshold1 <= Threshold2 <= Threshold3 <= Threshold4.
+thresholds default to NumericTraits<InputPixelType>::NonpositiveMin()
+. The two upper thresholds default NumericTraits<InputPixelType>::max
+. Threshold1 <= Threshold2 <= Threshold3 <= Threshold4.
 
 ";
 
 %feature("docstring")  itk::simple::DoubleThresholdImageFilter::SetThreshold4 "
 
 Set the thresholds. Four thresholds should be specified. The two lower
-thresholds default to NumericTraits<InputPixelType>::NonpositiveMin() . The two upper thresholds default NumericTraits<InputPixelType>::max . Threshold1 <= Threshold2 <= Threshold3 <= Threshold4.
+thresholds default to NumericTraits<InputPixelType>::NonpositiveMin()
+. The two upper thresholds default NumericTraits<InputPixelType>::max
+. Threshold1 <= Threshold2 <= Threshold3 <= Threshold4.
 
 ";
 
@@ -9138,14 +9295,16 @@ Destructor
 Computes the edge potential of an image from the image gradient.
 
 
-Input to this filter should be a CovariantVector image representing the image gradient.
+Input to this filter should be a CovariantVector image representing
+the image gradient.
 
 The filter expect both the input and output images to have the same
 number of dimensions, and the output to be of a scalar image type.
 See:
  itk::simple::EdgePotential for the procedural interface
 
- itk::EdgePotentialImageFilter for the Doxygen on the original ITK class.
+ itk::EdgePotentialImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkEdgePotentialImageFilter.h
@@ -9194,7 +9353,8 @@ the type of the output image. It is also parameterized by the
 operation to be applied. A Functor style is used.
 
 The constant must be of the same type than the pixel type of the
-corresponding image. It is wrapped in a SimpleDataObjectDecorator so it can be updated through the pipeline. The SetConstant() and
+corresponding image. It is wrapped in a SimpleDataObjectDecorator so
+it can be updated through the pipeline. The SetConstant() and
 GetConstant() methods are provided as shortcuts to set or get the
 constant value without manipulating the decorator.
 
@@ -9211,7 +9371,8 @@ Apply a custom operation to corresponding pixels in two images
 See:
  itk::simple::Equal for the procedural interface
 
- itk::BinaryFunctorImageFilter for the Doxygen on the original ITK class.
+ itk::BinaryFunctorImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -9320,12 +9481,12 @@ or one).
 See:
  ObjectMorphologyImageFilter , BinaryFunctionErodeImageFilter
 
-
  BinaryErodeImageFilter
 
  itk::simple::ErodeObjectMorphology for the procedural interface
 
- itk::ErodeObjectMorphologyImageFilter for the Doxygen on the original ITK class.
+ itk::ErodeObjectMorphologyImageFilter for the Doxygen on the original
+ITK class.
 
 
 C++ includes: sitkErodeObjectMorphologyImageFilter.h
@@ -9675,7 +9836,9 @@ is given by:
 OutputSize[j] = InputSize[j] * ExpandFactors[j]
 
 The output values are obtained by interpolating the input image. The
-default interpolation type used is the LinearInterpolateImageFunction . The user can specify a particular interpolation function via SetInterpolator() . Note that the input interpolator must derive from base class InterpolateImageFunction .
+default interpolation type used is the LinearInterpolateImageFunction
+. The user can specify a particular interpolation function via SetInterpolator() . Note that the input interpolator must derive from base class
+InterpolateImageFunction .
 
 This filter will produce an output with different pixel spacing that
 its input image such that:
@@ -9699,9 +9862,7 @@ number of dimensions.
 See:
  InterpolateImageFunction
 
-
-LinearInterpolationImageFunction
-
+ LinearInterpolationImageFunction
 
  VectorExpandImageFilter
 
@@ -9808,7 +9969,8 @@ image, 3D = a 4x4x4 image, specified as [x,y,z,2] from 4D (i.e. the
 3rd \"time\" slice from 4D). The ExtractionRegion.Size = [4,4,4,0] and
 ExtractionRegion.Index = [0,0,0,2].
 
-The number of dimension in ExtractionRegion.Size and Index must = InputImageDimension. The number of non-zero dimensions in
+The number of dimension in ExtractionRegion.Size and Index must =
+InputImageDimension. The number of non-zero dimensions in
 ExtractionRegion.Size must = OutputImageDimension.
 
 The output image produced by this filter will have the same origin as
@@ -9835,9 +9997,10 @@ This filter is implemented as a multithreaded filter. It provides a
 ThreadedGenerateData() method for its implementation.
 
 
-This filter is derived from InPlaceImageFilter . When the input to this filter matched the output requirested
-region, like with streaming filter for input, then setting this filter
-to run in-place will result in no copying of the bulk pixel data.
+This filter is derived from InPlaceImageFilter . When the input to
+this filter matched the output requirested region, like with streaming
+filter for input, then setting this filter to run in-place will result
+in no copying of the bulk pixel data.
 
 See:
  CropImageFilter
@@ -9849,8 +10012,9 @@ Crop an image by specifying the region to keep
 See:
  itk::simple::Extract for the procedural interface
 
- itk::ExtractImageFilter<InputImageType, typename InputImageType::template Rebind for the
-Doxygen on the original ITK class.
+ itk::ExtractImageFilter<InputImageType, typename
+InputImageType::template Rebind for the Doxygen on the original ITK
+class.
 
 
 
@@ -9967,7 +10131,8 @@ See:
 
  itk::simple::FFTConvolution for the procedural interface
 
- itk::FFTConvolutionImageFilter for the Doxygen on the original ITK class.
+ itk::FFTConvolutionImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkFFTConvolutionImageFilter.h
@@ -10101,7 +10266,8 @@ Computer Vision and Pattern Recognition, 2010.
 See:
  itk::simple::FFTNormalizedCorrelation for the procedural interface
 
- itk::FFTNormalizedCorrelationImageFilter for the Doxygen on the original ITK class.
+ itk::FFTNormalizedCorrelationImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkFFTNormalizedCorrelationImageFilter.h
@@ -10364,7 +10530,8 @@ Richard Beare
 See:
  itk::simple::FastApproximateRank for the procedural interface
 
- itk::FastApproximateRankImageFilter for the Doxygen on the original ITK class.
+ itk::FastApproximateRankImageFilter for the Doxygen on the original
+ITK class.
 
 
 C++ includes: sitkFastApproximateRankImageFilter.h
@@ -10442,6 +10609,8 @@ points.
 
 There are two ways to specify the output image information (
 LargestPossibleRegion, Spacing, Origin):
+
+
 it is copied directly from the input speed image
 
 it is specified by the user. Default values are used if the user does
@@ -10451,6 +10620,8 @@ not specify all the information.
 If the speed image is ITK_NULLPTR or if the OverrideOutputInformation
 is set to true, the output information is set from user specified
 parameters. These parameters can be specified using methods
+
+
 FastMarchingImageFilterBase::SetOutputRegion() ,
 
 FastMarchingImageFilterBase::SetOutputSpacing() ,
@@ -10464,18 +10635,20 @@ Implementation of this class is based on Chapter 8 of \"Level Set
 Methods and Fast Marching Methods\", J.A. Sethian, Cambridge Press,
 Second edition, 1999.
 
-TTraitstraits
+TTraits
+
+traits
 
 
 See:
-ImageFastMarchingTraits
+ ImageFastMarchingTraits
 
-
-ImageFastMarchingTraits2
+ ImageFastMarchingTraits2
 
  itk::simple::FastMarchingBase for the procedural interface
 
- itk::FastMarchingImageFilterBase for the Doxygen on the original ITK class.
+ itk::FastMarchingImageFilterBase for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkFastMarchingBaseImageFilter.h
@@ -10616,7 +10789,8 @@ specified using method the SetSpeedConstant() .
 
 If the speed function is constant and of value one, fast marching
 results in an approximate distance function from the initial alive
-points. FastMarchingImageFilter is used in the ReinitializeLevelSetImageFilter object to create a signed distance function from the zero level set.
+points. FastMarchingImageFilter is used in the ReinitializeLevelSetImageFilter object to create a
+signed distance function from the zero level set.
 
 The algorithm can be terminated early by setting an appropriate
 stopping value. The algorithm terminates when the current arrival time
@@ -10652,7 +10826,8 @@ See:
 
  itk::simple::FastMarching for the procedural interface
 
- itk::FastMarchingImageFilter for the Doxygen on the original ITK class.
+ itk::FastMarchingImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkFastMarchingImageFilter.h
@@ -10785,7 +10960,8 @@ Department, Mario Negri Institute, Italy.
 See:
  itk::simple::FastMarchingUpwindGradient for the procedural interface
 
- itk::FastMarchingUpwindGradientImageFilter for the Doxygen on the original ITK class.
+ itk::FastMarchingUpwindGradientImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkFastMarchingUpwindGradientImageFilter.h
@@ -10909,7 +11085,8 @@ arrival time is smooth.
 %feature("docstring")  itk::simple::FastMarchingUpwindGradientImageFilter::SetTargetPoints "
 
 Set the container of Target Points. If a target point is reached, the
-propagation stops. Trial points are represented as a VectorContainer of LevelSetNodes.
+propagation stops. Trial points are represented as a VectorContainer
+of LevelSetNodes.
 
 ";
 
@@ -10974,10 +11151,10 @@ deformation field type all have the same number of dimensions.
 See:
  DemonsRegistrationFilter
 
-
  DemonsRegistrationFunction
 
- itk::FastSymmetricForcesDemonsRegistrationFilter for the Doxygen on the original ITK class.
+ itk::FastSymmetricForcesDemonsRegistrationFilter for the Doxygen on
+the original ITK class.
 
 
 C++ includes: sitkFastSymmetricForcesDemonsRegistrationFilter.h
@@ -11451,9 +11628,10 @@ Generate an n-dimensional image of a Gabor filter.
 
 GaborImageSource generates an image of either the real (i.e. symmetric) or complex
 (i.e. antisymmetric) part of the Gabor filter with the orientation
-directed along the x-axis. The GaborKernelFunction is used to evaluate the contribution along the x-axis whereas a non-
-normalized 1-D Gaussian envelope provides the contribution in each of
-the remaining N dimensions. Orientation can be manipulated via the Transform classes of the toolkit.
+directed along the x-axis. The GaborKernelFunction is used to evaluate
+the contribution along the x-axis whereas a non-normalized 1-D
+Gaussian envelope provides the contribution in each of the remaining N
+dimensions. Orientation can be manipulated via the Transform classes of the toolkit.
 
 The output image may be of any dimension.
 
@@ -11572,10 +11750,10 @@ Generate an n-dimensional image of a Gaussian.
 
 GaussianImageSource generates an image of a Gaussian. m_Normalized determines whether or
 not the Gaussian is normalized (whether or not the sum over infinite
-space is 1.0) When creating an image, it is preferable tonotnormalize
-the Gaussian m_Scale scales the output of the Gaussian to span a range
-larger than 0->1, and is typically set to the maximum value of the
-output data type (for instance, 255 for uchars)
+space is 1.0) When creating an image, it is preferable to not
+normalize the Gaussian m_Scale scales the output of the Gaussian to
+span a range larger than 0->1, and is typically set to the maximum
+value of the output data type (for instance, 255 for uchars)
 
 The output image may be of any dimension.
 See:
@@ -11782,8 +11960,10 @@ map.
 
 
 IMPORTANT
-The SegmentationLevelSetImageFilter class and the GeodesicActiveContourLevelSetFunction class contain additional information necessary to gain full
-understanding of how to use this filter.
+The SegmentationLevelSetImageFilter class and the
+GeodesicActiveContourLevelSetFunction class contain additional
+information necessary to gain full understanding of how to use this
+filter.
 OVERVIEW
 This class is a level set method segmentation filter. An initial
 contour is propagated outwards (or inwards) until it ''sticks'' to the
@@ -11810,7 +11990,8 @@ potential map is compute from the image gradient, for example:
 where $ I $ is image intensity and $ (\\\\nabla * G) $ is the derivative of Gaussian operator.
 
 
-See SegmentationLevelSetImageFilter and SparseFieldLevelSetImageFilter for more information on Inputs.
+See SegmentationLevelSetImageFilter and SparseFieldLevelSetImageFilter
+for more information on Inputs.
 PARAMETERS
 The PropagationScaling parameter can be used to switch from
 propagation outwards (POSITIVE scaling parameter) versus propagating
@@ -11828,7 +12009,8 @@ region and positive values in the image represent the outside of the
 segmented region. The zero crossings of the image correspond to the
 position of the propagating front.
 
-See SparseFieldLevelSetImageFilter and SegmentationLevelSetImageFilter for more information.
+See SparseFieldLevelSetImageFilter and SegmentationLevelSetImageFilter
+for more information.
 REFERENCES
 
 \"Geodesic Active Contours\", V. Caselles, R. Kimmel and G. Sapiro.
@@ -11838,15 +12020,14 @@ International Journal on Computer Vision, Vol 22, No. 1, pp 61-97,
 See:
  SegmentationLevelSetImageFilter
 
-
  GeodesicActiveContourLevelSetFunction
-
 
  SparseFieldLevelSetImageFilter
 
  itk::simple::GeodesicActiveContourLevelSet for the procedural interface
 
- itk::GeodesicActiveContourLevelSetImageFilter for the Doxygen on the original ITK class.
+ itk::GeodesicActiveContourLevelSetImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkGeodesicActiveContourLevelSetImageFilter.h
@@ -11974,15 +12155,14 @@ itkAnisotropicDiffusionImageFilter.
 See:
  AnisotropicDiffusionImageFilter
 
-
  AnisotropicDiffusionFunction
 
-
-GradientAnisotropicDiffusionFunction
+ GradientAnisotropicDiffusionFunction
 
  itk::simple::GradientAnisotropicDiffusion for the procedural interface
 
- itk::GradientAnisotropicDiffusionImageFilter for the Doxygen on the original ITK class.
+ itk::GradientAnisotropicDiffusionImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkGradientAnisotropicDiffusionImageFilter.h
@@ -12076,12 +12256,9 @@ is specified as this third template parameter.
 See:
  Image
 
-
  Neighborhood
 
-
  NeighborhoodOperator
-
 
  NeighborhoodIterator
 
@@ -12198,12 +12375,9 @@ Computes the gradient magnitude of an image region at each pixel.
 See:
  Image
 
-
  Neighborhood
 
-
  NeighborhoodOperator
-
 
  NeighborhoodIterator
 Wiki Examples:
@@ -12214,7 +12388,8 @@ Compute the gradient magnitude image
 See:
  itk::simple::GradientMagnitude for the procedural interface
 
- itk::GradientMagnitudeImageFilter for the Doxygen on the original ITK class.
+ itk::GradientMagnitudeImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -12299,7 +12474,8 @@ Gaussian kernel
 See:
  itk::simple::GradientMagnitudeRecursiveGaussian for the procedural interface
 
- itk::GradientMagnitudeRecursiveGaussianImageFilter for the Doxygen on the original ITK class.
+ itk::GradientMagnitudeRecursiveGaussianImageFilter for the Doxygen on
+the original ITK class.
 
 
 
@@ -12403,7 +12579,8 @@ derivative of a Gaussian
 See:
  itk::simple::GradientRecursiveGaussian for the procedural interface
 
- itk::GradientRecursiveGaussianImageFilter for the Doxygen on the original ITK class.
+ itk::GradientRecursiveGaussianImageFilter for the Doxygen on the
+original ITK class.
 
 
 
@@ -12537,12 +12714,12 @@ Principles and Applications\", Second Edition, Springer, 2003.
 See:
  GrayscaleGeodesicDilateImageFilter
 
-
  MorphologyImageFilter , GrayscaleDilateImageFilter , GrayscaleFunctionDilateImageFilter , BinaryDilateImageFilter
 
  itk::simple::GrayscaleConnectedClosing for the procedural interface
 
- itk::GrayscaleConnectedClosingImageFilter for the Doxygen on the original ITK class.
+ itk::GrayscaleConnectedClosingImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkGrayscaleConnectedClosingImageFilter.h
@@ -12643,12 +12820,12 @@ Principles and Applications\", Second Edition, Springer, 2003.
 See:
  GrayscaleGeodesicDilateImageFilter
 
-
  MorphologyImageFilter , GrayscaleDilateImageFilter , GrayscaleFunctionDilateImageFilter , BinaryDilateImageFilter
 
  itk::simple::GrayscaleConnectedOpening for the procedural interface
 
- itk::GrayscaleConnectedOpeningImageFilter for the Doxygen on the original ITK class.
+ itk::GrayscaleConnectedOpeningImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkGrayscaleConnectedOpeningImageFilter.h
@@ -12733,7 +12910,7 @@ Destructor
 
 %feature("docstring") itk::simple::GrayscaleDilateImageFilter "
 
-gray scale dilation of an image
+Grayscale dilation of an image.
 
 
 Dilate an image using grayscale morphology. Dilation takes the maximum
@@ -12754,7 +12931,8 @@ Dilate a grayscale image
 See:
  itk::simple::GrayscaleDilate for the procedural interface
 
- itk::GrayscaleDilateImageFilter for the Doxygen on the original ITK class.
+ itk::GrayscaleDilateImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -12825,10 +13003,10 @@ Destructor
 
 %feature("docstring") itk::simple::GrayscaleErodeImageFilter "
 
-gray scale dilation of an image
+Grayscale erosion of an image.
 
 
-Erode an image using grayscale morphology. Dilation takes the maximum
+Erode an image using grayscale morphology. Erosion takes the maximum
 of all the pixels identified by the structuring element.
 
 The structuring element is assumed to be composed of binary values
@@ -12846,7 +13024,8 @@ Erode a grayscale image
 See:
  itk::simple::GrayscaleErode for the procedural interface
 
- itk::GrayscaleErodeImageFilter for the Doxygen on the original ITK class.
+ itk::GrayscaleErodeImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -12945,12 +13124,12 @@ and Applications\", Second Edition, Springer, 2003.
 See:
  ReconstructionByErosionImageFilter
 
-
  MorphologyImageFilter , GrayscaleErodeImageFilter , GrayscaleFunctionErodeImageFilter , BinaryErodeImageFilter
 
  itk::simple::GrayscaleFillhole for the procedural interface
 
- itk::GrayscaleFillholeImageFilter for the Doxygen on the original ITK class.
+ itk::GrayscaleFillholeImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkGrayscaleFillholeImageFilter.h
@@ -13058,7 +13237,8 @@ See:
 
  itk::simple::GrayscaleGeodesicDilate for the procedural interface
 
- itk::GrayscaleGeodesicDilateImageFilter for the Doxygen on the original ITK class.
+ itk::GrayscaleGeodesicDilateImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkGrayscaleGeodesicDilateImageFilter.h
@@ -13189,7 +13369,8 @@ See:
 
  itk::simple::GrayscaleGeodesicErode for the procedural interface
 
- itk::GrayscaleGeodesicErodeImageFilter for the Doxygen on the original ITK class.
+ itk::GrayscaleGeodesicErodeImageFilter for the Doxygen on the original
+ITK class.
 
 
 C++ includes: sitkGrayscaleGeodesicErodeImageFilter.h
@@ -13318,12 +13499,12 @@ and Applications\", Second Edition, Springer, 2003.
 See:
  GrayscaleGeodesicDilateImageFilter
 
-
  MorphologyImageFilter , GrayscaleDilateImageFilter , GrayscaleFunctionDilateImageFilter , BinaryDilateImageFilter
 
  itk::simple::GrayscaleGrindPeak for the procedural interface
 
- itk::GrayscaleGrindPeakImageFilter for the Doxygen on the original ITK class.
+ itk::GrayscaleGrindPeakImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkGrayscaleGrindPeakImageFilter.h
@@ -13412,7 +13593,8 @@ See:
 
  itk::simple::GrayscaleMorphologicalClosing for the procedural interface
 
- itk::GrayscaleMorphologicalClosingImageFilter for the Doxygen on the original ITK class.
+ itk::GrayscaleMorphologicalClosingImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkGrayscaleMorphologicalClosingImageFilter.h
@@ -13527,7 +13709,8 @@ See:
 
  itk::simple::GrayscaleMorphologicalOpening for the procedural interface
 
- itk::GrayscaleMorphologicalOpeningImageFilter for the Doxygen on the original ITK class.
+ itk::GrayscaleMorphologicalOpeningImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkGrayscaleMorphologicalOpeningImageFilter.h
@@ -13635,7 +13818,8 @@ the type of the output image. It is also parameterized by the
 operation to be applied. A Functor style is used.
 
 The constant must be of the same type than the pixel type of the
-corresponding image. It is wrapped in a SimpleDataObjectDecorator so it can be updated through the pipeline. The SetConstant() and
+corresponding image. It is wrapped in a SimpleDataObjectDecorator so
+it can be updated through the pipeline. The SetConstant() and
 GetConstant() methods are provided as shortcuts to set or get the
 constant value without manipulating the decorator.
 
@@ -13652,7 +13836,8 @@ Apply a custom operation to corresponding pixels in two images
 See:
  itk::simple::GreaterEqual for the procedural interface
 
- itk::BinaryFunctorImageFilter for the Doxygen on the original ITK class.
+ itk::BinaryFunctorImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -13751,7 +13936,8 @@ the type of the output image. It is also parameterized by the
 operation to be applied. A Functor style is used.
 
 The constant must be of the same type than the pixel type of the
-corresponding image. It is wrapped in a SimpleDataObjectDecorator so it can be updated through the pipeline. The SetConstant() and
+corresponding image. It is wrapped in a SimpleDataObjectDecorator so
+it can be updated through the pipeline. The SetConstant() and
 GetConstant() methods are provided as shortcuts to set or get the
 constant value without manipulating the decorator.
 
@@ -13768,7 +13954,8 @@ Apply a custom operation to corresponding pixels in two images
 See:
  itk::simple::Greater for the procedural interface
 
- itk::BinaryFunctorImageFilter for the Doxygen on the original ITK class.
+ itk::BinaryFunctorImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -14005,7 +14192,6 @@ and Applications\", Second Edition, Springer, 2003.
 See:
  GrayscaleGeodesicDilateImageFilter , HMaximaImageFilter ,
 
-
  MorphologyImageFilter , GrayscaleDilateImageFilter , GrayscaleFunctionDilateImageFilter , BinaryDilateImageFilter
 
  itk::simple::HConcave for the procedural interface
@@ -14118,7 +14304,6 @@ and Applications\", Second Edition, Springer, 2003.
 
 See:
  GrayscaleGeodesicDilateImageFilter , HMinimaImageFilter
-
 
  MorphologyImageFilter , GrayscaleDilateImageFilter , GrayscaleFunctionDilateImageFilter , BinaryDilateImageFilter
 
@@ -14241,7 +14426,6 @@ The height parameter is set using SetHeight.
 See:
  ReconstructionByDilationImageFilter , HMinimaImageFilter , HConvexImageFilter
 
-
  MorphologyImageFilter , GrayscaleDilateImageFilter , GrayscaleFunctionDilateImageFilter , BinaryDilateImageFilter
 
  itk::simple::HMaxima for the procedural interface
@@ -14333,7 +14517,6 @@ and Applications\", Second Edition, Springer, 2003.
 
 See:
  GrayscaleGeodesicDilateImageFilter , HMinimaImageFilter , HConvexImageFilter
-
 
  MorphologyImageFilter , GrayscaleDilateImageFilter , GrayscaleFunctionDilateImageFilter , BinaryDilateImageFilter
 
@@ -14455,7 +14638,8 @@ See:
 
  itk::simple::HalfHermitianToRealInverseFFT for the procedural interface
 
- itk::HalfHermitianToRealInverseFFTImageFilter for the Doxygen on the original ITK class.
+ itk::HalfHermitianToRealInverseFFTImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkHalfHermitianToRealInverseFFTImageFilter.h
@@ -14587,7 +14771,8 @@ both images have the same number of dimensions.
 See:
  DirectedHausdorffDistanceImageFilter
 
- itk::HausdorffDistanceImageFilter for the Doxygen on the original ITK class.
+ itk::HausdorffDistanceImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkHausdorffDistanceImageFilter.h
@@ -14678,7 +14863,8 @@ Imaging, 19(2):143-150, 2000.
 See:
  itk::simple::HistogramMatching for the procedural interface
 
- itk::HistogramMatchingImageFilter for the Doxygen on the original ITK class.
+ itk::HistogramMatchingImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkHistogramMatchingImageFilter.h
@@ -14781,7 +14967,8 @@ Threshold an image using the Huang Threshold.
 
 This filter creates a binary thresholded image that separates an image
 into foreground and background components. The filter computes the
-threshold using the HuangThresholdCalculator and applies that theshold to the input image using the BinaryThresholdImageFilter .
+threshold using the HuangThresholdCalculator and applies that theshold
+to the input image using the BinaryThresholdImageFilter .
 
 
 Richard Beare. Department of Medicine, Monash University, Melbourne,
@@ -14797,7 +14984,8 @@ See:
 
  itk::simple::HuangThreshold for the procedural interface
 
- itk::HuangThresholdImageFilter for the Doxygen on the original ITK class.
+ itk::HuangThresholdImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkHuangThresholdImageFilter.h
@@ -14876,7 +15064,8 @@ Set the value of MaskOutput to true or false respectfully.
 
 %feature("docstring")  itk::simple::HuangThresholdImageFilter::SetInsideValue "
 
-Set the \"inside\" pixel value. The default value NumericTraits<OutputPixelType>::max()
+Set the \"inside\" pixel value. The default value
+NumericTraits<OutputPixelType>::max()
 
 ";
 
@@ -14903,7 +15092,8 @@ Set/Get the number of histogram bins. Defaults is 128.
 
 %feature("docstring")  itk::simple::HuangThresholdImageFilter::SetOutsideValue "
 
-Set the \"outside\" pixel value. The default value NumericTraits<OutputPixelType>::Zero.
+Set the \"outside\" pixel value. The default value
+NumericTraits<OutputPixelType>::Zero.
 
 ";
 
@@ -15402,7 +15592,7 @@ base cast.
 
 
 See:
-itk::ImageToImageMetricv4::SetFixedImageMask
+ itk::ImageToImageMetricv4::SetFixedImageMask
 
 
 ";
@@ -15419,7 +15609,7 @@ base cast.
 
 
 See:
-itk::ImageToImageMetricv4::SetMovingImageMask
+ itk::ImageToImageMetricv4::SetMovingImageMask
 
 
 ";
@@ -15431,7 +15621,7 @@ Set sampling strategy for sample generation.
 
 
 See:
-itk::ImageRegistrationMethodv4::SetMetricSamplingStrategy
+ itk::ImageRegistrationMethodv4::SetMetricSamplingStrategy
 
 
 ";
@@ -15617,7 +15807,7 @@ shrink factor for each dimension.
 
 
 See:
-itk::ImageRegistrationMethodv4::SetShrinkFactorsPerLevel
+ itk::ImageRegistrationMethodv4::SetShrinkFactorsPerLevel
 
 
 ";
@@ -15629,7 +15819,7 @@ Set the sigmas of Gaussian used for smoothing at each level.
 
 
 See:
-itk::ImageRegistrationMethodv4::SetSmoothingSigmasPerLevel
+ itk::ImageRegistrationMethodv4::SetSmoothingSigmasPerLevel
 
 
 ";
@@ -15844,7 +16034,8 @@ See:
 
  itk::simple::IntensityWindowing for the procedural interface
 
- itk::IntensityWindowingImageFilter for the Doxygen on the original ITK class.
+ itk::IntensityWindowingImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkIntensityWindowingImageFilter.h
@@ -15871,28 +16062,28 @@ Name of this class
 %feature("docstring")  itk::simple::IntensityWindowingImageFilter::GetOutputMaximum "
 
 Set/Get the values of the maximum and minimum intensities of the
-outputimage
+output image.
 
 ";
 
 %feature("docstring")  itk::simple::IntensityWindowingImageFilter::GetOutputMinimum "
 
 Set/Get the values of the maximum and minimum intensities of the
-outputimage
+output image.
 
 ";
 
 %feature("docstring")  itk::simple::IntensityWindowingImageFilter::GetWindowMaximum "
 
 Set/Get the values of the maximum and minimum intensities of the input
-intensity window
+intensity window.
 
 ";
 
 %feature("docstring")  itk::simple::IntensityWindowingImageFilter::GetWindowMinimum "
 
 Set/Get the values of the maximum and minimum intensities of the input
-intensity window
+intensity window.
 
 ";
 
@@ -15906,28 +16097,28 @@ parameters
 %feature("docstring")  itk::simple::IntensityWindowingImageFilter::SetOutputMaximum "
 
 Set/Get the values of the maximum and minimum intensities of the
-outputimage
+output image.
 
 ";
 
 %feature("docstring")  itk::simple::IntensityWindowingImageFilter::SetOutputMinimum "
 
 Set/Get the values of the maximum and minimum intensities of the
-outputimage
+output image.
 
 ";
 
 %feature("docstring")  itk::simple::IntensityWindowingImageFilter::SetWindowMaximum "
 
 Set/Get the values of the maximum and minimum intensities of the input
-intensity window
+intensity window.
 
 ";
 
 %feature("docstring")  itk::simple::IntensityWindowingImageFilter::SetWindowMinimum "
 
 Set/Get the values of the maximum and minimum intensities of the input
-intensity window
+intensity window.
 
 ";
 
@@ -15951,7 +16142,8 @@ Threshold an image using the Intermodes Threshold.
 
 This filter creates a binary thresholded image that separates an image
 into foreground and background components. The filter computes the
-threshold using the IntermodesThresholdCalculator and applies that theshold to the input image using the BinaryThresholdImageFilter .
+threshold using the IntermodesThresholdCalculator and applies that
+theshold to the input image using the BinaryThresholdImageFilter .
 
 
 Richard Beare. Department of Medicine, Monash University, Melbourne,
@@ -15967,7 +16159,8 @@ See:
 
  itk::simple::IntermodesThreshold for the procedural interface
 
- itk::IntermodesThresholdImageFilter for the Doxygen on the original ITK class.
+ itk::IntermodesThresholdImageFilter for the Doxygen on the original
+ITK class.
 
 
 C++ includes: sitkIntermodesThresholdImageFilter.h
@@ -16073,7 +16266,8 @@ Set/Get the number of histogram bins.
 
 %feature("docstring")  itk::simple::IntermodesThresholdImageFilter::SetOutsideValue "
 
-Set the \"outside\" pixel value. The default value NumericTraits<OutputPixelType>::Zero.
+Set the \"outside\" pixel value. The default value
+NumericTraits<OutputPixelType>::Zero.
 
 ";
 
@@ -16112,7 +16306,8 @@ de Jouy-en-Josas, France
 See:
  itk::simple::InverseDeconvolution for the procedural interface
 
- itk::InverseDeconvolutionImageFilter for the Doxygen on the original ITK class.
+ itk::InverseDeconvolutionImageFilter for the Doxygen on the original
+ITK class.
 
 
 C++ includes: sitkInverseDeconvolutionImageFilter.h
@@ -16243,7 +16438,8 @@ type Vector .
 See:
  itk::simple::InverseDisplacementField for the procedural interface
 
- itk::InverseDisplacementFieldImageFilter for the Doxygen on the original ITK class.
+ itk::InverseDisplacementFieldImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkInverseDisplacementFieldImageFilter.h
@@ -16419,7 +16615,8 @@ Nick Tustison
 See:
  itk::simple::InvertDisplacementField for the procedural interface
 
- itk::InvertDisplacementFieldImageFilter for the Doxygen on the original ITK class.
+ itk::InvertDisplacementFieldImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkInvertDisplacementFieldImageFilter.h
@@ -16535,7 +16732,8 @@ Invert an image
 See:
  itk::simple::InvertIntensity for the procedural interface
 
- itk::InvertIntensityImageFilter for the Doxygen on the original ITK class.
+ itk::InvertIntensityImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -16555,6 +16753,9 @@ Execute the filter on the input image with the given parameters
 ";
 
 %feature("docstring")  itk::simple::InvertIntensityImageFilter::GetMaximum "
+
+Set/Get the maximum intensity value for the inversion.
+
 ";
 
 %feature("docstring")  itk::simple::InvertIntensityImageFilter::GetName "
@@ -16571,6 +16772,9 @@ parameters
 ";
 
 %feature("docstring")  itk::simple::InvertIntensityImageFilter::SetMaximum "
+
+Set/Get the maximum intensity value for the inversion.
+
 ";
 
 %feature("docstring")  itk::simple::InvertIntensityImageFilter::ToString "
@@ -16610,7 +16814,8 @@ Conference on Computer Aided Systems Theory , pages 48-51, Feb 2003.
 See:
  itk::simple::IsoContourDistance for the procedural interface
 
- itk::IsoContourDistanceImageFilter for the Doxygen on the original ITK class.
+ itk::IsoContourDistanceImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkIsoContourDistanceImageFilter.h
@@ -16689,7 +16894,8 @@ Threshold an image using the IsoData Threshold.
 
 This filter creates a binary thresholded image that separates an image
 into foreground and background components. The filter computes the
-threshold using the IsoDataThresholdCalculator and applies that theshold to the input image using the BinaryThresholdImageFilter .
+threshold using the IsoDataThresholdCalculator and applies that
+theshold to the input image using the BinaryThresholdImageFilter .
 
 
 Richard Beare. Department of Medicine, Monash University, Melbourne,
@@ -16705,7 +16911,8 @@ See:
 
  itk::simple::IsoDataThreshold for the procedural interface
 
- itk::IsoDataThresholdImageFilter for the Doxygen on the original ITK class.
+ itk::IsoDataThresholdImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkIsoDataThresholdImageFilter.h
@@ -16811,7 +17018,8 @@ Set/Get the number of histogram bins.
 
 %feature("docstring")  itk::simple::IsoDataThresholdImageFilter::SetOutsideValue "
 
-Set the \"outside\" pixel value. The default value NumericTraits<OutputPixelType>::Zero.
+Set the \"outside\" pixel value. The default value
+NumericTraits<OutputPixelType>::Zero.
 
 ";
 
@@ -16868,7 +17076,8 @@ check for this by querying the GetThresholdingFailed() flag.
 See:
  itk::simple::IsolatedConnected for the procedural interface
 
- itk::IsolatedConnectedImageFilter for the Doxygen on the original ITK class.
+ itk::IsolatedConnectedImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkIsolatedConnectedImageFilter.h
@@ -17045,7 +17254,8 @@ defaults to the 1.0.
 See:
  itk::simple::IsolatedWatershed for the procedural interface
 
- itk::IsolatedWatershedImageFilter for the Doxygen on the original ITK class.
+ itk::IsolatedWatershedImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkIsolatedWatershedImageFilter.h
@@ -17310,7 +17520,8 @@ Threshold an image using the KittlerIllingworth Threshold.
 
 This filter creates a binary thresholded image that separates an image
 into foreground and background components. The filter computes the
-threshold using the KittlerIllingworthThresholdCalculator and applies that theshold to the input image using the BinaryThresholdImageFilter .
+threshold using the KittlerIllingworthThresholdCalculator and applies
+that theshold to the input image using the BinaryThresholdImageFilter .
 
 
 Richard Beare. Department of Medicine, Monash University, Melbourne,
@@ -17326,7 +17537,8 @@ See:
 
  itk::simple::KittlerIllingworthThreshold for the procedural interface
 
- itk::KittlerIllingworthThresholdImageFilter for the Doxygen on the original ITK class.
+ itk::KittlerIllingworthThresholdImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkKittlerIllingworthThresholdImageFilter.h
@@ -17432,7 +17644,8 @@ Set/Get the number of histogram bins.
 
 %feature("docstring")  itk::simple::KittlerIllingworthThresholdImageFilter::SetOutsideValue "
 
-Set the \"outside\" pixel value. The default value NumericTraits<OutputPixelType>::Zero.
+Set the \"outside\" pixel value. The default value
+NumericTraits<OutputPixelType>::Zero.
 
 ";
 
@@ -17479,7 +17692,8 @@ Label the contours of connected components
 See:
  itk::simple::LabelContour for the procedural interface
 
- itk::LabelContourImageFilter for the Doxygen on the original ITK class.
+ itk::LabelContourImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -17591,7 +17805,8 @@ Convert an itk::Image consisting of labeled regions to a LabelMap
 See:
  itk::simple::LabelImageToLabelMapFilter for the procedural interface
 
- itk::LabelImageToLabelMapFilter for the Doxygen on the original ITK class.
+ itk::LabelImageToLabelMapFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -17663,9 +17878,11 @@ de Jouy-en-Josas, France.
 
 
 See:
- StatisticsLabelObject , LabelStatisticsOpeningImageFilter , LabelStatisticsOpeningImageFilter
+ StatisticsLabelObject , LabelStatisticsOpeningImageFilter ,
+LabelStatisticsOpeningImageFilter
 
- itk::LabelImageToStatisticsLabelMapFilter for the Doxygen on the original ITK class.
+ itk::LabelImageToStatisticsLabelMapFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkLabelIntensityStatisticsImageFilter.h
@@ -18092,7 +18309,9 @@ de Jouy-en-Josas, France.
 
 
 See:
- LabelMapToBinaryImageFilter , LabelMapToLabelImageFilter , LabelMapOverlayImageFilter
+ LabelMapOverlayImageFilter , LabelOverlayImageFilter , LabelOverlayFunctor
+
+ LabelMapToBinaryImageFilter , LabelMapToLabelImageFilter ,
 Wiki Examples:
 
 All Examples
@@ -18101,7 +18320,8 @@ Color the boundaries of labeled regions in an image
 See:
  itk::simple::LabelMapContourOverlay for the procedural interface
 
- itk::LabelMapContourOverlayImageFilter for the Doxygen on the original ITK class.
+ itk::LabelMapContourOverlayImageFilter for the Doxygen on the original
+ITK class.
 
 
 
@@ -18253,7 +18473,8 @@ See:
 
  itk::simple::LabelMapMask for the procedural interface
 
- itk::LabelMapMaskImageFilter for the Doxygen on the original ITK class.
+ itk::LabelMapMaskImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkLabelMapMaskImageFilter.h
@@ -18409,11 +18630,14 @@ de Jouy-en-Josas, France.
 
 
 See:
- LabelMapToBinaryImageFilter , LabelMapToLabelImageFilter
+ LabelOverlayImageFilter , LabelOverlayFunctor
+
+ LabelMapToRGBImageFilter , LabelMapToBinaryImageFilter , LabelMapToLabelImageFilter
 
  itk::simple::LabelMapOverlay for the procedural interface
 
- itk::LabelMapOverlayImageFilter for the Doxygen on the original ITK class.
+ itk::LabelMapOverlayImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkLabelMapOverlayImageFilter.h
@@ -18498,7 +18722,8 @@ See:
 
  itk::simple::LabelMapToBinary for the procedural interface
 
- itk::LabelMapToBinaryImageFilter for the Doxygen on the original ITK class.
+ itk::LabelMapToBinaryImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkLabelMapToBinaryImageFilter.h
@@ -18593,7 +18818,8 @@ Convert a LabelMap to a normal image with different values representing each reg
 See:
  itk::simple::LabelMapToLabel for the procedural interface
 
- itk::LabelMapToLabelImageFilter for the Doxygen on the original ITK class.
+ itk::LabelMapToLabelImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -18644,11 +18870,14 @@ de Jouy-en-Josas, France.
 
 
 See:
- LabelMapToBinaryImageFilter , LabelMapMaskImageFilter
+ LabelToRGBImageFilter , LabelToRGBFunctor
+
+ LabelMapOverlayImageFilter , LabelMapToBinaryImageFilter , LabelMapMaskImageFilter
 
  itk::simple::LabelMapToRGB for the procedural interface
 
- itk::LabelMapToRGBImageFilter for the Doxygen on the original ITK class.
+ itk::LabelMapToRGBImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkLabelMapToRGBImageFilter.h
@@ -18714,7 +18943,8 @@ Nicholas J. Tustison
 See:
  LabelOverlapMeasuresImageFilter
 
- itk::LabelOverlapMeasuresImageFilter for the Doxygen on the original ITK class.
+ itk::LabelOverlapMeasuresImageFilter for the Doxygen on the original
+ITK class.
 
 
 C++ includes: sitkLabelOverlapMeasuresImageFilter.h
@@ -18728,7 +18958,8 @@ Execute the filter on the input images
 
 %feature("docstring")  itk::simple::LabelOverlapMeasuresImageFilter::GetDiceCoefficient "
 
-alternative names
+Get the mean overlap (Dice coefficient) for the specified individual
+label.
 
 This is a measurement. Its value is updated in the Execute methods, so
 the value will only be valid after an execution.
@@ -18737,12 +18968,16 @@ the value will only be valid after an execution.
 
 %feature("docstring")  itk::simple::LabelOverlapMeasuresImageFilter::GetFalseNegativeError "
 
+Get the false negative error for the specified individual label.
+
 This is a measurement. Its value is updated in the Execute methods, so
 the value will only be valid after an execution.
 
 ";
 
 %feature("docstring")  itk::simple::LabelOverlapMeasuresImageFilter::GetFalsePositiveError "
+
+Get the false positive error for the specified individual label.
 
 This is a measurement. Its value is updated in the Execute methods, so
 the value will only be valid after an execution.
@@ -18751,7 +18986,8 @@ the value will only be valid after an execution.
 
 %feature("docstring")  itk::simple::LabelOverlapMeasuresImageFilter::GetJaccardCoefficient "
 
-alternative names
+Get the union overlap (Jaccard coefficient) for the specified
+individual label.
 
 This is a measurement. Its value is updated in the Execute methods, so
 the value will only be valid after an execution.
@@ -18759,6 +18995,9 @@ the value will only be valid after an execution.
 ";
 
 %feature("docstring")  itk::simple::LabelOverlapMeasuresImageFilter::GetMeanOverlap "
+
+Get the mean overlap (Dice coefficient) for the specified individual
+label.
 
 This is a measurement. Its value is updated in the Execute methods, so
 the value will only be valid after an execution.
@@ -18773,12 +19012,17 @@ Name of this class
 
 %feature("docstring")  itk::simple::LabelOverlapMeasuresImageFilter::GetUnionOverlap "
 
+Get the union overlap (Jaccard coefficient) for the specified
+individual label.
+
 This is a measurement. Its value is updated in the Execute methods, so
 the value will only be valid after an execution.
 
 ";
 
 %feature("docstring")  itk::simple::LabelOverlapMeasuresImageFilter::GetVolumeSimilarity "
+
+Get the volume similarity for the specified individual label.
 
 This is a measurement. Its value is updated in the Execute methods, so
 the value will only be valid after an execution.
@@ -18825,7 +19069,9 @@ de Jouy-en-Josas, France.
 
 
 See:
-ScalarToRGBPixelFunctor LabelToRGBImageFilter
+ LabelToRGBImageFilter
+
+ LabelMapOverlayImageFilter , LabelOverlayFunctor
 Wiki Examples:
 
 All Examples
@@ -18834,7 +19080,8 @@ Overlay a LabelMap on an image
 See:
  itk::simple::LabelOverlay for the procedural interface
 
- itk::LabelOverlayImageFilter for the Doxygen on the original ITK class.
+ itk::LabelOverlayImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -18929,7 +19176,8 @@ Gaetan Lehmann. Biologie du Developpement et de la Reproduction, INRA
 de Jouy-en-Josas, France.
 
 See:
- ShapeLabelObject , LabelShapeOpeningImageFilter , LabelStatisticsOpeningImageFilter
+ ShapeLabelObject , LabelShapeOpeningImageFilter ,
+LabelStatisticsOpeningImageFilter
 Wiki Examples:
 
 All Examples
@@ -18937,7 +19185,8 @@ All Examples
 Convert an itk::Image consisting of labeled regions to a ShapeLabelMap
 
 See:
- itk::LabelImageToShapeLabelMapFilter for the Doxygen on the original ITK class.
+ itk::LabelImageToShapeLabelMapFilter for the Doxygen on the original
+ITK class.
 
 
 C++ includes: sitkLabelShapeStatisticsImageFilter.h
@@ -19227,7 +19476,8 @@ All Examples
 Get statistical properties of labeled regions in an image
 
 See:
- itk::LabelStatisticsImageFilter for the Doxygen on the original ITK class.
+ itk::LabelStatisticsImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkLabelStatisticsImageFilter.h
@@ -19419,7 +19669,9 @@ Australia.
 
 
 See:
-ScalarToRGBPixelFunctor LabelOverlayImageFilter
+ LabelOverlayImageFilter
+
+ LabelMapToRGBImageFilter , LabelToRGBFunctor, ScalarToRGBPixelFunctor
 
  itk::simple::LabelToRGB for the procedural interface
 
@@ -19490,9 +19742,9 @@ Destructor
 Make sure that the objects are not overlapping.
 
 
-AttributeUniqueLabelMapFilter search the overlapping zones in the overlapping objects and keeps
-only a single object on all the pixels of the image. The object to
-keep is selected according to their label.
+AttributeUniqueLabelMapFilter search the overlapping zones in the
+overlapping objects and keeps only a single object on all the pixels
+of the image. The object to keep is selected according to their label.
 
 
 Gaetan Lehmann. Biologie du Developpement et de la Reproduction, INRA
@@ -19505,7 +19757,8 @@ See:
 
  itk::simple::LabelUniqueLabelMapFilter for the procedural interface
 
- itk::LabelUniqueLabelMapFilter for the Doxygen on the original ITK class.
+ itk::LabelUniqueLabelMapFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkLabelUniqueLabelMapFilter.h
@@ -19587,7 +19840,8 @@ INPUTS
 All input volumes to this filter must be segmentations of an image,
 that is, they must have discrete pixel values where each value
 represents a different segmented object.
- Input volumes must all contain the same size RequestedRegions. Not all input images must contain all possible labels, but all label
+ Input volumes must all contain the same size RequestedRegions. Not
+all input images must contain all possible labels, but all label
 values must have the same meaning in all images.
 
 OUTPUTS
@@ -19740,7 +19994,8 @@ landmarks
 See:
  itk::simple::LandmarkBasedTransformInitializerFilter for the procedural interface
 
- itk::LandmarkBasedTransformInitializer for the Doxygen on the original ITK class.
+ itk::LandmarkBasedTransformInitializer for the Doxygen on the original
+ITK class.
 
 
 
@@ -19871,15 +20126,14 @@ de Jouy-en-Josas, France
 See:
  IterativeDeconvolutionImageFilter
 
-
  RichardsonLucyDeconvolutionImageFilter
-
 
  ProjectedLandweberDeconvolutionImageFilter
 
  itk::simple::LandweberDeconvolution for the procedural interface
 
- itk::LandweberDeconvolutionImageFilter for the Doxygen on the original ITK class.
+ itk::LandweberDeconvolutionImageFilter for the Doxygen on the original
+ITK class.
 
 
 C++ includes: sitkLandweberDeconvolutionImageFilter.h
@@ -20001,15 +20255,11 @@ input and output images is not float or double.
 See:
  Image
 
-
  Neighborhood
-
 
  NeighborhoodOperator
 
-
  NeighborhoodIterator
-
 
  LaplacianOperator
 Wiki Examples:
@@ -20105,7 +20355,8 @@ Compute the Laplacian of Gaussian (LoG) of an image
 See:
  itk::simple::LaplacianRecursiveGaussian for the procedural interface
 
- itk::LaplacianRecursiveGaussianImageFilter for the Doxygen on the original ITK class.
+ itk::LaplacianRecursiveGaussianImageFilter for the Doxygen on the
+original ITK class.
 
 
 
@@ -20196,8 +20447,10 @@ features.
 
 
 IMPORTANT
-The SegmentationLevelSetImageFilter class and the LaplacianSegmentationLevelSetFunction class contain additional information necessary to the full
-understanding of how to use this filter.
+The SegmentationLevelSetImageFilter class and the
+LaplacianSegmentationLevelSetFunction class contain additional
+information necessary to the full understanding of how to use this
+filter.
 OVERVIEW
 This class is a level set method segmentation filter. It constructs a
 speed function which is zero at image edges as detected by a Laplacian
@@ -20245,22 +20498,23 @@ negative *values in the image are outside of the inside region. The
 zero crossings of *the image correspond to the position of the level
 set front.
 
-See SparseFieldLevelSetImageFilter and SegmentationLevelSetImageFilter for more information.
+See SparseFieldLevelSetImageFilter and SegmentationLevelSetImageFilter
+for more information.
 PARAMETERS
-This filter has no parameters other than those described in SegmentationLevelSetImageFilter .
+This filter has no parameters other than those described in
+SegmentationLevelSetImageFilter .
 
 See:
  SegmentationLevelSetImageFilter
 
-
  LaplacianSegmentationLevelSetFunction ,
-
 
  SparseFieldLevelSetImageFilter
 
  itk::simple::LaplacianSegmentationLevelSet for the procedural interface
 
- itk::LaplacianSegmentationLevelSetImageFilter for the Doxygen on the original ITK class.
+ itk::LaplacianSegmentationLevelSetImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkLaplacianSegmentationLevelSetImageFilter.h
@@ -20380,15 +20634,11 @@ The input to this filter is a scalar-valued itk::Image of arbitrary dimension. T
 See:
  Image
 
-
  Neighborhood
-
 
  NeighborhoodOperator
 
-
  NeighborhoodIterator
-
 
  LaplacianOperator
 Wiki Examples:
@@ -20399,7 +20649,8 @@ Sharpen an image
 See:
  itk::simple::LaplacianSharpening for the procedural interface
 
- itk::LaplacianSharpeningImageFilter for the Doxygen on the original ITK class.
+ itk::LaplacianSharpeningImageFilter for the Doxygen on the original
+ITK class.
 
 
 
@@ -20478,7 +20729,8 @@ the type of the output image. It is also parameterized by the
 operation to be applied. A Functor style is used.
 
 The constant must be of the same type than the pixel type of the
-corresponding image. It is wrapped in a SimpleDataObjectDecorator so it can be updated through the pipeline. The SetConstant() and
+corresponding image. It is wrapped in a SimpleDataObjectDecorator so
+it can be updated through the pipeline. The SetConstant() and
 GetConstant() methods are provided as shortcuts to set or get the
 constant value without manipulating the decorator.
 
@@ -20495,7 +20747,8 @@ Apply a custom operation to corresponding pixels in two images
 See:
  itk::simple::LessEqual for the procedural interface
 
- itk::BinaryFunctorImageFilter for the Doxygen on the original ITK class.
+ itk::BinaryFunctorImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -20594,7 +20847,8 @@ the type of the output image. It is also parameterized by the
 operation to be applied. A Functor style is used.
 
 The constant must be of the same type than the pixel type of the
-corresponding image. It is wrapped in a SimpleDataObjectDecorator so it can be updated through the pipeline. The SetConstant() and
+corresponding image. It is wrapped in a SimpleDataObjectDecorator so
+it can be updated through the pipeline. The SetConstant() and
 GetConstant() methods are provided as shortcuts to set or get the
 constant value without manipulating the decorator.
 
@@ -20611,7 +20865,8 @@ Apply a custom operation to corresponding pixels in two images
 See:
  itk::simple::Less for the procedural interface
 
- itk::BinaryFunctorImageFilter for the Doxygen on the original ITK class.
+ itk::BinaryFunctorImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -20754,7 +21009,7 @@ for each iteration is computed in LevelSetMotionFunction.
 WARNING:
 This filter assumes that the fixed image type, moving image type and
 deformation field type all have the same number of dimensions.
- Ref: B.C. Vemuri, J. Ye, Y. Chen, C.M. Leonard. \" Image registration
+ Ref: B.C. Vemuri, J. Ye, Y. Chen, C.M. Leonard. \"Image registration
 via level-set motion: applications to atlas-based segmentation\".
 Medical Image Analysis. Vol. 7. pp. 1-20. 2003.
 
@@ -20762,10 +21017,10 @@ Medical Image Analysis. Vol. 7. pp. 1-20. 2003.
 See:
  LevelSetMotionRegistrationFunction
 
-
  DemonsRegistrationFilter
 
- itk::LevelSetMotionRegistrationFilter for the Doxygen on the original ITK class.
+ itk::LevelSetMotionRegistrationFilter for the Doxygen on the original
+ITK class.
 
 
 C++ includes: sitkLevelSetMotionRegistrationFilter.h
@@ -20919,12 +21174,12 @@ prior to calculating gradients. The standard deviation is measured in
 physical units (for instance mm). Note that this smoothing value is
 not to be confused with the
 PDEDeformableRegistrationFilter::SetStandardDeviations() method. The
-method in PDEDeformableRegistrationFilter is for setting the smoothing parameters for regularizing the
-deformation field between interations. Those smoothing parameters are
-set in pixel units not physical units. Deformation field smoothing is
-not done by default in LevelSetMotionRegistration. This smoothing
-parameter is to condition the gradient calculation and parameter is
-specified in physical units.
+method in PDEDeformableRegistrationFilter is for setting the smoothing
+parameters for regularizing the deformation field between interations.
+Those smoothing parameters are set in pixel units not physical units.
+Deformation field smoothing is not done by default in
+LevelSetMotionRegistration. This smoothing parameter is to condition
+the gradient calculation and parameter is specified in physical units.
 
 ";
 
@@ -21052,7 +21307,8 @@ Threshold an image using the Li Threshold.
 
 This filter creates a binary thresholded image that separates an image
 into foreground and background components. The filter computes the
-threshold using the LiThresholdCalculator and applies that theshold to the input image using the BinaryThresholdImageFilter .
+threshold using the LiThresholdCalculator and applies that theshold to
+the input image using the BinaryThresholdImageFilter .
 
 
 Richard Beare. Department of Medicine, Monash University, Melbourne,
@@ -21174,7 +21430,8 @@ Set/Get the number of histogram bins.
 
 %feature("docstring")  itk::simple::LiThresholdImageFilter::SetOutsideValue "
 
-Set the \"outside\" pixel value. The default value NumericTraits<OutputPixelType>::Zero.
+Set the \"outside\" pixel value. The default value
+NumericTraits<OutputPixelType>::Zero.
 
 ";
 
@@ -21299,7 +21556,8 @@ or all 3D, or all ND)
 See:
  itk::simple::MagnitudeAndPhaseToComplex for the procedural interface
 
- itk::MagnitudeAndPhaseToComplexImageFilter for the Doxygen on the original ITK class.
+ itk::MagnitudeAndPhaseToComplexImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkMagnitudeAndPhaseToComplexImageFilter.h
@@ -21462,7 +21720,7 @@ Apply the inverse of a mask to an image
 See:
  itk::simple::MaskNegated for the procedural interface
 
-itk::MaskNegatedImageFilter for the Doxygen on the original ITK class.
+ itk::MaskNegatedImageFilter for the Doxygen on the original ITK class.
 
 
 C++ includes: sitkMaskNegatedImageFilter.h
@@ -21603,7 +21861,8 @@ Computer Vision and Pattern Recognition, 2010.
 See:
  itk::simple::MaskedFFTNormalizedCorrelation for the procedural interface
 
- itk::MaskedFFTNormalizedCorrelationImageFilter for the Doxygen on the original ITK class.
+ itk::MaskedFFTNormalizedCorrelationImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkMaskedFFTNormalizedCorrelationImageFilter.h
@@ -21678,7 +21937,8 @@ Threshold an image using the MaximumEntropy Threshold.
 
 This filter creates a binary thresholded image that separates an image
 into foreground and background components. The filter computes the
-threshold using the MaximumEntropyThresholdCalculator and applies that theshold to the input image using the BinaryThresholdImageFilter .
+threshold using the MaximumEntropyThresholdCalculator and applies that
+theshold to the input image using the BinaryThresholdImageFilter .
 
 
 Richard Beare. Department of Medicine, Monash University, Melbourne,
@@ -21694,7 +21954,8 @@ See:
 
  itk::simple::MaximumEntropyThreshold for the procedural interface
 
- itk::MaximumEntropyThresholdImageFilter for the Doxygen on the original ITK class.
+ itk::MaximumEntropyThresholdImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkMaximumEntropyThresholdImageFilter.h
@@ -21800,7 +22061,8 @@ Set/Get the number of histogram bins.
 
 %feature("docstring")  itk::simple::MaximumEntropyThresholdImageFilter::SetOutsideValue "
 
-Set the \"outside\" pixel value. The default value NumericTraits<OutputPixelType>::Zero.
+Set the \"outside\" pixel value. The default value
+NumericTraits<OutputPixelType>::Zero.
 
 ";
 
@@ -21901,27 +22163,22 @@ de jouy-en-josas, France.
 See:
  ProjectionImageFilter
 
-
  MedianProjectionImageFilter
-
 
  MeanProjectionImageFilter
 
-
  MinimumProjectionImageFilter
-
 
  StandardDeviationProjectionImageFilter
 
-
  SumProjectionImageFilter
-
 
  BinaryProjectionImageFilter
 
  itk::simple::MaximumProjection for the procedural interface
 
- itk::MaximumProjectionImageFilter for the Doxygen on the original ITK class.
+ itk::MaximumProjectionImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkMaximumProjectionImageFilter.h
@@ -21985,12 +22242,9 @@ A mean filter is one of the family of linear filters.
 See:
  Image
 
-
  Neighborhood
 
-
  NeighborhoodOperator
-
 
  NeighborhoodIterator
 Wiki Examples:
@@ -22073,27 +22327,22 @@ de Jouy-en-Josas, France.
 See:
  ProjectionImageFilter
 
-
  MedianProjectionImageFilter
-
 
  MinimumProjectionImageFilter
 
-
  StandardDeviationProjectionImageFilter
-
 
  SumProjectionImageFilter
 
-
  BinaryProjectionImageFilter
-
 
  MaximumProjectionImageFilter
 
  itk::simple::MeanProjection for the procedural interface
 
- itk::MeanProjectionImageFilter for the Doxygen on the original ITK class.
+ itk::MeanProjectionImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkMeanProjectionImageFilter.h
@@ -22161,12 +22410,9 @@ This filter requires that the input pixel type provides an operator<()
 See:
  Image
 
-
  Neighborhood
 
-
  NeighborhoodOperator
-
 
  NeighborhoodIterator
 Wiki Examples:
@@ -22251,27 +22497,22 @@ de Jouy-en-Josas, France.
 See:
  ProjectionImageFilter
 
-
  StandardDeviationProjectionImageFilter
-
 
  SumProjectionImageFilter
 
-
  BinaryProjectionImageFilter
-
 
  MaximumProjectionImageFilter
 
-
  MinimumProjectionImageFilter
-
 
  MeanProjectionImageFilter
 
  itk::simple::MedianProjection for the procedural interface
 
- itk::MedianProjectionImageFilter for the Doxygen on the original ITK class.
+ itk::MedianProjectionImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkMedianProjectionImageFilter.h
@@ -22453,7 +22694,8 @@ The threshold value $ T_{threshold} $ is the average intensity obtained in the d
 the gradient at point $ x $ at the extrema of the local neighborhood.
 
 This filter make use of the multi-threaded finite difference solver
-hierarchy. Updates are computed using a MinMaxCurvatureFlowFunction object. A zero flux Neumann boundary condition is used when computing
+hierarchy. Updates are computed using a MinMaxCurvatureFlowFunction
+object. A zero flux Neumann boundary condition is used when computing
 derivatives near the data boundary.
 
 
@@ -22470,15 +22712,14 @@ Sethian, Cambridge Press, Chapter 16, Second edition, 1999.
 See:
  MinMaxCurvatureFlowFunction
 
-
  CurvatureFlowImageFilter
-
 
  BinaryMinMaxCurvatureFlowImageFilter
 
  itk::simple::MinMaxCurvatureFlow for the procedural interface
 
- itk::MinMaxCurvatureFlowImageFilter for the Doxygen on the original ITK class.
+ itk::MinMaxCurvatureFlowImageFilter for the Doxygen on the original
+ITK class.
 
 
 C++ includes: sitkMinMaxCurvatureFlowImageFilter.h
@@ -22628,7 +22869,8 @@ pipeline. The implementation uses the StatisticsImageFilter .
 See:
  StatisticsImageFilter
 
- itk::MinimumMaximumImageFilter for the Doxygen on the original ITK class.
+ itk::MinimumMaximumImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkMinimumMaximumImageFilter.h
@@ -22699,24 +22941,20 @@ de Jouy-en-Josas, France.
 See:
  ProjectionImageFilter
 
-
  StandardDeviationProjectionImageFilter
-
 
  SumProjectionImageFilter
 
-
  BinaryProjectionImageFilter
 
-
  MaximumProjectionImageFilter
-
 
  MeanProjectionImageFilter
 
  itk::simple::MinimumProjection for the procedural interface
 
- itk::MinimumProjectionImageFilter for the Doxygen on the original ITK class.
+ itk::MinimumProjectionImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkMinimumProjectionImageFilter.h
@@ -22774,13 +23012,13 @@ value.
 
 MirrorPadImageFilter changes the image bounds of an image. Any added pixels are filled in
 with a mirrored replica of the input image. For instance, if the
-output image needs a pixel that istwo pixels to the left of the
-LargestPossibleRegionof the input image, the value assigned will be
-from the pixeltwo pixels inside the left boundary of the
+output image needs a pixel that is two pixels to the left of the
+LargestPossibleRegion of the input image, the value assigned will be
+from the pixel two pixels inside the left boundary of the
 LargestPossibleRegion. The image bounds of the output must be
 specified.
 
-Visual explanation of padding regions.This filter is implemented as a
+Visual explanation of padding regions. This filter is implemented as a
 multithreaded filter. It provides a ThreadedGenerateData() method for
 its implementation.
 
@@ -22922,7 +23160,8 @@ Threshold an image using the Moments Threshold.
 
 This filter creates a binary thresholded image that separates an image
 into foreground and background components. The filter computes the
-threshold using the MomentsThresholdCalculator and applies that theshold to the input image using the BinaryThresholdImageFilter .
+threshold using the MomentsThresholdCalculator and applies that
+theshold to the input image using the BinaryThresholdImageFilter .
 
 
 Richard Beare. Department of Medicine, Monash University, Melbourne,
@@ -22938,7 +23177,8 @@ See:
 
  itk::simple::MomentsThreshold for the procedural interface
 
- itk::MomentsThresholdImageFilter for the Doxygen on the original ITK class.
+ itk::MomentsThresholdImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkMomentsThresholdImageFilter.h
@@ -23044,7 +23284,8 @@ Set/Get the number of histogram bins.
 
 %feature("docstring")  itk::simple::MomentsThresholdImageFilter::SetOutsideValue "
 
-Set the \"outside\" pixel value. The default value NumericTraits<OutputPixelType>::Zero.
+Set the \"outside\" pixel value. The default value
+NumericTraits<OutputPixelType>::Zero.
 
 ";
 
@@ -23079,7 +23320,8 @@ See:
 
  itk::simple::MorphologicalGradient for the procedural interface
 
- itk::MorphologicalGradientImageFilter for the Doxygen on the original ITK class.
+ itk::MorphologicalGradientImageFilter for the Doxygen on the original
+ITK class.
 
 
 C++ includes: sitkMorphologicalGradientImageFilter.h
@@ -23205,7 +23447,8 @@ See:
 
  itk::simple::MorphologicalWatershedFromMarkers for the procedural interface
 
- itk::MorphologicalWatershedFromMarkersImageFilter for the Doxygen on the original ITK class.
+ itk::MorphologicalWatershedFromMarkersImageFilter for the Doxygen on
+the original ITK class.
 
 
 C++ includes: sitkMorphologicalWatershedFromMarkersImageFilter.h
@@ -23330,7 +23573,8 @@ See:
 
  itk::simple::MorphologicalWatershed for the procedural interface
 
- itk::MorphologicalWatershedImageFilter for the Doxygen on the original ITK class.
+ itk::MorphologicalWatershedImageFilter for the Doxygen on the original
+ITK class.
 
 
 C++ includes: sitkMorphologicalWatershedImageFilter.h
@@ -23464,7 +23708,8 @@ INPUTS
 All input volumes to this filter must be segmentations of an image,
 that is, they must have discrete pixel values where each value
 represents a different segmented object.
- Input volumes must all contain the same size RequestedRegions. Not all input images must contain all possible labels, but all label
+ Input volumes must all contain the same size RequestedRegions. Not
+all input images must contain all possible labels, but all label
 values must have the same meaning in all images.
 
 The filter can optionally be provided with estimates for the a priori
@@ -23631,8 +23876,8 @@ Set maximum number of iterations.
 
 %feature("docstring")  itk::simple::MultiLabelSTAPLEImageFilter::SetPriorProbabilities "
 
-    Set manual estimates for the a priori class probabilities.The size
-of the array must be greater than the value of the largest label. The index into the array corresponds to the label
+    Set manual estimates for the a priori class probabilities. The
+size of the array must be greater than the value of the largest label. The index into the array corresponds to the label
 value in the segmented image for the class.
 
 ";
@@ -23779,16 +24024,17 @@ Journal paper: https://hdl.handle.net/10380/3053
 
 REFERENCE
  J.G. Sled, A.P. Zijdenbos and A.C. Evans. \"A Nonparametric Method
-for Automatic Correction of Intensity Nonuniformity in  Data\" IEEE
+for Automatic Correction of Intensity Nonuniformity in Data\" IEEE
 Transactions on Medical Imaging, Vol 17, No 1. Feb 1998.
 
 N.J. Tustison, B.B. Avants, P.A. Cook, Y. Zheng, A. Egan, P.A.
-Yushkevich, and J.C. Gee. \"N4ITK:  Improved N3 Bias Correction\" IEEE
+Yushkevich, and J.C. Gee. \"N4ITK: Improved N3 Bias Correction\" IEEE
 Transactions on Medical Imaging, 29(6):1310-1320, June 2010.
 See:
  itk::simple::N4BiasFieldCorrection for the procedural interface
 
- itk::N4BiasFieldCorrectionImageFilter for the Doxygen on the original ITK class.
+ itk::N4BiasFieldCorrectionImageFilter for the Doxygen on the original
+ITK class.
 
 
 C++ includes: sitkN4BiasFieldCorrectionImageFilter.h
@@ -24119,7 +24365,8 @@ AND whose neighbors all lie within a Lower and Upper threshold range.
 See:
  itk::simple::NeighborhoodConnected for the procedural interface
 
- itk::NeighborhoodConnectedImageFilter for the Doxygen on the original ITK class.
+ itk::NeighborhoodConnectedImageFilter for the Doxygen on the original
+ITK class.
 
 
 C++ includes: sitkNeighborhoodConnectedImageFilter.h
@@ -24270,12 +24517,9 @@ to this (hyper) plane.
 See:
  Image
 
-
  Neighborhood
 
-
  NeighborhoodOperator
-
 
  NeighborhoodIterator
 Wiki Examples:
@@ -24449,9 +24693,7 @@ de Jouy-en-Josas, France.
 See:
  NormalizeImageFilter
 
-
  StatisticsImageFilter
-
 
  DivideImageFilter
 Wiki Examples:
@@ -24462,7 +24704,8 @@ Scale all pixels so that their sum is a specified constant
 See:
  itk::simple::NormalizeToConstant for the procedural interface
 
- itk::NormalizeToConstantImageFilter for the Doxygen on the original ITK class.
+ itk::NormalizeToConstantImageFilter for the Doxygen on the original
+ITK class.
 
 
 
@@ -24536,12 +24779,9 @@ under the mask.
 See:
  Image
 
-
  Neighborhood
 
-
  NeighborhoodOperator
-
 
  NeighborhoodIterator
 Wiki Examples:
@@ -24552,7 +24792,8 @@ Normalized correlation
 See:
  itk::simple::NormalizedCorrelation for the procedural interface
 
- itk::NormalizedCorrelationImageFilter for the Doxygen on the original ITK class.
+ itk::NormalizedCorrelationImageFilter for the Doxygen on the original
+ITK class.
 
 
 
@@ -24602,7 +24843,8 @@ the type of the output image. It is also parameterized by the
 operation to be applied. A Functor style is used.
 
 The constant must be of the same type than the pixel type of the
-corresponding image. It is wrapped in a SimpleDataObjectDecorator so it can be updated through the pipeline. The SetConstant() and
+corresponding image. It is wrapped in a SimpleDataObjectDecorator so
+it can be updated through the pipeline. The SetConstant() and
 GetConstant() methods are provided as shortcuts to set or get the
 constant value without manipulating the decorator.
 
@@ -24619,7 +24861,8 @@ Apply a custom operation to corresponding pixels in two images
 See:
  itk::simple::NotEqual for the procedural interface
 
- itk::BinaryFunctorImageFilter for the Doxygen on the original ITK class.
+ itk::BinaryFunctorImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -24799,7 +25042,8 @@ See:
 
  itk::simple::OpeningByReconstruction for the procedural interface
 
- itk::OpeningByReconstructionImageFilter for the Doxygen on the original ITK class.
+ itk::OpeningByReconstructionImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkOpeningByReconstructionImageFilter.h
@@ -25005,8 +25249,12 @@ Threshold an image using multiple Otsu Thresholds.
 
 
 This filter creates a labeled image that separates the input image
-into various classes. The filter computes the thresholds using the OtsuMultipleThresholdsCalculator and applies those thesholds to the input image using the ThresholdLabelerImageFilter . The NumberOfHistogramBins and NumberOfThresholds can be set for the
-Calculator. The LabelOffset can be set for the ThresholdLabelerImageFilter .
+into various classes. The filter computes the thresholds using the
+OtsuMultipleThresholdsCalculator and applies those thesholds to the
+input image using the ThresholdLabelerImageFilter . The
+NumberOfHistogramBins and NumberOfThresholds can be set for the
+Calculator. The LabelOffset can be set for the
+ThresholdLabelerImageFilter .
 
 This filter also includes an option to use the valley emphasis
 algorithm from H.F. Ng, \"Automatic thresholding for defect
@@ -25020,17 +25268,16 @@ default.
 
 
 See:
-ScalarImageToHistogramGenerator
-
+ ScalarImageToHistogramGenerator
 
  OtsuMultipleThresholdsCalculator
-
 
  ThresholdLabelerImageFilter
 
  itk::simple::OtsuMultipleThresholds for the procedural interface
 
- itk::OtsuMultipleThresholdsImageFilter for the Doxygen on the original ITK class.
+ itk::OtsuMultipleThresholdsImageFilter for the Doxygen on the original
+ITK class.
 
 
 C++ includes: sitkOtsuMultipleThresholdsImageFilter.h
@@ -25147,7 +25394,8 @@ Threshold an image using the Otsu Threshold.
 
 This filter creates a binary thresholded image that separates an image
 into foreground and background components. The filter computes the
-threshold using the OtsuThresholdCalculator and applies that theshold to the input image using the BinaryThresholdImageFilter .
+threshold using the OtsuThresholdCalculator and applies that theshold
+to the input image using the BinaryThresholdImageFilter .
 
 
 Richard Beare
@@ -25167,7 +25415,8 @@ See:
 
  itk::simple::OtsuThreshold for the procedural interface
 
- itk::OtsuThresholdImageFilter for the Doxygen on the original ITK class.
+ itk::OtsuThresholdImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkOtsuThresholdImageFilter.h
@@ -25246,7 +25495,8 @@ parameters
 
 %feature("docstring")  itk::simple::OtsuThresholdImageFilter::SetInsideValue "
 
-Set the \"inside\" pixel value. The default value NumericTraits<OutputPixelType>::max()
+Set the \"inside\" pixel value. The default value
+NumericTraits<OutputPixelType>::max()
 
 ";
 
@@ -25273,7 +25523,8 @@ Set/Get the number of histogram bins. Defaults is 128.
 
 %feature("docstring")  itk::simple::OtsuThresholdImageFilter::SetOutsideValue "
 
-Set the \"outside\" pixel value. The default value NumericTraits<OutputPixelType>::Zero.
+Set the \"outside\" pixel value. The default value
+NumericTraits<OutputPixelType>::Zero.
 
 ";
 
@@ -25390,11 +25641,13 @@ Derived class implementing a specific patch-based denoising algorithm,
 as detailed below.
 
 
-This class is derived from the base class PatchBasedDenoisingBaseImageFilter ; please refer to the documentation of the base class first. This
-class implements a denoising filter that uses iterative non-local, or
-semi-local, weighted averaging of image patches for image denoising.
-The intensity at each pixel 'p' gets updated as a weighted average of
-intensities of a chosen subset of pixels from the image.
+This class is derived from the base class
+PatchBasedDenoisingBaseImageFilter ; please refer to the documentation
+of the base class first. This class implements a denoising filter that
+uses iterative non-local, or semi-local, weighted averaging of image
+patches for image denoising. The intensity at each pixel 'p' gets
+updated as a weighted average of intensities of a chosen subset of
+pixels from the image.
 
 This class implements the denoising algorithm using a Gaussian kernel
 function for nonparametric density estimation. The class implements a
@@ -25410,7 +25663,8 @@ Awate and Whitaker 2005 IEEE CVPR and 2006 IEEE TPAMI.
 See:
  PatchBasedDenoisingBaseImageFilter
 
- itk::PatchBasedDenoisingImageFilter for the Doxygen on the original ITK class.
+ itk::PatchBasedDenoisingImageFilter for the Doxygen on the original
+ITK class.
 
 
 C++ includes: sitkPatchBasedDenoisingImageFilter.h
@@ -25764,7 +26018,8 @@ recommented that the component type be a real valued type.
 See:
  itk::simple::PhysicalPointImageSource for the procedural interface
 
- itk::PhysicalPointImageSource for the Doxygen on the original ITK class.
+ itk::PhysicalPointImageSource for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkPhysicalPointImageSource.h
@@ -26228,7 +26483,8 @@ If there is no active process the method has no effect.
 Add a Command Object to observer the event.
 
 
-The Command object's Execute method will be invoked when the internal ITK Object has the event. These events only occur during this ProcessObject's Execute method when the ITK filter is running. The command occurs
+The Command object's Execute method will be invoked when the internal ITK Object
+has the event. These events only occur during this ProcessObject's Execute method when the ITK filter is running. The command occurs
 in the same thread as this objects Execute methods was called in.
 
 An internal reference is made between the Command and this ProcessObject which enable automatic removal of the command when deleted. This
@@ -26329,15 +26585,14 @@ de Jouy-en-Josas, France
 See:
  IterativeDeconvolutionImageFilter
 
-
  RichardsonLucyDeconvolutionImageFilter
-
 
  LandweberDeconvolutionImageFilter
 
  itk::simple::ProjectedLandweberDeconvolution for the procedural interface
 
- itk::ProjectedLandweberDeconvolutionImageFilter for the Doxygen on the original ITK class.
+ itk::ProjectedLandweberDeconvolutionImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkProjectedLandweberDeconvolutionImageFilter.h
@@ -26544,7 +26799,6 @@ and have the same size and origin.
 See:
  VectorImage
 
-
  VectorIndexSelectionCastImageFilter
 Wiki Examples:
 
@@ -26621,12 +26875,12 @@ in that dimension and the division by 2 is rounded down.
 See:
  HalfHermitianToRealInverseFFTImageFilter
 
-
  ForwardFFTImageFilter
 
  itk::simple::RealToHalfHermitianForwardFFT for the procedural interface
 
- itk::RealToHalfHermitianForwardFFTImageFilter for the Doxygen on the original ITK class.
+ itk::RealToHalfHermitianForwardFFTImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkRealToHalfHermitianForwardFFTImageFilter.h
@@ -26687,8 +26941,8 @@ Volume 25, Issue 15, November 2004, Pages 1759-1767.
 
 The algorithm, a description of the transform and some applications
 can be found in \"Morphological Grayscale Reconstruction in Image
-Analysis:    Applications and Efficient Algorithms\", Luc Vincent,
-IEEE Transactions on image processing, Vol. 2, April 1993.
+Analysis:  Applications and Efficient Algorithms\", Luc Vincent, IEEE
+Transactions on image processing, Vol. 2, April 1993.
 
 
 Richard Beare. Department of Medicine, Monash University, Melbourne,
@@ -26699,7 +26953,8 @@ See:
 
  itk::simple::ReconstructionByDilation for the procedural interface
 
- itk::ReconstructionByDilationImageFilter for the Doxygen on the original ITK class.
+ itk::ReconstructionByDilationImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkReconstructionByDilationImageFilter.h
@@ -26796,8 +27051,8 @@ Volume 25, Issue 15, November 2004, Pages 1759-1767.
 
 The algorithm, a description of the transform and some applications
 can be found in \"Morphological Grayscale Reconstruction in Image
-Analysis:    Applications and Efficient Algorithms\", Luc Vincent,
-IEEE Transactions on image processing, Vol. 2, April 1993.
+Analysis:  Applications and Efficient Algorithms\", Luc Vincent, IEEE
+Transactions on image processing, Vol. 2, April 1993.
 
 
 Richard Beare. Department of Medicine, Monash University, Melbourne,
@@ -26808,7 +27063,8 @@ See:
 
  itk::simple::ReconstructionByErosion for the procedural interface
 
- itk::ReconstructionByErosionImageFilter for the Doxygen on the original ITK class.
+ itk::ReconstructionByErosionImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkReconstructionByErosionImageFilter.h
@@ -26896,17 +27152,19 @@ with the Gaussian kernel. This class implements the recursive
 filtering method proposed by R.Deriche in IEEE-PAMI Vol.12, No.1,
 January 1990, pp 78-87, \"Fast Algorithms for Low-Level Vision\"
 
-Details of the implementation are described in the technical report: R.
-Deriche, \"Recursively Implementing The Gaussian and Its
+Details of the implementation are described in the technical report:
+R. Deriche, \"Recursively Implementing The Gaussian and Its
 Derivatives\", INRIA, 1993, ftp://ftp.inria.fr/INRIA/tech-reports/RR/RR-1893.ps.gz
 
 Further improvements of the algorithm are described in: G. Farneback &
 C.-F. Westin, \"On Implementation of Recursive Gaussian Filters\", so
 far unpublished.
 
-As compared to itk::DiscreteGaussianImageFilter , this filter tends to be faster for large kernels, and it can take
-the derivative of the blurred image in one step. Also, note that we
-have itk::RecursiveGaussianImageFilter::SetSigma() , but itk::DiscreteGaussianImageFilter::SetVariance() .
+As compared to itk::DiscreteGaussianImageFilter , this filter tends to
+be faster for large kernels, and it can take the derivative of the
+blurred image in one step. Also, note that we have
+itk::RecursiveGaussianImageFilter::SetSigma() , but
+itk::DiscreteGaussianImageFilter::SetVariance() .
 
 
 See:
@@ -26919,7 +27177,8 @@ Find higher derivatives of an image
 See:
  itk::simple::RecursiveGaussian for the procedural interface
 
- itk::RecursiveGaussianImageFilter for the Doxygen on the original ITK class.
+ itk::RecursiveGaussianImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -26953,6 +27212,8 @@ Name of this class
 %feature("docstring")  itk::simple::RecursiveGaussianImageFilter::GetOrder "
 
      Set/Get the Order of the Gaussian to convolve with.
+
+
 ZeroOrder is equivalent to convolving with a Gaussian. This is the
 default.
 
@@ -27029,6 +27290,8 @@ other methods such as a discrete Gaussian kernel should be considered.
 %feature("docstring")  itk::simple::RecursiveGaussianImageFilter::SetOrder "
 
      Set/Get the Order of the Gaussian to convolve with.
+
+
 ZeroOrder is equivalent to convolving with a Gaussian. This is the
 default.
 
@@ -27092,7 +27355,8 @@ Extract a portion of an image (region of interest)
 See:
  itk::simple::RegionOfInterest for the procedural interface
 
- itk::RegionOfInterestImageFilter for the Doxygen on the original ITK class.
+ itk::RegionOfInterestImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -27173,9 +27437,7 @@ Jouy-en-Josas, France. The paper can be found at https://hdl.handle.net/1926/153
 See:
  ValuedRegionalMaximaImageFilter
 
-
  HConvexImageFilter
-
 
  RegionalMinimaImageFilter
 Wiki Examples:
@@ -27186,7 +27448,8 @@ RegionalMaximaImageFilter
 See:
  itk::simple::RegionalMaxima for the procedural interface
 
- itk::RegionalMaximaImageFilter for the Doxygen on the original ITK class.
+ itk::RegionalMaximaImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -27329,7 +27592,6 @@ RegionalMaximaImageFilter MathematicalMorphologyImageFilters
 See:
  ValuedRegionalMinimaImageFilter
 
-
  HConcaveImageFilter
 Wiki Examples:
 
@@ -27339,7 +27601,8 @@ RegionalMinimaImageFilter
 See:
  itk::simple::RegionalMinima for the procedural interface
 
- itk::RegionalMinimaImageFilter for the Doxygen on the original ITK class.
+ itk::RegionalMinimaImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -27485,9 +27748,10 @@ relabeled output using a BinaryThresholdImageFilter . A group of objects can be 
 a ThresholdImageFilter .
 
 Once all the objects are relabeled, the application can query the
-number of objects and the size of each object. Object sizes are returned in a vector. The size of the background is not
-calculated. So the size of object #1 is GetSizeOfObjectsInPixels()
-[0], the size of object #2 is GetSizeOfObjectsInPixels() [1], etc.
+number of objects and the size of each object. Object sizes are
+returned in a vector. The size of the background is not calculated. So
+the size of object #1 is GetSizeOfObjectsInPixels() [0], the size of
+object #2 is GetSizeOfObjectsInPixels() [1], etc.
 
 If user sets a minimum object size, all objects with fewer pixels than
 the minimum will be discarded, so that the number of objects reported
@@ -27512,7 +27776,8 @@ Assign contiguous labels to connected regions of an image
 See:
  itk::simple::RelabelComponent for the procedural interface
 
- itk::RelabelComponentImageFilter for the Doxygen on the original ITK class.
+ itk::RelabelComponentImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -27664,7 +27929,8 @@ Threshold an image using the RenyiEntropy Threshold.
 
 This filter creates a binary thresholded image that separates an image
 into foreground and background components. The filter computes the
-threshold using the RenyiEntropyThresholdCalculator and applies that theshold to the input image using the BinaryThresholdImageFilter .
+threshold using the RenyiEntropyThresholdCalculator and applies that
+theshold to the input image using the BinaryThresholdImageFilter .
 
 
 Richard Beare. Department of Medicine, Monash University, Melbourne,
@@ -27680,7 +27946,8 @@ See:
 
  itk::simple::RenyiEntropyThreshold for the procedural interface
 
- itk::RenyiEntropyThresholdImageFilter for the Doxygen on the original ITK class.
+ itk::RenyiEntropyThresholdImageFilter for the Doxygen on the original
+ITK class.
 
 
 C++ includes: sitkRenyiEntropyThresholdImageFilter.h
@@ -27786,7 +28053,8 @@ Set/Get the number of histogram bins.
 
 %feature("docstring")  itk::simple::RenyiEntropyThresholdImageFilter::SetOutsideValue "
 
-Set the \"outside\" pixel value. The default value NumericTraits<OutputPixelType>::Zero.
+Set the \"outside\" pixel value. The default value
+NumericTraits<OutputPixelType>::Zero.
 
 ";
 
@@ -27813,12 +28081,14 @@ interpolating via some image function. The class is templated over the
 types of the input and output images.
 
 Note that the choice of interpolator function can be important. This
-function is set via SetInterpolator() . The default is LinearInterpolateImageFunction <InputImageType, TInterpolatorPrecisionType>, which is reasonable for
-ordinary medical images. However, some synthetic images have pixels
-drawn from a finite prescribed set. An example would be a mask
-indicating the segmentation of a brain into a small number of tissue
-types. For such an image, one does not want to interpolate between
-different pixel values, and so NearestNeighborInterpolateImageFunction < InputImageType, TCoordRep > would be a better choice.
+function is set via SetInterpolator() . The default is LinearInterpolateImageFunction <InputImageType,
+TInterpolatorPrecisionType>, which is reasonable for ordinary medical
+images. However, some synthetic images have pixels drawn from a finite
+prescribed set. An example would be a mask indicating the segmentation
+of a brain into a small number of tissue types. For such an image, one
+does not want to interpolate between different pixel values, and so
+NearestNeighborInterpolateImageFunction < InputImageType, TCoordRep >
+would be a better choice.
 
 If an sample is taken from outside the image domain, the default
 behavior is to use a default pixel value. If different behavior is
@@ -27880,8 +28150,13 @@ image. The default default pixel value is 0.
 
 %feature("docstring")  itk::simple::ResampleImageFilter::GetInterpolator "
 
-Get/Set the interpolator function. The default is LinearInterpolateImageFunction <InputImageType, TInterpolatorPrecisionType>. Some other options are NearestNeighborInterpolateImageFunction (useful for binary masks and other images with a small number of
-possible pixel values), and BSplineInterpolateImageFunction (which provides a higher order of interpolation).
+Get/Set the interpolator function. The default is
+LinearInterpolateImageFunction <InputImageType,
+TInterpolatorPrecisionType>. Some other options are
+NearestNeighborInterpolateImageFunction (useful for binary masks and
+other images with a small number of possible pixel values), and
+BSplineInterpolateImageFunction (which provides a higher order of
+interpolation).
 
 ";
 
@@ -27949,8 +28224,13 @@ image. The default default pixel value is 0.
 
 %feature("docstring")  itk::simple::ResampleImageFilter::SetInterpolator "
 
-Get/Set the interpolator function. The default is LinearInterpolateImageFunction <InputImageType, TInterpolatorPrecisionType>. Some other options are NearestNeighborInterpolateImageFunction (useful for binary masks and other images with a small number of
-possible pixel values), and BSplineInterpolateImageFunction (which provides a higher order of interpolation).
+Get/Set the interpolator function. The default is
+LinearInterpolateImageFunction <InputImageType,
+TInterpolatorPrecisionType>. Some other options are
+NearestNeighborInterpolateImageFunction (useful for binary masks and
+other images with a small number of possible pixel values), and
+BSplineInterpolateImageFunction (which provides a higher order of
+interpolation).
 
 ";
 
@@ -28036,8 +28316,9 @@ The following equation gives the mapping of the intensity values
 RealType. Before assigning the computed value to the output pixel.
 
 NOTE: In this filter the minimum and maximum values of the input image
-are computed internally using the MinimumMaximumImageCalculator . Users are not supposed to set those values in this filter. If you
-need a filter where you can set the minimum and maximum values of the
+are computed internally using the MinimumMaximumImageCalculator .
+Users are not supposed to set those values in this filter. If you need
+a filter where you can set the minimum and maximum values of the
 input, please use the IntensityWindowingImageFilter . If you want a filter that can use a user-defined linear
 transformation for the intensity, then please use the ShiftScaleImageFilter .
 
@@ -28052,7 +28333,8 @@ Rescale the intensity values of an image to a specified range
 See:
  itk::simple::RescaleIntensity for the procedural interface
 
- itk::RescaleIntensityImageFilter for the Doxygen on the original ITK class.
+ itk::RescaleIntensityImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -28138,15 +28420,14 @@ de Jouy-en-Josas, France
 See:
  IterativeDeconvolutionImageFilter
 
-
  LandweberDeconvolutionImageFilter
-
 
  ProjectedLandweberDeconvolutionImageFilter
 
  itk::simple::RichardsonLucyDeconvolution for the procedural interface
 
- itk::RichardsonLucyDeconvolutionImageFilter for the Doxygen on the original ITK class.
+ itk::RichardsonLucyDeconvolutionImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkRichardsonLucyDeconvolutionImageFilter.h
@@ -28500,7 +28781,8 @@ Simulation\". https://hdl.handle.net/10380/3158
 See:
  itk::simple::SaltAndPepperNoise for the procedural interface
 
- itk::SaltAndPepperNoiseImageFilter for the Doxygen on the original ITK class.
+ itk::SaltAndPepperNoiseImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkSaltAndPepperNoiseImageFilter.h
@@ -28562,16 +28844,16 @@ Dense implementation of the Chan and Vese multiphase level set image
 filter.
 
 
-This code was adapted from the paper:\"An active contour model without
-edges\" T. Chan and L. Vese. In Scale-Space Theories in Computer
-Vision, pages 141-151, 1999.
+This code was adapted from the paper: \"An active contour model
+without edges\" T. Chan and L. Vese. In Scale-Space Theories in
+Computer Vision, pages 141-151, 1999.
 
 
 Mosaliganti K., Smith B., Gelas A., Gouaillard A., Megason S.
- This code was taken from the Insight Journal paper:\"Cell Tracking
+ This code was taken from the Insight Journal paper: \"Cell Tracking
 using Coupled Active Surfaces for Nuclei and Membranes\" http://www.insight-journal.org/browse/publication/642 https://hdl.handle.net/10380/3055
 
-That is based on the papers:\"Level Set Segmentation: Active Contours
+That is based on the papers: \"Level Set Segmentation: Active Contours
 without edge\" http://www.insight-journal.org/browse/publication/322 https://hdl.handle.net/1926/1532
 
 and
@@ -28586,7 +28868,8 @@ Single-phase Chan And Vese Dense Field Level Set Segmentation
 See:
  itk::simple::ScalarChanAndVeseDenseLevelSet for the procedural interface
 
- itk::ScalarChanAndVeseDenseLevelSetImageFilter for the Doxygen on the original ITK class.
+ itk::ScalarChanAndVeseDenseLevelSetImageFilter for the Doxygen on the
+original ITK class.
 
 
 
@@ -28755,7 +29038,8 @@ Label connected components in a grayscale image
 See:
  itk::simple::ScalarConnectedComponent for the procedural interface
 
- itk::ScalarConnectedComponentImageFilter for the Doxygen on the original ITK class.
+ itk::ScalarConnectedComponentImageFilter for the Doxygen on the
+original ITK class.
 
 
 
@@ -28842,14 +29126,11 @@ ordering the labels by their relative size in number of pixels.
 See:
  Image
 
-
  ImageKmeansModelEstimator
 
+ KdTreeBasedKmeansEstimator, WeightedCentroidKdTreeGenerator, KdTree
 
-KdTreeBasedKmeansEstimator, WeightedCentroidKdTreeGenerator, KdTree
-
-
-RelabelImageFilter
+ RelabelImageFilter
 Wiki Examples:
 
 All Examples
@@ -28858,7 +29139,8 @@ Cluster the pixels in a greyscale image
 See:
  itk::simple::ScalarImageKmeans for the procedural interface
 
- itk::ScalarImageKmeansImageFilter for the Doxygen on the original ITK class.
+ itk::ScalarImageKmeansImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -28882,7 +29164,7 @@ Execute the filter on the input image with the given parameters
 
 %feature("docstring")  itk::simple::ScalarImageKmeansImageFilter::GetFinalMeans "
 
-Return the array of Means found after the classification
+Return the array of Means found after the classification.
 
 This is a measurement. Its value is updated in the Execute methods, so
 the value will only be valid after an execution.
@@ -28975,7 +29257,7 @@ Tustison N., Zhang H., Lehmann G., Yushkevich P., Gee J. https://hdl.handle.net/
 
 
 See:
-BinaryFunctionImageFilter TernaryFunctionImageFilter
+ BinaryFunctionImageFilter TernaryFunctionImageFilter
 Wiki Examples:
 
 All Examples
@@ -28984,7 +29266,8 @@ Apply a color map to an image
 See:
  itk::simple::ScalarToRGBColormap for the procedural interface
 
- itk::ScalarToRGBColormapImageFilter for the Doxygen on the original ITK class.
+ itk::ScalarToRGBColormapImageFilter for the Doxygen on the original
+ITK class.
 
 
 
@@ -29286,7 +29569,8 @@ Threshold an image using the Shanbhag Threshold.
 
 This filter creates a binary thresholded image that separates an image
 into foreground and background components. The filter computes the
-threshold using the ShanbhagThresholdCalculator and applies that theshold to the input image using the BinaryThresholdImageFilter .
+threshold using the ShanbhagThresholdCalculator and applies that
+theshold to the input image using the BinaryThresholdImageFilter .
 
 
 Richard Beare. Department of Medicine, Monash University, Melbourne,
@@ -29302,7 +29586,8 @@ See:
 
  itk::simple::ShanbhagThreshold for the procedural interface
 
- itk::ShanbhagThresholdImageFilter for the Doxygen on the original ITK class.
+ itk::ShanbhagThresholdImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkShanbhagThresholdImageFilter.h
@@ -29401,7 +29686,8 @@ Set/Get the number of histogram bins.
 
 %feature("docstring")  itk::simple::ShanbhagThresholdImageFilter::SetOutsideValue "
 
-Set the \"outside\" pixel value. The default value NumericTraits<OutputPixelType>::Zero.
+Set the \"outside\" pixel value. The default value
+NumericTraits<OutputPixelType>::Zero.
 
 ";
 
@@ -29432,8 +29718,9 @@ map.
 
 
 IMPORTANT
-The SegmentationLevelSetImageFilter class and the ShapeDetectionLevelSetFunction class contain additional information necessary to gain full
-understanding of how to use this filter.
+The SegmentationLevelSetImageFilter class and the
+ShapeDetectionLevelSetFunction class contain additional information
+necessary to gain full understanding of how to use this filter.
 OVERVIEW
 This class is a level set method segmentation filter. An initial
 contour is propagated outwards (or inwards) until it ''sticks'' to the
@@ -29458,7 +29745,8 @@ potential map is compute from the image gradient, for example:
 where $ I $ is image intensity and $ (\\\\nabla * G) $ is the derivative of Gaussian operator.
 
 
-See SegmentationLevelSetImageFilter and SparseFieldLevelSetImageFilter for more information on Inputs.
+See SegmentationLevelSetImageFilter and SparseFieldLevelSetImageFilter
+for more information on Inputs.
 PARAMETERS
 The PropagationScaling parameter can be used to switch from
 propagation outwards (POSITIVE scaling parameter) versus propagating
@@ -29480,7 +29768,8 @@ region and positive values in the image represent the outside of the
 segmented region. The zero crossings of the image correspond to the
 position of the propagating front.
 
-See SparseFieldLevelSetImageFilter and SegmentationLevelSetImageFilter for more information.
+See SparseFieldLevelSetImageFilter and SegmentationLevelSetImageFilter
+for more information.
 REFERENCES
 
 \"Shape Modeling with Front Propagation: A Level Set Approach\", R.
@@ -29491,15 +29780,14 @@ Analysis and Machine Intelligence, Vol 17, No. 2, pp 158-174, February
 See:
  SegmentationLevelSetImageFilter
 
-
  ShapeDetectionLevelSetFunction
-
 
  SparseFieldLevelSetImageFilter
 
  itk::simple::ShapeDetectionLevelSet for the procedural interface
 
- itk::ShapeDetectionLevelSetImageFilter for the Doxygen on the original ITK class.
+ itk::ShapeDetectionLevelSetImageFilter for the Doxygen on the original
+ITK class.
 
 
 C++ includes: sitkShapeDetectionLevelSetImageFilter.h
@@ -29693,8 +29981,39 @@ Destructor
 Alter an image with shot noise.
 
 
-The shot noise follows a Poisson distribution.
+The shot noise follows a Poisson distribution:
 
+
+$ I = N(I_0) $
+
+where $ N(I_0) $ is a Poisson-distributed random variable of mean $ I_0 $ . The noise is thus dependent on the pixel intensities in the image.
+ The intensities in the image can be scaled by a user provided value
+to map pixel values to the actual number of particles. The scaling can
+be seen as the inverse of the gain used during the acquisition. The
+noisy signal is then scaled back to its input intensity range:
+
+
+$ I = \\\\frac{N(I_0 \\\\times s)}{s} $
+
+where $ s $ is the scale factor.
+ The Poisson-distributed variable $ \\\\lambda $ is computed by using the algorithm:
+
+
+$ \\\\begin{array}{l} k \\\\leftarrow 0 \\\\\\\\ p \\\\leftarrow 1
+\\\\\\\\ \\\\textbf{repeat} \\\\\\\\ \\\\left\\\\{ \\\\begin{array}{l}
+k \\\\leftarrow k+1 \\\\\\\\ p \\\\leftarrow p \\\\ast U()
+\\\\end{array} \\\\right. \\\\\\\\ \\\\textbf{until } p >
+e^{\\\\lambda} \\\\\\\\ \\\\textbf{return} (k) \\\\end{array} $
+
+where $ U() $ provides a uniformly distributed random variable in the interval $ [0,1] $ .
+ This algorithm is very inefficient for large values of $ \\\\lambda $ , though. Fortunately, the Poisson distribution can be accurately
+approximated by a Gaussian distribution of mean and variance $ \\\\lambda $ when $ \\\\lambda $ is large enough. In this implementation, this value is considered to
+be 50. This leads to the faster algorithm:
+
+
+$ \\\\lambda + \\\\sqrt{\\\\lambda} \\\\times N()$
+
+where $ N() $ is a normally distributed random variable of mean 0 and variance 1.
 
 Gaetan Lehmann
  This code was contributed in the Insight Journal paper \"Noise
@@ -29728,10 +30047,10 @@ Name of this class
 
 %feature("docstring")  itk::simple::ShotNoiseImageFilter::GetScale "
 
-a value to map the pixel value to the actual number of photon. This
-value defaults to 1.0. The scaling can be seen as the inverse of the
-gain used during the acquisition. The noisy signal is then scaled back
-to its input intensity range.
+Set/Get the value to map the pixel value to the actual particle
+counting. The scaling can be seen as the inverse of the gain used
+during the acquisition. The noisy signal is then scaled back to its
+input intensity range. Defaults to 1.0.
 
 ";
 
@@ -29739,6 +30058,12 @@ to its input intensity range.
 ";
 
 %feature("docstring")  itk::simple::ShotNoiseImageFilter::SetScale "
+
+Set/Get the value to map the pixel value to the actual particle
+counting. The scaling can be seen as the inverse of the gain used
+during the acquisition. The noisy signal is then scaled back to its
+input intensity range. Defaults to 1.0.
+
 ";
 
 %feature("docstring")  itk::simple::ShotNoiseImageFilter::SetSeed "
@@ -29970,6 +30295,8 @@ As a convention, the distance is evaluated from the boundary of the ON
 pixels.
 
 The filter returns
+
+
 A signed distance map with the approximation to the euclidean
 distance.
 
@@ -29978,18 +30305,20 @@ A voronoi partition. (See itkDanielssonDistanceMapImageFilter)
 A vector map containing the component of the vector relating the
 current pixel with the closest point of the closest object to this
 pixel. Given that the components of the distance are computed in
-\"pixels\", the vector is represented by an itk::Offset . That is, physical coordinates are not used. (See
+\"pixels\", the vector is represented by an itk::Offset . That is,
+physical coordinates are not used. (See
 itkDanielssonDistanceMapImageFilter)
  This filter internally uses the DanielssonDistanceMap filter. This
 filter is N-dimensional.
 
 
 See:
-itkDanielssonDistanceMapImageFilter
+ itkDanielssonDistanceMapImageFilter
 
  itk::simple::SignedDanielssonDistanceMap for the procedural interface
 
- itk::SignedDanielssonDistanceMapImageFilter for the Doxygen on the original ITK class.
+ itk::SignedDanielssonDistanceMapImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkSignedDanielssonDistanceMapImageFilter.h
@@ -30131,7 +30460,8 @@ Analysis and Machine Intelligence, 25(2): 265-270, 2003.
 See:
  itk::simple::SignedMaurerDistanceMap for the procedural interface
 
- itk::SignedMaurerDistanceMapImageFilter for the Doxygen on the original ITK class.
+ itk::SignedMaurerDistanceMapImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkSignedMaurerDistanceMapImageFilter.h
@@ -30425,7 +30755,8 @@ image have the same number of dimensions.
 
 
 See:
- itk::SimilarityIndexImageFilter for the Doxygen on the original ITK class.
+ itk::SimilarityIndexImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkSimilarityIndexImageFilter.h
@@ -30491,18 +30822,16 @@ The neighborhood \"radius\" is set thanks to the radius params.
 See:
  Image
 
-
  Neighborhood
 
-
  NeighborhoodOperator
-
 
  NeighborhoodIterator
 
  itk::simple::SimpleContourExtractor for the procedural interface
 
- itk::SimpleContourExtractorImageFilter for the Doxygen on the original ITK class.
+ itk::SimpleContourExtractorImageFilter for the Doxygen on the original
+ITK class.
 
 
 C++ includes: sitkSimpleContourExtractorImageFilter.h
@@ -30763,7 +31092,8 @@ Gaussian smoothing that works with image adaptors
 See:
  itk::simple::SmoothingRecursiveGaussian for the procedural interface
 
- itk::SmoothingRecursiveGaussianImageFilter for the Doxygen on the original ITK class.
+ itk::SmoothingRecursiveGaussianImageFilter for the Doxygen on the
+original ITK class.
 
 
 
@@ -30861,15 +31191,11 @@ edge strength.
 See:
  ImageToImageFilter
 
-
  SobelOperator
-
 
  Neighborhood
 
-
  NeighborhoodOperator
-
 
  NeighborhoodIterator
 Wiki Examples:
@@ -30880,7 +31206,8 @@ SobelEdgeDetectionImageFilter
 See:
  itk::simple::SobelEdgeDetection for the procedural interface
 
- itk::SobelEdgeDetectionImageFilter for the Doxygen on the original ITK class.
+ itk::SobelEdgeDetectionImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -30935,7 +31262,8 @@ Simulation\". https://hdl.handle.net/10380/3158
 See:
  itk::simple::SpeckleNoise for the procedural interface
 
- itk::SpeckleNoiseImageFilter for the Doxygen on the original ITK class.
+ itk::SpeckleNoiseImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkSpeckleNoiseImageFilter.h
@@ -31112,7 +31440,8 @@ compute the difference of the two pixel values
 
 compute the square of the difference
 
-cast the double value resulting from sqr() to the pixel type of the output image
+cast the double value resulting from sqr() to the pixel type of the
+output image
 
 store the casted value into the output image.
  The filter expect all images to have the same dimension (e.g. all 2D,
@@ -31126,7 +31455,8 @@ Compute the squared difference of corresponding pixels in two images
 See:
  itk::simple::SquaredDifference for the procedural interface
 
- itk::SquaredDifferenceImageFilter for the Doxygen on the original ITK class.
+ itk::SquaredDifferenceImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -31189,30 +31519,24 @@ de Jouy-en-Josas, France.
 See:
  ProjectionImageFilter
 
-
  MedianProjectionImageFilter
 
-
  MeanProjectionImageFilter
-
 
  SumProjectionImageFilter
 
-
  MeanProjectionImageFilter
-
 
  MaximumProjectionImageFilter
 
-
  MinimumProjectionImageFilter
-
 
  BinaryProjectionImageFilter
 
  itk::simple::StandardDeviationProjection for the procedural interface
 
- itk::StandardDeviationProjectionImageFilter for the Doxygen on the original ITK class.
+ itk::StandardDeviationProjectionImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkStandardDeviationProjectionImageFilter.h
@@ -31471,30 +31795,24 @@ de Jouy-en-Josas, France.
 See:
  ProjectionImageFilter
 
-
  MedianProjectionImageFilter
 
-
  MeanProjectionImageFilter
 
-
  MeanProjectionImageFilter
-
 
  MaximumProjectionImageFilter
 
-
  MinimumProjectionImageFilter
 
-
  BinaryProjectionImageFilter
-
 
  StandardDeviationProjectionImageFilter
 
  itk::simple::SumProjection for the procedural interface
 
- itk::SumProjectionImageFilter for the Doxygen on the original ITK class.
+ itk::SumProjectionImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkSumProjectionImageFilter.h
@@ -31589,13 +31907,12 @@ deformation field type all have the same number of dimensions.
 See:
  SymmetricForcesDemonsRegistrationFunction
 
-
  DemonsRegistrationFilter
-
 
  DemonsRegistrationFunction
 
- itk::SymmetricForcesDemonsRegistrationFilter for the Doxygen on the original ITK class.
+ itk::SymmetricForcesDemonsRegistrationFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkSymmetricForcesDemonsRegistrationFilter.h
@@ -31938,7 +32255,7 @@ Destructor
 
 %feature("docstring") itk::simple::TernaryMagnitudeImageFilter "
 
-Pixel-wise addition of three images.
+Compute the pixel-wise magnitude of three images.
 
 
 This class is templated over the types of the three input images and
@@ -31947,7 +32264,8 @@ by the C++ defaults.
 See:
  itk::simple::TernaryMagnitude for the procedural interface
 
- itk::TernaryMagnitudeImageFilter for the Doxygen on the original ITK class.
+ itk::TernaryMagnitudeImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkTernaryMagnitudeImageFilter.h
@@ -31987,7 +32305,7 @@ Destructor
 
 %feature("docstring") itk::simple::TernaryMagnitudeSquaredImageFilter "
 
-Pixel-wise addition of three images.
+Compute the pixel-wise squared magnitude of three images.
 
 
 This class is templated over the types of the three input images and
@@ -31996,7 +32314,8 @@ by the C++ defaults.
 See:
  itk::simple::TernaryMagnitudeSquared for the procedural interface
 
- itk::TernaryMagnitudeSquaredImageFilter for the Doxygen on the original ITK class.
+ itk::TernaryMagnitudeSquaredImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkTernaryMagnitudeSquaredImageFilter.h
@@ -32089,7 +32408,7 @@ Execute the filter on the input image with the given parameters
 
 %feature("docstring")  itk::simple::ThresholdImageFilter::GetLower "
 
-Set/Get methods to set the lower threshold
+Set/Get methods to set the lower threshold.
 
 ";
 
@@ -32107,13 +32426,13 @@ Get the \"outside\" pixel value.
 
 %feature("docstring")  itk::simple::ThresholdImageFilter::GetUpper "
 
-Set/Get methods to set the upper threshold
+Set/Get methods to set the upper threshold.
 
 ";
 
 %feature("docstring")  itk::simple::ThresholdImageFilter::SetLower "
 
-Set/Get methods to set the lower threshold
+Set/Get methods to set the lower threshold.
 
 ";
 
@@ -32126,7 +32445,7 @@ pixel value. The default value NumericTraits<PixelType>::ZeroValue() .
 
 %feature("docstring")  itk::simple::ThresholdImageFilter::SetUpper "
 
-Set/Get methods to set the upper threshold
+Set/Get methods to set the upper threshold.
 
 ";
 
@@ -32167,10 +32486,11 @@ workshop for a complete description. References are below.
 Parameters
 The MinimumObjectSizeInPixels parameter is controlled through the
 class Get/SetMinimumObjectSizeInPixels() method. Similar to the
-standard itk::BinaryThresholdImageFilter the Get/SetInside and Get/SetOutside values of the threshold can be
-set. The GetNumberOfObjects() and GetThresholdValue() methods return
-the number of objects above the minimum pixel size and the calculated
-threshold value.
+standard itk::BinaryThresholdImageFilter the Get/SetInside and
+Get/SetOutside values of the threshold can be set. The
+GetNumberOfObjects() and GetThresholdValue() methods return the number
+of objects above the minimum pixel size and the calculated threshold
+value.
 Automatic Thresholding in ITK
 There are multiple methods to automatically calculate the threshold
 intensity value of an image. As of version 4.0, ITK has a Thresholding
@@ -32190,7 +32510,8 @@ list serve for archival purposes.
 See:
  itk::simple::ThresholdMaximumConnectedComponents for the procedural interface
 
- itk::ThresholdMaximumConnectedComponentsImageFilter for the Doxygen on the original ITK class.
+ itk::ThresholdMaximumConnectedComponentsImageFilter for the Doxygen on
+the original ITK class.
 
 
 C++ includes: sitkThresholdMaximumConnectedComponentsImageFilter.h
@@ -32340,8 +32661,10 @@ Segments structures in images based on intensity values.
 
 
 IMPORTANT
-The SegmentationLevelSetImageFilter class and the ThresholdSegmentationLevelSetFunction class contain additional information necessary to the full
-understanding of how to use this filter.
+The SegmentationLevelSetImageFilter class and the
+ThresholdSegmentationLevelSetFunction class contain additional
+information necessary to the full understanding of how to use this
+filter.
 OVERVIEW
 This class is a level set method segmentation filter. It constructs a
 speed function which is close to zero at the upper and lower bounds of
@@ -32372,22 +32695,25 @@ negative values in the image are outside of the inside region. The
 zero crossings of the image correspond to the position of the level
 set front.
 
-See SparseFieldLevelSetImageFilter and SegmentationLevelSetImageFilter for more information.
+See SparseFieldLevelSetImageFilter and SegmentationLevelSetImageFilter
+for more information.
 PARAMETERS
-In addition to parameters described in SegmentationLevelSetImageFilter , this filter adds the UpperThreshold and LowerThreshold. See ThresholdSegmentationLevelSetFunction for a description of how these values affect the segmentation.
+In addition to parameters described in SegmentationLevelSetImageFilter
+, this filter adds the UpperThreshold and LowerThreshold. See
+ThresholdSegmentationLevelSetFunction for a description of how these
+values affect the segmentation.
 
 See:
  SegmentationLevelSetImageFilter
 
-
  ThresholdSegmentationLevelSetFunction ,
-
 
  SparseFieldLevelSetImageFilter
 
  itk::simple::ThresholdSegmentationLevelSet for the procedural interface
 
- itk::ThresholdSegmentationLevelSetImageFilter for the Doxygen on the original ITK class.
+ itk::ThresholdSegmentationLevelSetImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkThresholdSegmentationLevelSetImageFilter.h
@@ -32526,7 +32852,8 @@ de Jouy-en-Josas, France
 See:
  itk::simple::TikhonovDeconvolution for the procedural interface
 
- itk::TikhonovDeconvolutionImageFilter for the Doxygen on the original ITK class.
+ itk::TikhonovDeconvolutionImageFilter for the Doxygen on the original
+ITK class.
 
 
 C++ includes: sitkTikhonovDeconvolutionImageFilter.h
@@ -32792,7 +33119,8 @@ Performs actually coping if needed to make object unique.
 
 
 The Transform class by default performs lazy coping and assignment. This method
-make sure that coping actually happens to the itk::Transform pointed to is only pointed to by this object.
+make sure that coping actually happens to the itk::Transform pointed
+to is only pointed to by this object.
 
 ";
 
@@ -32898,7 +33226,8 @@ Marius Staring, Leiden University Medical Center, The Netherlands.
 See:
  itk::simple::TransformToDisplacementFieldFilter for the procedural interface
 
- itk::TransformToDisplacementFieldFilter for the Doxygen on the original ITK class.
+ itk::TransformToDisplacementFieldFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkTransformToDisplacementFieldFilter.h
@@ -33046,7 +33375,8 @@ Threshold an image using the Triangle Threshold.
 
 This filter creates a binary thresholded image that separates an image
 into foreground and background components. The filter computes the
-threshold using the TriangleThresholdCalculator and applies that theshold to the input image using the BinaryThresholdImageFilter .
+threshold using the TriangleThresholdCalculator and applies that
+theshold to the input image using the BinaryThresholdImageFilter .
 
 
 Richard Beare. Department of Medicine, Monash University, Melbourne,
@@ -33062,7 +33392,8 @@ See:
 
  itk::simple::TriangleThreshold for the procedural interface
 
- itk::TriangleThresholdImageFilter for the Doxygen on the original ITK class.
+ itk::TriangleThresholdImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkTriangleThresholdImageFilter.h
@@ -33161,7 +33492,8 @@ Set/Get the number of histogram bins.
 
 %feature("docstring")  itk::simple::TriangleThresholdImageFilter::SetOutsideValue "
 
-Set the \"outside\" pixel value. The default value NumericTraits<OutputPixelType>::Zero.
+Set the \"outside\" pixel value. The default value
+NumericTraits<OutputPixelType>::Zero.
 
 ";
 
@@ -33194,7 +33526,8 @@ Computes the negative of each pixel.
 See:
  itk::simple::UnaryMinus for the procedural interface
 
- itk::UnaryFunctorImageFilter for the Doxygen on the original ITK class.
+ itk::UnaryFunctorImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkUnaryMinusImageFilter.h
@@ -33253,9 +33586,7 @@ Australia.
 See:
  ValuedRegionalMinimaImageFilter
 
-
  ValuedRegionalExtremaImageFilter
-
 
  HMinimaImageFilter
 Wiki Examples:
@@ -33266,7 +33597,8 @@ ValuedRegionalMaximaImageFilter
 See:
  itk::simple::ValuedRegionalMaxima for the procedural interface
 
- itk::ValuedRegionalMaximaImageFilter for the Doxygen on the original ITK class.
+ itk::ValuedRegionalMaximaImageFilter for the Doxygen on the original
+ITK class.
 
 
 
@@ -33354,7 +33686,6 @@ Australia.
 See:
  ValuedRegionalMaximaImageFilter , ValuedRegionalExtremaImageFilter ,
 
-
  HMinimaImageFilter
 Wiki Examples:
 
@@ -33364,7 +33695,8 @@ ValuedRegionalMinimaImageFilter
 See:
  itk::simple::ValuedRegionalMinima for the procedural interface
 
- itk::ValuedRegionalMinimaImageFilter for the Doxygen on the original ITK class.
+ itk::ValuedRegionalMinimaImageFilter for the Doxygen on the original
+ITK class.
 
 
 
@@ -33464,7 +33796,8 @@ may be adjusted to contain the seed point's intensity.
 See:
  itk::simple::VectorConfidenceConnected for the procedural interface
 
- itk::VectorConfidenceConnectedImageFilter for the Doxygen on the original ITK class.
+ itk::VectorConfidenceConnectedImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkVectorConfidenceConnectedImageFilter.h
@@ -33620,7 +33953,8 @@ of phase are similar. Assumes that vectors are normalized.
 See:
  itk::simple::VectorConnectedComponent for the procedural interface
 
- itk::VectorConnectedComponentImageFilter for the Doxygen on the original ITK class.
+ itk::VectorConnectedComponentImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkVectorConnectedComponentImageFilter.h
@@ -33710,7 +34044,8 @@ Extract a component/channel of a vector image
 See:
  itk::simple::VectorIndexSelectionCast for the procedural interface
 
- itk::VectorIndexSelectionCastImageFilter for the Doxygen on the original ITK class.
+ itk::VectorIndexSelectionCastImageFilter for the Doxygen on the
+original ITK class.
 
 
 
@@ -33797,7 +34132,8 @@ magnitude image
 See:
  itk::simple::VectorMagnitude for the procedural interface
 
- itk::VectorMagnitudeImageFilter for the Doxygen on the original ITK class.
+ itk::VectorMagnitudeImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -33986,24 +34322,20 @@ pixel.
 See:
  Image
 
-
  VotingBinaryImageFilter
-
 
  VotingBinaryIterativeHoleFillingImageFilter
 
-
  Neighborhood
 
-
  NeighborhoodOperator
-
 
  NeighborhoodIterator
 
  itk::simple::VotingBinaryHoleFilling for the procedural interface
 
- itk::VotingBinaryHoleFillingImageFilter for the Doxygen on the original ITK class.
+ itk::VotingBinaryHoleFillingImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkVotingBinaryHoleFillingImageFilter.h
@@ -34104,18 +34436,16 @@ Pixels which are not Foreground or Background will remain unchanged.
 See:
  Image
 
-
  Neighborhood
 
-
  NeighborhoodOperator
-
 
  NeighborhoodIterator
 
  itk::simple::VotingBinary for the procedural interface
 
- itk::VotingBinaryImageFilter for the Doxygen on the original ITK class.
+ itk::VotingBinaryImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkVotingBinaryImageFilter.h
@@ -34260,24 +34590,20 @@ one iteration is taken as the input image for the next iteration.
 See:
  Image
 
-
  VotingBinaryImageFilter
-
 
  VotingBinaryHoleFillingImageFilter
 
-
  Neighborhood
 
-
  NeighborhoodOperator
-
 
  NeighborhoodIterator
 
  itk::simple::VotingBinaryIterativeHoleFilling for the procedural interface
 
- itk::VotingBinaryIterativeHoleFillingImageFilter for the Doxygen on the original ITK class.
+ itk::VotingBinaryIterativeHoleFillingImageFilter for the Doxygen on
+the original ITK class.
 
 
 C++ includes: sitkVotingBinaryIterativeHoleFillingImageFilter.h
@@ -34430,7 +34756,9 @@ such that:
 Typically the mapped position does not correspond to an integer pixel
 position in the input image. Interpolation via an image function is
 used to compute values at non-integer positions. The default
-interpolation typed used is the LinearInterpolateImageFunction . The user can specify a particular interpolation function via SetInterpolator() . Note that the input interpolator must derive from base class InterpolateImageFunction .
+interpolation typed used is the LinearInterpolateImageFunction . The
+user can specify a particular interpolation function via SetInterpolator() . Note that the input interpolator must derive from base class
+InterpolateImageFunction .
 
 Position mapped to outside of the input image buffer are assigned a
 edge padding value.
@@ -34740,7 +35068,8 @@ Cory Quammen, The University of North Carolina at Chapel Hill
 See:
  itk::simple::WienerDeconvolution for the procedural interface
 
- itk::WienerDeconvolutionImageFilter for the Doxygen on the original ITK class.
+ itk::WienerDeconvolutionImageFilter for the Doxygen on the original
+ITK class.
 
 
 C++ includes: sitkWienerDeconvolutionImageFilter.h
@@ -34836,13 +35165,13 @@ value.
 
 WrapPadImageFilter changes the image bounds of an image. Added pixels are filled in with
 a wrapped replica of the input image. For instance, if the output
-image needs a pixel that istwo pixels to the left of the
-LargestPossibleRegionof the input image, the value assigned will be
-from the pixeltwo pixels inside the right boundary of the
+image needs a pixel that is two pixels to the left of the
+LargestPossibleRegion of the input image, the value assigned will be
+from the pixel two pixels inside the right boundary of the
 LargestPossibleRegion. The image bounds of the output must be
 specified.
 
-Visual explanation of padding regions.This filter is implemented as a
+Visual explanation of padding regions. This filter is implemented as a
 multithreaded filter. It provides a ThreadedGenerateData() method for
 its implementation.
 
@@ -34995,7 +35324,8 @@ Threshold an image using the Yen Threshold.
 
 This filter creates a binary thresholded image that separates an image
 into foreground and background components. The filter computes the
-threshold using the YenThresholdCalculator and applies that theshold to the input image using the BinaryThresholdImageFilter .
+threshold using the YenThresholdCalculator and applies that theshold
+to the input image using the BinaryThresholdImageFilter .
 
 
 Richard Beare
@@ -35010,7 +35340,8 @@ See:
 
  itk::simple::YenThreshold for the procedural interface
 
- itk::YenThresholdImageFilter for the Doxygen on the original ITK class.
+ itk::YenThresholdImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkYenThresholdImageFilter.h
@@ -35109,7 +35440,8 @@ Set/Get the number of histogram bins.
 
 %feature("docstring")  itk::simple::YenThresholdImageFilter::SetOutsideValue "
 
-Set the \"outside\" pixel value. The default value NumericTraits<OutputPixelType>::Zero.
+Set the \"outside\" pixel value. The default value
+NumericTraits<OutputPixelType>::Zero.
 
 ";
 
@@ -35140,8 +35472,8 @@ This filter implements a zero-crossing based edge detecor.
 
 The zero-crossing based edge detector looks for pixels in the
 Laplacian of an image where the value of the Laplacian passes through
-zeropoints where the Laplacian changes sign. Such points often occur
-at ``edges'' in imagesi.e. points where the intensity of the image
+zero points where the Laplacian changes sign. Such points often occur
+at \"edges\" in images i.e. points where the intensity of the image
 changes rapidly, but they also occur at places that are not as easy to
 associate with edges. It is best to think of the zero crossing
 detector as some sort of feature detector rather than as a specific
@@ -35165,20 +35497,20 @@ To use this filter, first set the parameters (variance and maximum
 error) needed by the embedded DiscreteGaussianImageFilter , i.e. See DiscreteGaussianImageFilter for information about these parameters. Optionally, you may also set
 foreground and background values for the zero-crossing filter. The
 default label values are Zero for the background and One for the
-foreground, as defined in NumericTraits for the data type of the output image.
+foreground, as defined in NumericTraits for the data type of the
+output image.
 
 See:
  DiscreteGaussianImageFilter
 
-
  LaplacianImageFilter
-
 
  ZeroCrossingImageFilter
 
  itk::simple::ZeroCrossingBasedEdgeDetection for the procedural interface
 
- itk::ZeroCrossingBasedEdgeDetectionImageFilter for the Doxygen on the original ITK class.
+ itk::ZeroCrossingBasedEdgeDetectionImageFilter for the Doxygen on the
+original ITK class.
 
 
 C++ includes: sitkZeroCrossingBasedEdgeDetectionImageFilter.h
@@ -35292,8 +35624,11 @@ The input to this filter is an itk::Image of arbitrary dimension. The algorithm 
 that operator>, operator<, operator==, and operator!= are defined.
 
 The output of the filter is a binary, labeled image of user-specified
-type. By default, zero-crossing pixels are labeled with a default foreground'' value of itk::NumericTraits<OutputDataType>::OneValue() , where OutputDataType is the data type
-of the output image. All other pixels are labeled with a defaultbackground'' value of itk::NumericTraits<OutputDataType>::ZeroValue() .
+type. By default, zero-crossing pixels are labeled with a default
+\"foreground\" value of itk::NumericTraits<OutputDataType>::OneValue()
+, where OutputDataType is the data type of the output image. All other
+pixels are labeled with a default \"background\" value of
+itk::NumericTraits<OutputDataType>::ZeroValue() .
 Parameters
 There are two parameters for this filter. ForegroundValue is the value
 that marks zero-crossing pixels. The BackgroundValue is the value
@@ -35302,12 +35637,9 @@ given to all other pixels.
 See:
  Image
 
-
  Neighborhood
 
-
  NeighborhoodOperator
-
 
  NeighborhoodIterator
 Wiki Examples:
@@ -35318,7 +35650,8 @@ Find zero crossings in a signed image
 See:
  itk::simple::ZeroCrossing for the procedural interface
 
- itk::ZeroCrossingImageFilter for the Doxygen on the original ITK class.
+ itk::ZeroCrossingImageFilter for the Doxygen on the original ITK
+class.
 
 
 
@@ -35409,7 +35742,8 @@ See:
 
  itk::simple::ZeroFluxNeumannPad for the procedural interface
 
- itk::ZeroFluxNeumannPadImageFilter for the Doxygen on the original ITK class.
+ itk::ZeroFluxNeumannPadImageFilter for the Doxygen on the original ITK
+class.
 
 
 C++ includes: sitkZeroFluxNeumannPadImageFilter.h
@@ -35649,6 +35983,66 @@ C++ includes: sitkMemberFunctionFactoryBase.h
 C++ includes: sitkMemberFunctionFactoryBase.h
 ";
 
+%feature("docstring")  itk::Functor::BioRadImageIOFactoryRegister__Private "
+";
+
+%feature("docstring")  itk::Functor::BMPImageIOFactoryRegister__Private "
+";
+
+%feature("docstring")  itk::Functor::GDCMImageIOFactoryRegister__Private "
+";
+
+%feature("docstring")  itk::Functor::GE4ImageIOFactoryRegister__Private "
+";
+
+%feature("docstring")  itk::Functor::GE5ImageIOFactoryRegister__Private "
+";
+
+%feature("docstring")  itk::Functor::GiplImageIOFactoryRegister__Private "
+";
+
+%feature("docstring")  itk::Functor::HDF5ImageIOFactoryRegister__Private "
+";
+
+%feature("docstring")  itk::Functor::HDF5TransformIOFactoryRegister__Private "
+";
+
+%feature("docstring")  itk::Functor::JPEGImageIOFactoryRegister__Private "
+";
+
+%feature("docstring")  itk::Functor::LSMImageIOFactoryRegister__Private "
+";
+
+%feature("docstring")  itk::Functor::MatlabTransformIOFactoryRegister__Private "
+";
+
+%feature("docstring")  itk::Functor::MetaImageIOFactoryRegister__Private "
+";
+
+%feature("docstring")  itk::Functor::MRCImageIOFactoryRegister__Private "
+";
+
+%feature("docstring")  itk::Functor::NiftiImageIOFactoryRegister__Private "
+";
+
+%feature("docstring")  itk::Functor::NrrdImageIOFactoryRegister__Private "
+";
+
+%feature("docstring")  itk::Functor::PNGImageIOFactoryRegister__Private "
+";
+
+%feature("docstring")  itk::Functor::StimulateImageIOFactoryRegister__Private "
+";
+
+%feature("docstring")  itk::Functor::TIFFImageIOFactoryRegister__Private "
+";
+
+%feature("docstring")  itk::Functor::TxtTransformIOFactoryRegister__Private "
+";
+
+%feature("docstring")  itk::Functor::VTKImageIOFactoryRegister__Private "
+";
+
 %feature("docstring")  itk::simple::Abs "
 
 Computes the absolute value of each pixel.
@@ -35733,7 +36127,7 @@ See:
 
 %feature("docstring")  itk::simple::AdditiveGaussianNoise "
 
-Alter an image with additive gaussian white noise.
+Alter an image with additive Gaussian white noise.
 
 
 This function directly calls the execute method of AdditiveGaussianNoiseImageFilter in order to support a procedural API
@@ -36307,9 +36701,9 @@ See:
 
 %feature("docstring")  itk::simple::CenteredTransformInitializer "
 
-CenteredTransformInitializer is a helper class intended to initialize the center of rotation and
-the translation of Transforms having the center of rotation among
-their parameters.
+CenteredTransformInitializer is a helper class intended to initialize
+the center of rotation and the translation of Transforms having the
+center of rotation among their parameters.
 
 
 This function directly calls the execute method of CenteredTransformInitializerFilter in order to support a procedural API
@@ -36323,8 +36717,8 @@ See:
 
 %feature("docstring")  itk::simple::CenteredVersorTransformInitializer "
 
-CenteredVersorTransformInitializer is a helper class intended to initialize the center of rotation,
-versor, and translation of the VersorRigid3DTransform.
+CenteredVersorTransformInitializer is a helper class intended to
+initialize the center of rotation, versor, and translation of the VersorRigid3DTransform.
 
 
 This function directly calls the execute method of
@@ -36559,7 +36953,8 @@ See:
 
 %feature("docstring")  itk::simple::Crop "
 
-Decrease the image size by cropping the image by an itk::Size at both the upper and lower bounds of the largest possible region.
+Decrease the image size by cropping the image by an itk::Size at both
+the upper and lower bounds of the largest possible region.
 
 
 This function directly calls the execute method of CropImageFilter in order to support a procedural API
@@ -38664,9 +39059,35 @@ See:
 ";
 
 %feature("docstring")  itk::simple::ReadImage "
+
+ReadImage is a procedural interface to the ImageFileReader class which is convenient for most image reading tasks.
+
+
+For more complicated use cases such as requiring loading of all tags,
+including private ones, from a DICOM file the object oriented
+interface should be used. The reader can be explicitly set to load all
+tags (LoadPrivateTagsOn()).
+
 ";
 
 %feature("docstring")  itk::simple::ReadImage "
+
+ReadImage is a procedural interface to the ImageSeriesReader class which is convenient for most image reading tasks.
+
+
+Note that when reading a series of images that have meta-data
+associated with them (e.g. a DICOM series) the resulting image will
+have an empty meta-data dictionary. It is possible to programmatically
+add a meta-data dictionary to the compounded image by reading in one
+or more images from the series using the ImageFileReader class,
+analyzing the meta-dictionary associated with each of those images and
+creating one that is relevant for the compounded image.
+
+
+See:
+ itk::simple::ImageFileReader for reading a single file
+
+
 ";
 
 %feature("docstring")  itk::simple::ReadTransform "
@@ -39360,7 +39781,7 @@ See:
 
 %feature("docstring")  itk::simple::TernaryMagnitude "
 
-Pixel-wise addition of three images.
+Compute the pixel-wise magnitude of three images.
 
 
 This function directly calls the execute method of TernaryMagnitudeImageFilter in order to support a procedural API
@@ -39374,7 +39795,7 @@ See:
 
 %feature("docstring")  itk::simple::TernaryMagnitudeSquared "
 
-Pixel-wise addition of three images.
+Compute the pixel-wise squared magnitude of three images.
 
 
 This function directly calls the execute method of TernaryMagnitudeSquaredImageFilter in order to support a procedural API


### PR DESCRIPTION
Updated ITK documentation and an updated doxy2swig.py script
were used to regenerated the PythonDocstrings.i file.