### PR TITLE
Don't use ITK_MODULES_ENABLED for complete list of install ITK modules

### DIFF
--- a/CMake/sitkGenerateFilterSource.cmake
+++ b/CMake/sitkGenerateFilterSource.cmake
@@ -150,13 +150,16 @@ function( expand_template FILENAME input_dir output_dir library_name )
 
   get_json_path( itk_module ${input_json_file} itk_module)
 
-  list (FIND ITK_MODULES_ENABLED "${itk_module}" _index)
 
   if("${itk_module}" STREQUAL "")
     message(WARNING "Missing \"itk_module\" field in ")
-  elseif (NOT "${itk_module}" STREQUAL "" AND ${_index} EQUAL -1)
-    # required module is not enabled, don't process
-    return()
+  else()
+    list (FIND ITK_MODULES_ENABLED "${itk_module}" _index)
+    find_package(ITK QUIET COMPONENTS ${itk_module})
+    if (NOT ITK_FOUND)
+      # required module is not enabled, don't process
+      return()
+    endif()
   endif()
 
   # Get the list of template component files for this template

--- a/Code/BasicFilters/src/CMakeLists.txt
+++ b/Code/BasicFilters/src/CMakeLists.txt
@@ -130,9 +130,10 @@ foreach( itk_module ${module_vars} )
 
   # cmake >= 3.3
   # if( ${itk_module} IN_LIST ITK_MODULES_ENABLED)
+ find_package(ITK QUIET COMPONENTS ${itk_module})
   list (FIND ITK_MODULES_ENABLED ${itk_module} _index)
   list (LENGTH SimpleITKBasicFiltersGeneratedSource_${itk_module} _len)
-  if (${_index} GREATER -1 AND ${_len} GREATER 0)
+  if (ITK_FOUND AND ${_len} GREATER 0)
     add_filter_library( SimpleITK_${itk_module}
                         SimpleITKBasicFiltersGeneratedSource_${itk_module}
                         itk_module )


### PR DESCRIPTION
The ITK_MODULES_ENABLED variable may only include ITK modules enabled
during the initial configuration, and may not include install remote
or external modules.

It is preferred to use find_packages to "query" if ITK has a module
available, as a complete list of install ITK module may not exist.

Suggested-by: Matt McCormick <matt.mccormick@kitware.com>