### PR TITLE
Fix out of bound array access in Image4D.ExtractImageFilter test

### DIFF
--- a/Testing/Unit/sitkImage4DTests.cxx
+++ b/Testing/Unit/sitkImage4DTests.cxx
@@ -574,6 +574,9 @@ TEST_F(Image4D, ExtractImageFilter)
 
   sitk::Image out = sitk::Extract(img, extractSize);
 
-  ASSERT_EQ ( out.GetDimension(), 3 );
-  EXPECT_EQ ( out.GetSize()[3], 13 );
+  ASSERT_EQ ( 3u, out.GetDimension() );
+  EXPECT_EQ ( 10u, out.GetSize().at(0) );
+  EXPECT_EQ ( 11u, out.GetSize().at(1) );
+  EXPECT_EQ ( 13u, out.GetSize().at(2) );
+  EXPECT_EQ ( 1430u, out.GetNumberOfPixels() );
 }


### PR DESCRIPTION
The size was indexed by 3 when the size was only 3. This access has
been changed to the safe `at` function and the index corrected to
2. Additionally, the order of the arguments was corrected so that the
expected value is first. Added additional check to the size and shape
of the output image.