### PR TITLE
Relax tolerance for DiscreteGaussianImageFilter_short test

### DIFF
--- a/Code/BasicFilters/json/DiscreteGaussianImageFilter.json
+++ b/Code/BasicFilters/json/DiscreteGaussianImageFilter.json
@@ -57,7 +57,7 @@
       "tag" : "short",
       "description" : "Simply run with a short image with default settings",
       "settings" : [],
-      "tolerance" : "0.4",
+      "tolerance" : "0.5",
       "inputs" : [
         "Input/RA-Slice-Short.nrrd"
       ]


### PR DESCRIPTION
Thanks to Gustavo Serra Scalet for reporting the test failure on a
POWER8 system with `-O3` optimization on as 0.48. This was also
reproduced on intel architectures with `-m32` in Debug with a failing
RMS of 0.455.

We are relaxing to 0.5, with consideration being made for numerical
precision and this algorithm does a C++ cast for int->float resulting
in truncation during conversion.