### PR TITLE
BUG: Use of floor division instead of regular division.

### DIFF
--- a/Examples/DemonsRegistration1/DemonsRegistration1.py
+++ b/Examples/DemonsRegistration1/DemonsRegistration1.py
@@ -72,5 +72,8 @@ if ( not "SITK_NOSHOW" in os.environ ):
     out = resampler.Execute(moving)
     simg1 = sitk.Cast(sitk.RescaleIntensity(fixed), sitk.sitkUInt8)
     simg2 = sitk.Cast(sitk.RescaleIntensity(out), sitk.sitkUInt8)
-    cimg = sitk.Compose(simg1, simg2, simg1/2.+simg2/2.)
+    # Use the // floor division operator so that the pixel type is
+    # the same for all three images which is the expectation for
+    # the compose filter.
+    cimg = sitk.Compose(simg1, simg2, simg1//2.+simg2//2.)
     sitk.Show( cimg, "DeformableRegistration1 Composition" )

--- a/Examples/DemonsRegistration2/DemonsRegistration2.py
+++ b/Examples/DemonsRegistration2/DemonsRegistration2.py
@@ -87,5 +87,5 @@ if (not "SITK_NOSHOW" in os.environ):
     out = resampler.Execute(moving)
     simg1 = sitk.Cast(sitk.RescaleIntensity(fixed), sitk.sitkUInt8)
     simg2 = sitk.Cast(sitk.RescaleIntensity(out), sitk.sitkUInt8)
-    cimg = sitk.Compose(simg1, simg2, simg1/2.+simg2/2.)
+    cimg = sitk.Compose(simg1, simg2, simg1//2.+simg2//2.)
     sitk.Show( cimg, "DeformableRegistration1 Composition" )

--- a/Examples/ImageRegistrationMethod1/ImageRegistrationMethod1.py
+++ b/Examples/ImageRegistrationMethod1/ImageRegistrationMethod1.py
@@ -67,5 +67,5 @@ if ( not "SITK_NOSHOW" in os.environ ):
     out = resampler.Execute(moving)
     simg1 = sitk.Cast(sitk.RescaleIntensity(fixed), sitk.sitkUInt8)
     simg2 = sitk.Cast(sitk.RescaleIntensity(out), sitk.sitkUInt8)
-    cimg = sitk.Compose(simg1, simg2, simg1/2.+simg2/2.)
+    cimg = sitk.Compose(simg1, simg2, simg1//2.+simg2//2.)
     sitk.Show( cimg, "ImageRegistration1 Composition" )

--- a/Examples/ImageRegistrationMethod2/ImageRegistrationMethod2.py
+++ b/Examples/ImageRegistrationMethod2/ImageRegistrationMethod2.py
@@ -87,5 +87,5 @@ if ( not "SITK_NOSHOW" in os.environ ):
 
     simg1 = sitk.Cast(sitk.RescaleIntensity(fixed), sitk.sitkUInt8)
     simg2 = sitk.Cast(sitk.RescaleIntensity(out), sitk.sitkUInt8)
-    cimg = sitk.Compose(simg1, simg2, simg1/2.+simg2/2.)
+    cimg = sitk.Compose(simg1, simg2, simg1//2.+simg2//2.)
     sitk.Show( cimg, "ImageRegistration2 Composition" )

--- a/Examples/ImageRegistrationMethod3/ImageRegistrationMethod3.py
+++ b/Examples/ImageRegistrationMethod3/ImageRegistrationMethod3.py
@@ -86,5 +86,5 @@ if ( not "SITK_NOSHOW" in os.environ ):
 
     simg1 = sitk.Cast(sitk.RescaleIntensity(fixed), sitk.sitkUInt8)
     simg2 = sitk.Cast(sitk.RescaleIntensity(out), sitk.sitkUInt8)
-    cimg = sitk.Compose(simg1, simg2, simg1/2.+simg2/2.)
+    cimg = sitk.Compose(simg1, simg2, simg1//2.+simg2//2.)
     sitk.Show( cimg, "ImageRegistration2 Composition" )

--- a/Examples/ImageRegistrationMethod4/ImageRegistrationMethod4.py
+++ b/Examples/ImageRegistrationMethod4/ImageRegistrationMethod4.py
@@ -78,5 +78,5 @@ if ( not "SITK_NOSHOW" in os.environ ):
     out = resampler.Execute(moving)
     simg1 = sitk.Cast(sitk.RescaleIntensity(fixed), sitk.sitkUInt8)
     simg2 = sitk.Cast(sitk.RescaleIntensity(out), sitk.sitkUInt8)
-    cimg = sitk.Compose(simg1, simg2, simg1/2.+simg2/2.)
+    cimg = sitk.Compose(simg1, simg2, simg1//2.+simg2//2.)
     sitk.Show( cimg, "ImageRegistration4 Composition" )

--- a/Examples/ImageRegistrationMethodBSpline1/ImageRegistrationMethodBSpline1.py
+++ b/Examples/ImageRegistrationMethodBSpline1/ImageRegistrationMethodBSpline1.py
@@ -78,5 +78,5 @@ if ( not "SITK_NOSHOW" in os.environ ):
     out = resampler.Execute(moving)
     simg1 = sitk.Cast(sitk.RescaleIntensity(fixed), sitk.sitkUInt8)
     simg2 = sitk.Cast(sitk.RescaleIntensity(out), sitk.sitkUInt8)
-    cimg = sitk.Compose(simg1, simg2, simg1/2.+simg2/2.)
+    cimg = sitk.Compose(simg1, simg2, simg1//2.+simg2//2.)
     sitk.Show( cimg, "ImageRegistration1 Composition" )

--- a/Examples/ImageRegistrationMethodBSpline2/ImageRegistrationMethodBSpline2.py
+++ b/Examples/ImageRegistrationMethodBSpline2/ImageRegistrationMethodBSpline2.py
@@ -86,5 +86,5 @@ if ( not "SITK_NOSHOW" in os.environ ):
     out = resampler.Execute(moving)
     simg1 = sitk.Cast(sitk.RescaleIntensity(fixed), sitk.sitkUInt8)
     simg2 = sitk.Cast(sitk.RescaleIntensity(out), sitk.sitkUInt8)
-    cimg = sitk.Compose(simg1, simg2, simg1/2.+simg2/2.)
+    cimg = sitk.Compose(simg1, simg2, simg1//2.+simg2//2.)
     sitk.Show( cimg, "ImageRegistration1 Composition" )

--- a/Examples/ImageRegistrationMethodDisplacement1/ImageRegistrationMethodDisplacement1.py
+++ b/Examples/ImageRegistrationMethodDisplacement1/ImageRegistrationMethodDisplacement1.py
@@ -133,5 +133,5 @@ if ( not "SITK_NOSHOW" in os.environ ):
     out = resampler.Execute(moving)
     simg1 = sitk.Cast(sitk.RescaleIntensity(fixed), sitk.sitkUInt8)
     simg2 = sitk.Cast(sitk.RescaleIntensity(out), sitk.sitkUInt8)
-    cimg = sitk.Compose(simg1, simg2, simg1/2.+simg2/2.)
+    cimg = sitk.Compose(simg1, simg2, simg1//2.+simg2//2.)
     sitk.Show( cimg, "ImageRegistration1 Composition" )

--- a/Examples/ImageRegistrationMethodExhaustive/ImageRegistrationMethodExhaustive.py
+++ b/Examples/ImageRegistrationMethodExhaustive/ImageRegistrationMethodExhaustive.py
@@ -111,5 +111,5 @@ if ( not "SITK_NOSHOW" in os.environ ):
 
     simg1 = sitk.Cast(sitk.RescaleIntensity(fixed), sitk.sitkUInt8)
     simg2 = sitk.Cast(sitk.RescaleIntensity(out), sitk.sitkUInt8)
-    cimg = sitk.Compose(simg1, simg2, simg1/2.+simg2/2.)
+    cimg = sitk.Compose(simg1, simg2, simg1//2.+simg2//2.)
     sitk.Show( cimg, "ImageRegistrationExhaustive Composition" )


### PR DESCRIPTION
The compose filter expects all inputs to have the same pixel
type. This was not the case when using regular division. Changed it to
floor division.

Change-Id: I9e7dacd9d04f5d4d680c97fa3fcdc14aabfc2da8