### PR TITLE
Add exception for trying to write DICOM with ImageSeriesWriter

### DIFF
--- a/Code/IO/include/sitkImageSeriesWriter.h
+++ b/Code/IO/include/sitkImageSeriesWriter.h
@@ -30,6 +30,15 @@ namespace itk {
     /** \class ImageSeriesWriter
      * \brief Writer series of image from a SimpleITK image.
      *
+     * The ImageSeriesWriter is for writing a 3D image as a series of
+     * 2D images. A list of names for the series of 2D images must be
+     * provided, and an exception will be generated if the number of
+     * file names does not match the size of the image in the z-direction.
+     *
+     * DICOM series cannot be written with this class, as an exception
+     * will be generated. To write a DICOM series the individual
+     * slices must be extracted, proper DICOM tags must be added to
+     * the dictionaries, then written with the ImageFileWriter.
      *
      * \sa itk::simple::WriteImage for the procedural interface
      **/

--- a/Code/IO/src/sitkImageSeriesWriter.cxx
+++ b/Code/IO/src/sitkImageSeriesWriter.cxx
@@ -26,6 +26,8 @@
 #include <itkImageIOBase.h>
 #include <itkImageSeriesWriter.h>
 
+#include <cctype>
+
 namespace itk {
   namespace simple {
 
@@ -120,6 +122,26 @@ namespace itk {
   {
     // Define the input and output image types
     typedef TImageType     InputImageType;
+
+    // Verify input file name are provided
+    if( this->m_FileNames.empty() )
+      {
+      sitkExceptionMacro("The parameter \"FileNames\" is empty!");
+      }
+
+    // Verify the input file name are not DICOM
+    for(unsigned int i = 0; i < this->m_FileNames.size(); ++i)
+      {
+      const std::string & fn = this->m_FileNames[i];
+      std::string ext = fn.substr(fn.find_last_of(".")+1);
+      std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+
+      if (ext == "dcm" || ext == "dicom")
+        {
+        sitkExceptionMacro(<<this->GetName()<<" does not support writing a DICOM series!")
+        }
+      }
+
 
     typename InputImageType::ConstPointer image = this->CastImageToITK<InputImageType>( inImage );
 

--- a/Testing/Unit/sitkImageIOTests.cxx
+++ b/Testing/Unit/sitkImageIOTests.cxx
@@ -403,6 +403,24 @@ TEST(IO, ImageSeriesWriter )
   fileNames.resize(0);
   writer.SetFileNames( fileNames );
   EXPECT_ANY_THROW(writer.Execute(image));
+
+  // Check writing DICOM series throws an exception
+  fileNames.clear();
+  fileNames.push_back( dataFinder.GetOutputDirectory()+"/ImageSeriesWriter_1.dcm" );
+  fileNames.push_back( dataFinder.GetOutputDirectory()+"/ImageSeriesWriter_2.dcm" );
+  fileNames.push_back( dataFinder.GetOutputDirectory()+"/ImageSeriesWriter_3.dcm" );
+
+  EXPECT_ANY_THROW( sitk::WriteImage( image, fileNames ) );
+
+  writer.SetFileNames(fileNames);
+  EXPECT_ANY_THROW(writer.Execute(image));
+
+  fileNames.clear();
+  fileNames.push_back( dataFinder.GetOutputDirectory()+"/ImageSeriesWriter_1.DICOM" );
+  fileNames.push_back( dataFinder.GetOutputDirectory()+"/ImageSeriesWriter_2.DICOM" );
+  fileNames.push_back( dataFinder.GetOutputDirectory()+"/ImageSeriesWriter_3.DICOM" );
+
+  EXPECT_ANY_THROW( sitk::WriteImage( image, fileNames ) );
 }
 
 


### PR DESCRIPTION
The default behavior of the ITK ImageSeriesWriter with DICOM does not
produce a correct DICOM series. Each file written has a different
series ID, and overrides the physical origin to (0,0,0).

Due to these problems we are disabling writing a DICOM series with
this class.