### PR TITLE
Use the install directory for include interface

### DIFF
--- a/Code/BasicFilters/src/CMakeLists.txt
+++ b/Code/BasicFilters/src/CMakeLists.txt
@@ -29,7 +29,7 @@ function(add_filter_library library_name src_list_var itk_module_list_var)
     PUBLIC
       $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/Code/BasicFilters/include>
       $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/Code/BasicFilters/include>
-      $<INSTALL_INTERFACE:include>
+      $<INSTALL_INTERFACE:${SimpleITK_INSTALL_INCLUDE_DIR}>
     PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR} )
   if(BUILD_SHARED_LIBS)
@@ -77,7 +77,7 @@ endif()
 target_include_directories( SimpleITKBasicFilters0
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/Code/BasicFilters/include>
-    $<INSTALL_INTERFACE:include>
+    $<INSTALL_INTERFACE:${SimpleITK_INSTALL_INCLUDE_DIR}>
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR} )
 target_compile_options( SimpleITKBasicFilters0

--- a/Code/Common/src/CMakeLists.txt
+++ b/Code/Common/src/CMakeLists.txt
@@ -41,7 +41,7 @@ target_include_directories ( SimpleITKCommon
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/Code/Common/include>
     $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/Code/Common/include>
-    $<INSTALL_INTERFACE:include> )
+    $<INSTALL_INTERFACE:${SimpleITK_INSTALL_INCLUDE_DIR}> )
 if(NOT SITK_HAS_STDINT_H AND MSVC)
   target_include_directories ( SimpleITKCommon
     PUBLIC

--- a/Code/Explicit/src/CMakeLists.txt
+++ b/Code/Explicit/src/CMakeLists.txt
@@ -37,7 +37,7 @@ target_include_directories ( SimpleITKExplicit
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/Code/Explicit/include>
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/Code/Common/include>
     $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/Code/Common/include>
-    $<INSTALL_INTERFACE:include> )
+    $<INSTALL_INTERFACE:${SimpleITK_INSTALL_INCLUDE_DIR}> )
 target_compile_definitions( SimpleITKExplicit
   PUBLIC
     SITK_USE_EXPLICITITK )

--- a/Code/IO/src/CMakeLists.txt
+++ b/Code/IO/src/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 target_include_directories ( SimpleITKIO
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/Code/IO/include>
-    $<INSTALL_INTERFACE:include>
+    $<INSTALL_INTERFACE:${SimpleITK_INSTALL_INCLUDE_DIR}>
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR} )
 target_compile_options( SimpleITKIO

--- a/Code/Registration/src/CMakeLists.txt
+++ b/Code/Registration/src/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 target_include_directories ( SimpleITKRegistration
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/Code/Registration/include>
-    $<INSTALL_INTERFACE:include>
+    $<INSTALL_INTERFACE:${SimpleITK_INSTALL_INCLUDE_DIR}>
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR} )
 


### PR DESCRIPTION
The correct include directory was not being specified for the
interface include directory for SimpleITK. This has been corrected to
the proper variable where SimpleITK headers are installed.