### PR TITLE
Only warn when the source version is not available.

### DIFF
--- a/CMake/sitkSourceVersion.cmake
+++ b/CMake/sitkSourceVersion.cmake
@@ -34,9 +34,16 @@ get_git_head_revision(GIT_REFVAR _GIT_VERSION_HASH)
 # if there is not git directory we should be in a distributed package
 # which should contain this additional cmake file with the
 # _GIT_VERSION variables
-if(_GIT_VERSION_HASH STREQUAL "GITDIR-NOTFOUND")
+if(_GIT_VERSION_HASH STREQUAL "GITDIR-NOTFOUND" AND
+    EXISTS "${CMAKE_CURRENT_LIST_DIR}/sitkSourceVersionVars.cmake" )
   include( "${CMAKE_CURRENT_LIST_DIR}/sitkSourceVersionVars.cmake" )
   return()
+else()
+  message(WARNING "Unable to determine source version!\n
+Please use the git repository or an official source distribution.\n")
+  set(_GIT_VERSION_DEV "")
+  return()
+
 endif()
 
 if(_GIT_VERSION_HASH MATCHES "[a-fA-F0-9]+")


### PR DESCRIPTION
The SimpleITK version expects to be able to determine the version from
a git repository or from saved information from the repository. This
patch not produces a only a warning when the version information is
not properly available. The version will fallback to a non specific
"dev" without a number. This will test less thank any other version,
since it's not a proper version of SimpleITK.