### PR TITLE
BUG: SITK_4D_IMAGES is a preprocessor directive, not a CMake option, and should not be renamed to SimpleITK_4D_IMAGES

### DIFF
--- a/Code/BasicFilters/json/JoinSeriesImageFilter.json
+++ b/Code/BasicFilters/json/JoinSeriesImageFilter.json
@@ -5,7 +5,7 @@
   "number_of_inputs" : 1,
   "pixel_types" : "NonLabelPixelIDTypeList",
   "output_image_type" : "typename InputImageType::template Rebind<typename InputImageType::PixelType, InputImageType::ImageDimension+1>::Type",
-  "custom_register" : "this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 2 > ();\n  #ifdef SimpleITK_4D_IMAGES\n    this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 3 > ();\n  #endif",
+  "custom_register" : "this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 2 > ();\n  #ifdef SITK_4D_IMAGES\n    this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 3 > ();\n  #endif",
   "members" : [
     {
       "name" : "Origin",


### PR DESCRIPTION
SimpleITK/SimpleITK#176