### PR TITLE
Fix the SimpleITK install directory used for super SimpleITK Examples

### DIFF
--- a/SuperBuild/External_SimpleITKExamples.cmake
+++ b/SuperBuild/External_SimpleITKExamples.cmake
@@ -20,7 +20,7 @@ if (${BUILD_EXAMPLES} )
       --no-warn-unused-cli
       -C "${CMAKE_CURRENT_BINARY_DIR}/${proj}-build/CMakeCacheInit.txt"
       ${ep_common_args}
-      -DSimpleITK_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/SimpleITK-0.11/
+      -DSimpleITK_DIR:PATH=${CMAKE_INSTALL_PREFIX}/lib/cmake/SimpleITK-1.0/
       -DCMAKE_SKIP_RPATH:BOOL=ON
       -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
     BUILD_COMMAND ${BUILD_COMMAND_STRING}


### PR DESCRIPTION
The version was not update to SimpleITK version 1.0 and the binary
build directory was used not the install directory.