### PR TITLE
Add wrapping of the RoundImageFilter

### DIFF
--- a/Code/BasicFilters/json/RoundImageFilter.json
+++ b/Code/BasicFilters/json/RoundImageFilter.json
@@ -1,0 +1,23 @@
+{
+  "name" : "RoundImageFilter",
+  "template_code_filename" : "ImageFilter",
+  "template_test_filename" : "ImageFilter",
+  "doc" : "",
+  "number_of_inputs" : 1,
+  "pixel_types" : "RealPixelIDTypeList",
+  "members" : [],
+  "tests" : [
+    {
+      "tag" : "default",
+      "description" : "Simply run with default settings",
+      "settings" : [],
+      "md5hash" : "3ccccde44efaa3d688a86e94335c1f16",
+      "inputs" : [
+        "Input/RA-Float.nrrd"
+      ]
+    }
+  ],
+  "briefdescription" : "Rounds the value of each pixel.",
+  "detaileddescription" : "The computations are performed using itk::Math::Round(x).",
+  "itk_module" : "ITKImageIntensity"
+}


### PR DESCRIPTION
This filter is only useful to operate on floats. Additionally, while
the output is an integer, the operation of casting to an integer is
another filter, Cast or Clamp.