### PR TITLE
WIP: Address "SimpleITKExplicit" INTERFACE_INCLUDE_DIRECTORIES source

### DIFF
--- a/CMake/sitkTargetUseITK.cmake
+++ b/CMake/sitkTargetUseITK.cmake
@@ -3,16 +3,26 @@
 # This function has the following form:
 #   sitk_target_use_itk(<target>
 #                       <PRIVATE|PUBLIC|INTERFACE>
+#                       [BUILD_INTERFACE]
 #                       [itk_module [itk_module [...]]])
 #
 #   It configures the target, with the require include directories and
 # link libraries to use the list of itk modules provided. The keyword
-# to indicate interface of the library is also required.
+# to indicate interface of the library is also required. If the string
+# BUILD_INTERFACE is provided, then the $<BUILD_INTERFACE:...>
+# generator expression will be added to the itk modules include
+# directories.
 
 function(sitk_target_use_itk target_name interface_keyword)
 
   set(itk_modules ${ARGV})
   list(REMOVE_AT itk_modules 0 1)
+  list(GET ARGV 2 build_interface)
+  if(build_interface STREQUAL "BUILD_INTERFACE")
+    list(REMOVE_AT itk_modules 0)
+  else()
+    unset(build_interface)
+  endif()
 
   itk_module_config(_itk ${itk_modules})
 
@@ -26,9 +36,15 @@ function(sitk_target_use_itk target_name interface_keyword)
       ${_itk_LIBRARIES} )
   endif()
   if(_itk_INCLUDE_DIRS)
-    target_include_directories( ${target_name}
-      ${interface_keyword}
-      ${_itk_INCLUDE_DIRS} )
+    if(build_interface)
+      target_include_directories( ${target_name}
+        ${interface_keyword}
+        $<BUILD_INTERFACE:${_itk_INCLUDE_DIRS}> )
+    else()
+      target_include_directories( ${target_name}
+        ${interface_keyword}
+        ${_itk_INCLUDE_DIRS})
+    endif()
   endif()
 
 endfunction()

--- a/Code/Explicit/src/CMakeLists.txt
+++ b/Code/Explicit/src/CMakeLists.txt
@@ -31,7 +31,7 @@ add_library ( SimpleITKExplicit ${SimpleITKExplicit_FORCE_LIBRARY_TYPE} ${Simple
 if( SITK_BUILD_SHARED_LIBS )
   set_target_properties(SimpleITKExplicit PROPERTIES CXX_VISIBILITY_PRESET default)
 endif()
-sitk_target_use_itk( SimpleITKExplicit PUBLIC ${use_itk_modules} )
+sitk_target_use_itk( SimpleITKExplicit PUBLIC BUILD_INTERFACE ${use_itk_modules} )
 target_include_directories ( SimpleITKExplicit
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/Code/Explicit/include>


### PR DESCRIPTION
This patches addresses the following CMake error:
CMake Error in Code/Explicit/src/CMakeLists.txt:
Target "SimpleITKExplicit" INTERFACE_INCLUDE_DIRECTORIES property
contains
path:
"/tmp/simpleitk-20170405-63774-kll36r/sitk-build/ITK-prefix/include/ITK-4.11"
which is prefixed in the source directory.
-- Generating done

This occurs when the build directory is a sub-directory of the source
tree and `CMAKE_INSTALL_PREFIX` is specified.

The SimpleITKExplicit library is intended to only be directly used by
other SimpleITK libraries.