### PR TITLE
Add explicit check for BSpline Order in Landmark initializer

### DIFF
--- a/Code/BasicFilters/src/sitkLandmarkBasedTransformInitializerFilter.cxx
+++ b/Code/BasicFilters/src/sitkLandmarkBasedTransformInitializerFilter.cxx
@@ -30,6 +30,7 @@
 
 // Additional include files
 #include "sitkTransform.h"
+#include "sitkBSplineTransform.h"
 // Done with additional include files
 
 namespace itk {
@@ -184,6 +185,13 @@ Transform LandmarkBasedTransformInitializerFilter::ExecuteInternal ( const Trans
       {
       sitkExceptionMacro( "Image not set for BSplineTransform initializer." );
       }
+    {
+    BSplineTransform bsTx(*inTransform);
+    if (bsTx.GetOrder() != 3)
+      {
+      sitkExceptionMacro( "BSplineTransform is only supported  with an order of 3." )
+      }
+    }
     // Get the pointer to the ITK image contained in image1
     typename InputImageType::ConstPointer referenceImage = this->CastImageToITK<InputImageType>( this->m_ReferenceImage );
     filter->SetReferenceImage ( referenceImage.GetPointer() );


### PR DESCRIPTION
The LantmarkBasedTransformInitializer only supports BSpline transform
of order 3. When a different order transform as passed the following
unhelpful error message was presented:
itk::ERROR: LandmarkBasedTransformInitializer(0x31204f0): Unsupported
Transform Type BSplineTransform

A custom check for the proper transform has been added with a verbose
error message which describes the requirement.

Addressed comments in #197.