### PR TITLE
Improvements to garbage collection in R package

### DIFF
--- a/Wrapping/R/R.i
+++ b/Wrapping/R/R.i
@@ -40,6 +40,28 @@
 }
 %}
 
+// Specific typemaps for Image returns so that the finalizer gets attached.
+// Would be nice if this can be generalised, but I can't see a way at present.
+// Currently the finalizer gets attached by the wrapping of constructors,
+// but not to the Execute methods, or the function interface.
+%typemap(scoerceout) itk::simple::Image &, itk::simple::Image &&, itk::simple::Image *, itk::simple::Image *const
+%{
+  if (inherits($result, 'externalptr')) {
+   reg.finalizer($result, delete_Image)
+   $result <- new("$R_class", ref=$result);
+} else {
+   stop("Exception in SITK - check warning messages\n")
+}
+%}
+%typemap(scoerceout) itk::simple::Image
+%{
+  if (inherits($result, 'externalptr')) {
+   reg.finalizer($result, delete_Image)
+   $result <- new("$&R_class", ref=$result);
+} else {
+   stop("Exception in SITK - check warning messages\n")
+}
+%}
 
 // SEXP numeric typemap for array/image converion - SEXP are
 // arrays here


### PR DESCRIPTION
itk::simple::Images lead to leaks in the R package.
Swig attaches finalizers to the results
of constructor calls, but not to objects returned by method calls.

The change here isn't as general as I'd like, but cures the most
dramatic problems. These are illustrated by the code below. I'm
not sure that the code can be included as a useful test, as
it requires something external to check process RAM usage.

library(SimpleITK)

InputIm <- Image(512, 512, 512, 'sitkFloat64')
ProcessedIms <- replicate(5, ShiftScale(InputIm, 1, 2))
ProcessedIms <- 0
gc()

Change-Id: Iacd3e9d40048e3ed5f8ea57cfd967e56e89205e4