### PR TITLE
On Win32 Add User's home & desktop to search path

### DIFF
--- a/Code/IO/src/sitkShow.cxx
+++ b/Code/IO/src/sitkShow.cxx
@@ -380,6 +380,11 @@ namespace itk
     paths.push_back ( ProgramFiles + "\\" + directory + "\\");
     }
 
+  if ( itksys::SystemTools::GetEnv ( "USERPROFILE", ProgramFiles ) )
+    {
+    paths.push_back ( ProgramFiles + "\\" + directory + "\\");
+    paths.push_back ( ProgramFiles + "\\Desktop\\" + directory + "\\");
+    }
 
   // Find the executable
   ExecutableName = itksys::SystemTools::FindFile ( ExecutableName.c_str(), paths );


### PR DESCRIPTION
Added the user's home directory and desktop to the application
search path when trying to find ImageJ in the Show function.

Change-Id: Ib76256be6159a012cc545a631e902bbffd012201