### PR TITLE
Fix use of setuptools

### DIFF
--- a/Wrapping/Python/Packaging/setup.py.in
+++ b/Wrapping/Python/Packaging/setup.py.in
@@ -1,8 +1,8 @@
 import sys
 
-if "setuptools" in sys.modules.keys():
+try:
     from setuptools import setup, Distribution
-else:
+except ImportError:
     from distutils.core import setup
     from distutils.dist import Distribution
 


### PR DESCRIPTION
Hi,

I was not able to create wheel using your `setup.py`
```
pip setup.py bdist_wheel
```

I spend few time to understand that the way used to autodetect `setuptools` is not the right one.

Here is a fix to use `setuptools` if it is available on your environment. That's a really common way in the Python world.

Now i can create wheels without any problems.