### PR TITLE
Relax tolerance on MagnitudeAndPhaseToComplex from i686 results

### DIFF
--- a/Code/BasicFilters/json/MagnitudeAndPhaseToComplexImageFilter.json
+++ b/Code/BasicFilters/json/MagnitudeAndPhaseToComplexImageFilter.json
@@ -12,7 +12,7 @@
     {
       "tag" : "defaults",
       "description" : "Test defaults",
-      "tolerance" : "0.001",
+      "tolerance" : "0.0015",
       "settings" : [],
       "inputs" : [
         "Input/RA-Slice-Float.nrrd",

--- a/Testing/Unit/sitkBasicFiltersTests.cxx
+++ b/Testing/Unit/sitkBasicFiltersTests.cxx
@@ -684,10 +684,10 @@ TEST(BasicFilters,LandmarkBasedTransformInitializer) {
   EXPECT_EQ ( "LandmarkBasedTransformInitializerFilter", filter.GetName() );
 
   out = filter.Execute( sitk::Euler2DTransform() );
-  EXPECT_VECTOR_DOUBLE_NEAR(v3(0.0, 0.0, 0.0), out.GetParameters(), 1e-25);
+  EXPECT_VECTOR_DOUBLE_NEAR(v3(0.0, 0.0, 0.0), out.GetParameters(), 1e-15);
 
   out = filter.Execute( sitk::Similarity2DTransform() );
-  EXPECT_VECTOR_DOUBLE_NEAR(v4(1.0, 0.0, 0.0, 0.0), out.GetParameters(), 1e-25);
+  EXPECT_VECTOR_DOUBLE_NEAR(v4(1.0, 0.0, 0.0, 0.0), out.GetParameters(), 1e-15);
 
 
   EXPECT_ANY_THROW( filter.Execute( sitk::VersorTransform() ) );


### PR DESCRIPTION
From experience with compilation in Debug mode for i686 via the "-m32"
flag, the tolerance is being relaxed to 0.0015, because the observed
RMS value for the test was: 0.00106792