### PR TITLE
Fixing spelling mistakes in documentation and comments

### DIFF
--- a/Code/BasicFilters/include/sitkImageOperators.h
+++ b/Code/BasicFilters/include/sitkImageOperators.h
@@ -36,7 +36,7 @@ namespace simple {
 * \brief Performs the operator on a per pixel basis.
 *
 * All overloaded simpleITK operators are performed on a per-pixel
-* basis, and implemented with the coresponding image filters. These
+* basis, and implemented with the corresponding image filters. These
 * operators gernerally don't work with label images, and the logical
 * operators don't work with images of real components or vector images.
 * @{

--- a/Code/BasicFilters/src/sitkImageToKernel.hxx
+++ b/Code/BasicFilters/src/sitkImageToKernel.hxx
@@ -53,7 +53,7 @@ padFilter->SetConstant( NumericTraits< KernelImagePixelType >::ZeroValue() );
 typename TImageType::SizeType padSize = image->GetLargestPossibleRegion().GetSize();
 for( unsigned int i = 0; i < TImageType::ImageDimension; ++i )
   {
-  // Pad by 1 if the size fo the image in this dimension is even.
+  // Pad by 1 if the size of the image in this dimension is even.
   padSize[i] = 1 - padSize[i]%2;
 
   if ( padSize[i] != 0 )

--- a/Code/Common/include/Ancillary/TypeList.h
+++ b/Code/Common/include/Ancillary/TypeList.h
@@ -74,7 +74,7 @@ struct SITK_ABI_HIDDEN NullType {};
  * \code
  * MakeTypeList<T1, T2, T3>::Type
  * \endcode
- * returns a typelist that contans the types T1, T2, T3
+ * returns a typelist that contains the types T1, T2, T3
  *
  * Example:
  * \code

--- a/Code/Common/include/sitkDualMemberFunctionFactory.h
+++ b/Code/Common/include/sitkDualMemberFunctionFactory.h
@@ -153,7 +153,7 @@ public:
    *  pixelID1 or pixelID2 is the value of Image::GetPixelIDValue(),
    *  or PixelIDToPixelIDValue<PixelIDType>::Result
    *
-   *  imageDimension is the the value returned by Image::GetDimension()
+   *  imageDimension is the value returned by Image::GetDimension()
    *
    *  Example usage:
    *  \code

--- a/Code/Common/include/sitkDualMemberFunctionFactory.hxx
+++ b/Code/Common/include/sitkDualMemberFunctionFactory.hxx
@@ -93,7 +93,7 @@ DualMemberFunctionFactory< TMemberFunctionPointer >
   PixelIDValueType pixelID1 = ImageTypeToPixelIDValue<TImageType1>::Result;
   PixelIDValueType pixelID2 = ImageTypeToPixelIDValue<TImageType2>::Result;
 
-  // this shouldn't occour, just may be useful for debugging
+  // this shouldn't occur, just may be useful for debugging
   assert( pixelID1 >= 0 && pixelID1 < typelist::Length< InstantiatedPixelIDTypeList >::Result );
   assert( pixelID2 >= 0 && pixelID2 < typelist::Length< InstantiatedPixelIDTypeList >::Result );
 

--- a/Code/Common/include/sitkEnableIf.h
+++ b/Code/Common/include/sitkEnableIf.h
@@ -30,7 +30,7 @@ namespace simple
  *
  * If the parameter V is true then the Type trait is the second
  * template parameter, otherwise an implementation does not exist and
- * with SFIANE another implementation may be choosen.
+ * with SFIANE another implementation may be chosen.
  *
  * Example:
  * \code

--- a/Code/Common/include/sitkImage.h
+++ b/Code/Common/include/sitkImage.h
@@ -42,7 +42,7 @@ class SmartPointer;
 namespace simple
 {
 
-  // This is the foward declaration of a class used internally to the
+  // This is the forward declaration of a class used internally to the
   // Image class, but the actually interface is not exposed to simple
   // ITK. A pointer to the implementation is used as per the pimple
   // idiom.
@@ -122,11 +122,11 @@ namespace simple
 
     /** Get access to internal ITK data object.
      *
-     * The return value should imediately be assigned to as
+     * The return value should immediately be assigned to as
      * itk::SmartPointer.
      *
      * In many cases the value may need to be dynamically casted to
-     * the the actual image type. The GetPixelIDValue() method should
+     * the actual image type. The GetPixelIDValue() method should
      * return an PixelID which identifies the image type which the
      * DataObject points to.
      *
@@ -176,7 +176,7 @@ namespace simple
     /** \brief Set/Get the Direction
      *
      * Internally, the Direction is represented by a matrix 2x2 for a
-     * 2D and and 3x3 for a 3D image. The matrix is passed as a 1D
+     * 2D and 3x3 for a 3D image. The matrix is passed as a 1D
      * array in row-major form.
      * @{
      */
@@ -432,18 +432,18 @@ namespace simple
      * This is the single method which needs to be explicitly
      * instantiated to separate the internal ITK and Pimple image from
      * the external SimpleITK interface. Template parameters have been
-     * choosen carefully to flexibly enable this.
+     * chosen carefully to flexibly enable this.
      */
     template <int VPixelIDValue, unsigned int VImageDimension>
     void InternalInitialization( typename PixelIDToImageType<typename typelist::TypeAt<InstantiatedPixelIDTypeList,
                                                                                        VPixelIDValue>::Result,
                                                              VImageDimension>::ImageType *i );
 
-    /** Dispatched from the InternalInitialization method. The enable
-     * if idiom is used here for method overloading. The second method
-     * is for non-instantiated image, which turn into a void pointer
-     * for the paramter. However, this second method should never be
-     * executed.
+    /** Dispatched from the InternalInitialization method. The
+     * "enable-if" idiom is used here for method overloading. The
+     * second method is for non-instantiated image, which turn into a
+     * void pointer for the parameter. However, this second method
+     * should never be executed.
      * @{
      */
     template<int VPixelIDValue, typename TImageType>

--- a/Code/Common/include/sitkMacro.h
+++ b/Code/Common/include/sitkMacro.h
@@ -53,9 +53,9 @@
 
 
 #if __cplusplus >= 201103L
-// In c++11 the override keyword allows you to explicity define that a function
+// In c++11 the override keyword allows you to explicitly define that a function
 // is intended to override the base-class version.  This makes the code more
-// managable and fixes a set of common hard-to-find bugs.
+// manageable and fixes a set of common hard-to-find bugs.
 #define SITK_OVERRIDE override
 // In C++11 the throw-list specification has been deprecated,
 // replaced with the noexcept specifier. Using this function

--- a/Code/Common/include/sitkMemberFunctionFactory.h
+++ b/Code/Common/include/sitkMemberFunctionFactory.h
@@ -135,7 +135,7 @@ public:
    *  pixelID is the value of Image::GetPixelIDValue(), or
    *  PixelIDToPixelIDValue<PixelIDType>::Result
    *
-   *  imageDimension is the the value returned by Image::GetDimension()
+   *  imageDimension is the value returned by Image::GetDimension()
    *
    *  Example usage:
    *  \code

--- a/Code/Common/include/sitkMemberFunctionFactory.hxx
+++ b/Code/Common/include/sitkMemberFunctionFactory.hxx
@@ -88,7 +88,7 @@ void MemberFunctionFactory<TMemberFunctionPointer>
 {
   PixelIDValueType pixelID = ImageTypeToPixelIDValue<TImageType>::Result;
 
-  // this shouldn't occour, just may be useful for debugging
+  // this shouldn't occur, just may be useful for debugging
   assert( pixelID >= 0 && pixelID < typelist::Length< InstantiatedPixelIDTypeList >::Result );
 
   sitkStaticAssert( IsInstantiated<TImageType>::Value,

--- a/Code/Common/include/sitkPixelIDTypeLists.h
+++ b/Code/Common/include/sitkPixelIDTypeLists.h
@@ -35,7 +35,7 @@ namespace simple
 
 /** List of all pixel ids for the itk::Image class.
  *
- * \todo adress vnl issues with long long types
+ * \todo address vnl issues with long long types
  *
  * \sa BasicPixelID
  */

--- a/Code/Common/include/sitkPixelIDValues.h
+++ b/Code/Common/include/sitkPixelIDValues.h
@@ -45,7 +45,7 @@ struct ImageTypeToPixelIDValue
 
 /** \brief Enumerated values of pixelIDs
  *
- * Each PixelID's value correspondes to the index of the PixelID type,
+ * Each PixelID's value corresponded to the index of the PixelID type,
  * in the type list "InstantiatedPixelIDTypeList". It is possible that
  * different configurations for SimpleITK could result in different
  * values for pixelID. So these enumerated values should be used.
@@ -53,8 +53,8 @@ struct ImageTypeToPixelIDValue
  * Additionally, not all PixelID an instantiated in for the tool
  * kit. If a PixelID is not instantiated then it's value is
  * -1. Therefore it is likely that multiple elements in the
- * enumeration will have a zero value. Therefore the first prefered
- * methods is to use "if" statements, with the first branch checking
+ * enumeration will have a zero value. Therefore the first preferred
+ * method is to use "if" statements, with the first branch checking
  * for the Unknown value.
  *
  * If a switch case statement is needed the ConditionalValue

--- a/Code/Common/include/sitkTemplateFunctions.h
+++ b/Code/Common/include/sitkTemplateFunctions.h
@@ -34,7 +34,7 @@ namespace simple {
 
 /** \brief A function which does nothing
  *
- * This function is to be used to mark parameters as unused to supress
+ * This function is to be used to mark parameters as unused to suppress
  * compiler warning.
  */
 template <typename T>
@@ -80,7 +80,7 @@ TITKPointVector SITKCommon_HIDDEN sitkSTLVectorToITKPointVector( const std::vect
 
 /** \brief Copy the elements of an std::vector into an ITK fixed width vector
  *
- * If there are more elements in paramter "in" than the templated ITK
+ * If there are more elements in parameter "in" than the templated ITK
  * vector type, they are truncated. If less, then an exception is
  * generated.
  */

--- a/Code/Common/include/sitkTransform.h
+++ b/Code/Common/include/sitkTransform.h
@@ -28,7 +28,7 @@ namespace itk
 {
 
 // Forward declaration for pointer
-// After ITK_VERSION 4.5 (Acutally after June 20th, 2013) the ITK Transform
+// After ITK_VERSION 4.5 (Actually after June 20th, 2013) the ITK Transform
 // classes are now templated.  This requires forward declarations to be defined
 // differently.
 #if ( ( SITK_ITK_VERSION_MAJOR == 4 ) && ( SITK_ITK_VERSION_MINOR < 5 ) )
@@ -142,11 +142,11 @@ public:
 
   /** Get access to internal ITK data object.
    *
-   * The return value should imediately be assigned to as
+   * The return value should immediately be assigned to as
    * itk::SmartPointer.
    *
-   * In many cases the value may need to be dynamically casted to
-   * the the actual transform type.
+   * In many cases the value may need to be dynamically cast to
+   * the actual transform type.
    *
    * @{
    */

--- a/Code/Common/src/sitkConfigure.h.in
+++ b/Code/Common/src/sitkConfigure.h.in
@@ -56,7 +56,7 @@
 #endif
 
 // Include ITK version reported in CMake with SITK prefix, so that
-// SimpleITK dosen't need ITK header in our headers.
+// SimpleITK doesn't need ITK header in our headers.
 #define SITK_ITK_VERSION_MAJOR @ITK_VERSION_MAJOR@
 #define SITK_ITK_VERSION_MINOR @ITK_VERSION_MINOR@
 #define SITK_ITK_VERSION_PATCH @ITK_VERSION_PATCH@

--- a/Code/Common/src/sitkPixelIDValues.cxx
+++ b/Code/Common/src/sitkPixelIDValues.cxx
@@ -33,7 +33,7 @@ const std::string GetPixelIDValueAsString( PixelIDValueType type )
 
   if ( type == sitkUnknown )
     {
-    // Unknow must be first because other enums may be -1 if they are
+    // Unknown must be first because other enums may be -1 if they are
     // not instantiated
     return "Unknown pixel id";
     }
@@ -153,7 +153,7 @@ PixelIDValueType GetPixelIDValueFromString(const std::string &enumString )
 
   if ( enumString == "sitkUnknown" )
     {
-    // Unknow must be first because other enums may be -1 if they are
+    // Unknown must be first because other enums may be -1 if they are
     // not instantiated
       return sitkUnknown;
     }

--- a/Code/IO/include/sitkImageFileReader.h
+++ b/Code/IO/include/sitkImageFileReader.h
@@ -44,7 +44,7 @@ namespace itk {
       /** Print ourselves to string */
       virtual std::string ToString() const;
 
-      /** return user readable name fo the filter */
+      /** return user readable name of the filter */
       virtual std::string GetName() const { return std::string("ImageFileReader"); }
 
       SITK_RETURN_SELF_TYPE_HEADER SetFileName ( const std::string &fn );

--- a/Code/IO/include/sitkImageFileWriter.h
+++ b/Code/IO/include/sitkImageFileWriter.h
@@ -59,7 +59,7 @@ class SmartPointer;
       /** Print ourselves to string */
       virtual std::string ToString() const;
 
-      /** return user readable name fo the filter */
+      /** return user readable name of the filter */
       virtual std::string GetName() const { return std::string("ImageFileWriter"); }
 
       /** \brief Enable compression if available for file type.

--- a/Code/IO/include/sitkImageSeriesReader.h
+++ b/Code/IO/include/sitkImageSeriesReader.h
@@ -42,7 +42,7 @@ namespace itk {
       /** Print ourselves to string */
       virtual std::string ToString() const;
 
-      /** return user readable name fo the filter */
+      /** return user readable name of the filter */
       virtual std::string GetName() const { return std::string("ImageSeriesReader"); }
 
       /** \brief Generate a sequence of filenames from a directory with a DICOM data set and a series ID.

--- a/Code/IO/include/sitkImageSeriesWriter.h
+++ b/Code/IO/include/sitkImageSeriesWriter.h
@@ -53,7 +53,7 @@ namespace itk {
       /** Print ourselves to string */
       virtual std::string ToString() const;
 
-      /** return user readable name fo the filter */
+      /** return user readable name of the filter */
       virtual std::string GetName() const { return std::string("ImageSeriesWriter"); }
 
       /** \brief Enable compression if available for file type.

--- a/Code/IO/include/sitkImportImageFilter.h
+++ b/Code/IO/include/sitkImportImageFilter.h
@@ -54,7 +54,7 @@ namespace itk {
       /** Print ourselves to string */
       virtual std::string ToString() const;
 
-      /** return user readable name fo the filter */
+      /** return user readable name of the filter */
       virtual std::string GetName() const { return std::string("ImportImageFilter"); }
 
       SITK_RETURN_SELF_TYPE_HEADER SetSize( const std::vector< unsigned int > &size );
@@ -84,7 +84,7 @@ namespace itk {
 
     protected:
 
-      // Internal method called the the template dispatch system
+      // Internal method called by the template dispatch system
       template <class TImageType> Image ExecuteInternal ( void );
 
       // If the output image type is a VectorImage then the number of

--- a/Code/IO/src/sitkImageFileReader.cxx
+++ b/Code/IO/src/sitkImageFileReader.cxx
@@ -112,7 +112,7 @@ namespace itk {
     typedef itk::ImageFileReader<ImageType> Reader;
 
     // if the InstantiatedToken is correctly implemented this should
-    // not occour
+    // not occur
     assert( ImageTypeToPixelIDValue<ImageType>::Result != (int)sitkUnknown );
     assert( imageio != SITK_NULLPTR );
     typename Reader::Pointer reader = Reader::New();

--- a/Code/IO/src/sitkImageReaderBase.cxx
+++ b/Code/IO/src/sitkImageReaderBase.cxx
@@ -23,7 +23,7 @@
 #include <itksys/SystemTools.hxx>
 
 // Include the Transform IO here, so that the IO factory registration
-// will occour.
+// will occur.
 #include <itkTransformFileReader.h>
 #include <itkTransformFileWriter.h>
 

--- a/Code/IO/src/sitkShow.cxx
+++ b/Code/IO/src/sitkShow.cxx
@@ -83,7 +83,7 @@ namespace itk
 
   // Function to replace %tokens in a string.  The tokens are %a and %f for
   // application and file name respectively.  %% will send % to the output string.
-  // Multiple occurances of a token are allowed.
+  // Multiple occurrences of a token are allowed.
   //
   static std::string ReplaceWords(std::string command, std::string app, std::string filename, std::string title, bool& fileFlag)
     {
@@ -471,7 +471,7 @@ namespace itk
     // N.B. Because the launched process may spawn a child process for
     // the acutal application we want, this methods is needed to be
     // called before the GetState, so that we get more then the
-    // imediate result of the initial execution.
+    // immediate result of the initial execution.
     double timeout = ProcessDelay;
     itksysProcess_WaitForExit( kp, &timeout );
 
@@ -516,7 +516,7 @@ namespace itk
         }
         break;
 
-      // these states should not occour, because they are the result
+      // these states should not occur, because they are the result
       // from actions we don't take
       case itksysProcess_State_Expired:
       case itksysProcess_State_Disowned:
@@ -657,7 +657,7 @@ namespace itk
     }
 
 
-  // Replace the string tokens and split the command string into seperate words.
+  // Replace the string tokens and split the command string into separate words.
   CommandLine = ConvertCommand(Command, ExecutableName, TempFile, title);
 
   // run the compiled command-line in a process which will detach

--- a/Documentation/Doxygen/Developer.dox
+++ b/Documentation/Doxygen/Developer.dox
@@ -16,7 +16,7 @@ General information about Gerrit can be found here:
 
 For those already familiar with git, gerrit, ITK and building SimpelITK, here is a quick overview of the process:
 
-The first thing which should be done before any code is commited locally is running the script to setup your local git repository for development.
+The first thing which should be done before any code is committed locally is running the script to setup your local git repository for development.
 
 \code
 $ Utilities/SetupForDevelopment.sh
@@ -95,7 +95,7 @@ git add -- ./Testing/Input/NewInput.png.md5
 
 The SimpleITK Dashboard is a central location where systems report on
 continuous or nightly compilation and testing results. It is a
-invaluable tool in the extreme programing or agile development
+invaluable tool in the extreme programming or agile development
 process. The <a
 href="http://www.cdash.org/CDash/index.php?project=simpleITK">SimpleITK
 dashboard</a> is now a standalone dashboard.
@@ -128,7 +128,7 @@ $ git pull origin
 \endcode
 
 - Next, we need to create a custom CTest script for our system. More
-  information on the varaible are describe in the header of
+  information on the variable are describe in the header of
   "simpleitk_common.cmake". Here is a sample which can be place in
   "~/Dashboards/SimpleITKScripts/simpleitk_nightly.cmake":
 \code
@@ -212,7 +212,7 @@ reduce recompilation. Using <a href="http://ccache.samba.org/">ccache</a>
 can greatly accelerate the development time when rebuilding
 SimpleITK frequently. Usage is quite simple, download and
 install. However, getting CMake to work with the compiler requires
-setting a few enviromental variables:
+setting a few environmental variables:
 
 \verbatim
 CXX=/usr/local/bin/ccache /usr/bin/g++-4.2

--- a/Documentation/Doxygen/FilterTemplates.dox
+++ b/Documentation/Doxygen/FilterTemplates.dox
@@ -13,7 +13,7 @@ generation system to wrap existing ITK filters into SimpleITK filters. The
 development process consists of writing a JSON data file which specifies the
 information needed to fill in the fields of the template file. During
 compilation, all of the .json files are parsed using a lua template engine
-which fills in the apropriate template file from the provided fields. This
+which fills in the appropriate template file from the provided fields. This
 ReadMe provides a detailed description of the fields that can be used in the
 json data files and what effect each field has on the resulting image filter.
 When writing your own json file, it should be saved in:
@@ -123,7 +123,7 @@ must be written for the filter
 additional header files to include in the cxx file for this filter.
 
 - [OPTIONAL] \b custom_set_intput: (\e string)  Code which is used to
-  set input or multiple inputs to the filter. This overides the
+  set input or multiple inputs to the filter. This overrides the
   standard setting of the inputs.
 
 - [OPTIONAL] \b output_pixel_type: (\e string) String representing the specific
@@ -162,7 +162,7 @@ custom method are:
   - \b doc: (\e string) Documentation for this custom method
   - \b name: (\e string) The name of the method
   - \b return_type: (\e string) the return type of the method
-  - [OPTIONAL] \b parameters: (\e list) A list of of parameters for the method.
+  - [OPTIONAL] \b parameters: (\e list) A list of parameters for the method.
   Each method is specified by an object with the following fields:
     - \b type: (\e string) The parameter's type
     - \b var_name: (\e string) The name of the variable to be used in the \b body

--- a/Documentation/Doxygen/MainPage.dox
+++ b/Documentation/Doxygen/MainPage.dox
@@ -35,7 +35,7 @@ https://www.itk.org
 
 This documentation describes the C++ API of the SimpleITK interface
 to the Insight Toolkit. The wrapped languages have a very simular
-interface, that should should only be trivially different.  The
+interface, that should only be trivially different.  The
 Related Pages link presents interface conventions, user and
 developer information. Additionally the Example tab provides a
 variety of example of SimpleITK with different language bindings.

--- a/Examples/BufferImportExport.cxx
+++ b/Examples/BufferImportExport.cxx
@@ -48,7 +48,7 @@ int main( int , char *[] )
   importer.SetSize( std::vector<unsigned int>( 3, 100 ) );
   importer.SetBufferAsUInt8( in );
 
-  // actaully convert the buffer to a simpleITK image
+  // actually convert the buffer to a simpleITK image
   sitk::Image img = importer.Execute();
 
 

--- a/Examples/CSharp/ImageGetBuffer.cs
+++ b/Examples/CSharp/ImageGetBuffer.cs
@@ -37,7 +37,7 @@ namespace itk.simple.examples {
       // Cast to we know the the pixel type
       input = SimpleITK.Cast(input, PixelId.sitkFloat32);
 
-      // calculate the nubmer of pixels
+      // calculate the number of pixels
       VectorUInt32 size = input.GetSize();
       int len = 1;
       for (int dim = 0; dim < input.GetDimension(); dim++) {

--- a/Examples/DicomSeriesReadModifyWrite/DicomSeriesReadModifySeriesWrite.py
+++ b/Examples/DicomSeriesReadModifyWrite/DicomSeriesReadModifySeriesWrite.py
@@ -61,7 +61,7 @@ filtered_image = sitk.DiscreteGaussian(image3D)
 
 # Write the 3D image as a series
 # IMPORTANT: There are many DICOM tags that need to be updated when you modify an
-#            original image. This is a delicate opration and requires knowlege of
+#            original image. This is a delicate opration and requires knowledge of
 #            the DICOM standard. This example only modifies some. For a more complete
 #            list of tags that need to be modified see:
 #                           http://gdcm.sourceforge.net/wiki/index.php/Writing_DICOM

--- a/Examples/ITKIntegration/ITKIntegration.cxx
+++ b/Examples/ITKIntegration/ITKIntegration.cxx
@@ -85,7 +85,7 @@ int main( int argc, char *argv[])
   typedef itk::Image< InternalPixelType, Dimension > InternalImageType;
 
   //
-  // We must check the the image dimension and the pixel type of the
+  // We must check the image dimension and the pixel type of the
   // SimpleITK image match the ITK image we will cast to.s
   //
   if ( image.GetDimension() != Dimension )

--- a/SuperBuild/pcre_configure_step.cmake.in
+++ b/SuperBuild/pcre_configure_step.cmake.in
@@ -1,4 +1,4 @@
-# Set the important envirimental variables that auto-conf uses to
+# Set the important environmental variables that auto-conf uses to
 # configure, mostly these are passed from the CMake
 # configuration. Others are just explicitly passed from the
 # enviroment. If there is a problem with them in the future they can

--- a/SuperBuild/swig_configure_step.cmake.in
+++ b/SuperBuild/swig_configure_step.cmake.in
@@ -1,4 +1,4 @@
-# Set the important envirimental variables that auto-conf uses to
+# Set the important environmental variables that auto-conf uses to
 # configure, mostly these are passed from the CMake
 # configuration. Others are just explicitly passed from the
 # enviroment. If there is a problem with them in the future they can

--- a/Testing/Unit/IOTest.py
+++ b/Testing/Unit/IOTest.py
@@ -20,7 +20,7 @@ from __future__ import print_function
 import SimpleITK as sitk
 import sys
 
-# this test is suppose to test the python interface to the IO classs
+# this test is suppose to test the python interface to the IO classes
 
 if len ( sys.argv ) != 2:
     print( "Usage: %s outputPath" % ( sys.argv[0] ) )

--- a/Testing/Unit/sitkExceptionsTests.cxx
+++ b/Testing/Unit/sitkExceptionsTests.cxx
@@ -82,7 +82,7 @@ TEST_F(sitkExceptionsTest, Test3) {
   e0 = e1;
   e0 = empty;
 
-  // test self assigment too
+  // test self assignment too
   e0 = e0;
 
 

--- a/Wrapping/Python/PythonVirtualEnvInstall.cmake.in
+++ b/Wrapping/Python/PythonVirtualEnvInstall.cmake.in
@@ -37,7 +37,7 @@ execute_process(
   )
 
 if ( failed )
-  message( FATAL_ERROR "Creation of Python virtual enviroment failed.\n${error}" )
+  message( FATAL_ERROR "Creation of Python virtual environment failed.\n${error}" )
 endif()
 
 #

--- a/Wrapping/R/Packaging/SimpleITK/R/zA.R
+++ b/Wrapping/R/Packaging/SimpleITK/R/zA.R
@@ -62,7 +62,7 @@ ImportPixVec <- function(VP)
 }
 
 ## SetPixel and GetPixel methods. We've provided dummy "extends" methods for these.
-## We'll overwite the bindings here
+## We'll overwrite the bindings here
 Image_SetPixel = function(self, idx, v)
 {
   idx = as.integer(idx);

--- a/Wrapping/R/Packaging/SimpleITK/R/zOps.R
+++ b/Wrapping/R/Packaging/SimpleITK/R/zOps.R
@@ -66,7 +66,7 @@ setMethod('%/%', signature(e1="_p_itk__simple__Image", e2="numeric"),
           function(e1, e2) stop("No integer division op for images")
           )
 
-## Math group - names are consistent, so we can do this programatically
+## Math group - names are consistent, so we can do this programmatically
 
 for (nm in c('cos', 'sin', 'tan', 'acos', 'asin', 'atan', 'abs', 'exp', 'sqrt',
             'log', 'log10'))

--- a/Wrapping/R/R.i
+++ b/Wrapping/R/R.i
@@ -56,7 +56,7 @@
 %}
 
 
-// SEXP numeric typemap for array/image converion - SEXP are
+// SEXP numeric typemap for array/image conversion - SEXP are
 // arrays here
 %typemap("rtype") SEXP "numeric";
 


### PR DESCRIPTION
Debian's spellintian from lintian was used from a docker container to
check the code.