### PR TITLE
Enable ITK remote modules to be enables in Superbuild

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -26,7 +26,7 @@ foreach (_varName ${_varNames})
   if(_varName MATCHES "^ITK_"
       OR _varName MATCHES "^ITKV3"
       OR _varName MATCHES "FFTW"
-      OR _varName MATCHES "^Module_ITK")
+      OR _varName MATCHES "^Module_")
     message( STATUS "Passing variable \"${_varName}=${${_varName}}\" to ITK external project.")
     list(APPEND ITK_VARS ${_varName})
   endif()


### PR DESCRIPTION
Update the regular expression used to propagate CMake flags from the
superbuild to the ITK project. Remote the ITK prefix in the module
name enables ITK remote modules to be enabled through the SimpleITK
superbuild process.