### PR TITLE
Catch error of null ImageJ application

### DIFF
--- a/Code/IO/src/sitkShow.cxx
+++ b/Code/IO/src/sitkShow.cxx
@@ -111,6 +111,10 @@ namespace itk
               break;
             case 'a':
               // %a for application
+              if (!app.length())
+                {
+                sitkExceptionMacro( "No ImageJ/Fiji application found." )
+                }
               result.append(app);
               i++;
               break;


### PR DESCRIPTION
In this patch we are checking for a null ImageJ executable string.
We do this at the point where that string is replacing the "%a"
macro in the command string.  This allows the user to replace
the command string, possibly not using "%a".  This sitation
would occur if the user was using some other application.  In
that case, a null ImageJ app string would not cause an error.

Change-Id: I87a0c4b7072adc0e00744de28659b8a7366010a1