### PR TITLE
Only support uint8 pixel types for N4 mask

### DIFF
--- a/Code/BasicFilters/json/N4BiasFieldCorrectionImageFilter.json
+++ b/Code/BasicFilters/json/N4BiasFieldCorrectionImageFilter.json
@@ -1,11 +1,11 @@
 {
   "name" : "N4BiasFieldCorrectionImageFilter",
-  "template_code_filename" : "DualImageFilter",
+  "template_code_filename" : "ImageFilter",
   "template_test_filename" : "ImageFilter",
   "number_of_inputs" : 0,
   "doc" : "Some global documentation",
   "pixel_types" : "RealPixelIDTypeList",
-  "pixel_types2" : "IntegerPixelIDTypeList",
+  "filter_type" : "itk::N4BiasFieldCorrectionImageFilter<InputImageType, itk::Image< uint8_t, TImageType::ImageDimension>, OutputImageType>",
   "inputs" : [
     {
       "name" : "Image",
@@ -13,7 +13,9 @@
     },
     {
       "name" : "MaskImage",
-      "type" : "Image"
+      "type" : "Image",
+      "custom_itk_cast" : "filter->SetMaskImage( this->CastImageToITK<typename FilterType::MaskImageType>(*inMaskImage) );",
+      "optional" : true
     }
   ],
   "members" : [


### PR DESCRIPTION
The established SimpleITK convention is that mask images are
uint8. The prevent combination explosion of supporting multiple
primary input image types each with different mask types.

Additionally, the MaskImage is not marked as optional.