### PR TITLE
Updating the documentation of the FilterProgressReporting example.

### DIFF
--- a/Examples/FilterProgressReporting/Documentation.rst
+++ b/Examples/FilterProgressReporting/Documentation.rst
@@ -5,6 +5,96 @@ Filter Progress Reporting
 Overview
 --------
 
+SimpleITK has the ability to add commands or callbacks as observers of
+events that may occur during data processing. This feature can be used to add
+progress reporting to a console, to monitor the process of optimization,
+to abort a process, or to improve the integration of
+SimpleITK into Graphical User Interface event queues.
+
+
+Events
+------
+
+Events are a simple enumerated type in SimpleITK, represented by
+the `EventEnum type <https://itk.org/SimpleITKDoxygen/html/namespaceitk_1_1simple.html#aa7399868984d99493c5a307cce373ace>`_.
+More information about each event type can be found in the documentation
+for the enum. All SimpleITK filters, including the reading
+and writing ones, are derived from the ProcessObject class which has
+support for events. SimpleITK utilizes the native ITK event system
+but has simpler events and methods to add an observer or commands. The goal
+is to provide a simpler interface more suitable for scripting
+languages.
+
+Commands
+--------
+
+The command design pattern is used to allow user code to be executed
+when an event occurs. It is encapsulated in the Command class. The
+Command class provides a virtual Execute method to be overridden in
+derived classes. Additionally, SimpleITK provides internal reference
+tracking between the ProcessObject and the Command. This reference tracking
+allows an object to be created on the stack or dynamically allocated, without
+additional burden.
+
+Command Directors for Wrapped Languages
+---------------------------------------
+SimpleITK uses SWIG's director feature to enable wrapped languages to
+derive classes from the Command class.  Thus a user may  override the
+Command class's Execute method for custom call-backs. The following
+languages support deriving classes from the Command class:
+
+Python
+......
+.. literalinclude:: FilterProgressReporting.py
+   :language: python
+   :start-after: [python director command]
+   :end-before: [python director command]
+
+Java
+....
+.. literalinclude:: FilterProgressReporting.java
+   :language: java
+   :start-after: sphinx_start_command_inheritance
+   :end-before: sphinx_end_command_inheritance
+
+CSharp
+......
+.. literalinclude:: FilterProgressReporting.cs
+   :language: c#
+   :start-after: [csharp director command]
+   :end-before: [csharp director command]
+
+Ruby
+....
+.. literalinclude:: FilterProgressReporting.rb
+   :language: ruby
+   :start-after: [ruby director command]
+   :end-before: [ruby director command]
+
+
+Command Functions and Lambdas for Wrapped Languages
+---------------------------------------------------
+
+Not all scripting languages are naturally object oriented, and it is
+often easier to simply define a callback inline with a lambda
+function. The following language supports inline function definitions
+for functions for the ProcessObject::AddCommand method:
+
+Python
+......
+.. literalinclude:: FilterProgressReporting.py
+   :language: python
+   :start-after: [python lambda command]
+   :end-before: [python lambda command]
+
+R
+.
+.. literalinclude:: FilterProgressReporting.R
+   :language: r
+   :start-after: [R lambda command]
+   :end-before: [R lambda command]
+
+
 
 Code
 ----

--- a/Examples/FilterProgressReporting/Documentation.rst
+++ b/Examples/FilterProgressReporting/Documentation.rst
@@ -54,8 +54,8 @@ Java
 ....
 .. literalinclude:: FilterProgressReporting.java
    :language: java
-   :start-after: sphinx_start_command_inheritance
-   :end-before: sphinx_end_command_inheritance
+   :start-after: [java director command]
+   :end-before: [java director command]
 
 CSharp
 ......

--- a/Examples/FilterProgressReporting/FilterProgressReporting.R
+++ b/Examples/FilterProgressReporting/FilterProgressReporting.R
@@ -27,7 +27,7 @@ args <- commandArgs( TRUE )
 
 if (length(args) <  3){
    write("Usage arguments: <input> <variance> <output>", stderr())
-   quit(1)
+   quit(save="no", status=1)
 }
 
 reader <- ImageFileReader()
@@ -41,10 +41,8 @@ gaussian$SetVariance( as.numeric(args[2]) )
 
 ##! [R lambda command]
 gaussian$AddCommand( 'sitkStartEvent',  function(method) {cat("StartEvent\n")} )
+gaussian$AddCommand( 'sitkEndEvent',  function(method) {cat("EndEvent\n")} )
 ##! [R lambda command]
-
-cmd <- RCommand()
-gaussian$AddCommand( 'sitkEndEvent', cmd )
 
 image = gaussian$Execute( image )
 

--- a/Examples/FilterProgressReporting/FilterProgressReporting.java
+++ b/Examples/FilterProgressReporting/FilterProgressReporting.java
@@ -18,7 +18,7 @@
 
 import org.itk.simple.*;
 
-//sphinx_start_command_inheritance
+//! [java director command]
 class MyCommand  extends Command {
 
   private ProcessObject m_ProcessObject;
@@ -33,7 +33,7 @@ class MyCommand  extends Command {
     System.out.format("%s Progress: %f\n", m_ProcessObject.getName(), progress);
   }
 }
-//sphinx_end_command_inheritance
+//! [java director command]
 
 class FilterProgressReporting {
 

--- a/Examples/FilterProgressReporting/FilterProgressReporting.java
+++ b/Examples/FilterProgressReporting/FilterProgressReporting.java
@@ -18,6 +18,7 @@
 
 import org.itk.simple.*;
 
+//sphinx_start_command_inheritance
 class MyCommand  extends Command {
 
   private ProcessObject m_ProcessObject;
@@ -32,6 +33,7 @@ class MyCommand  extends Command {
     System.out.format("%s Progress: %f\n", m_ProcessObject.getName(), progress);
   }
 }
+//sphinx_end_command_inheritance
 
 class FilterProgressReporting {
 

--- a/Examples/FilterProgressReporting/FilterProgressReporting.rb
+++ b/Examples/FilterProgressReporting/FilterProgressReporting.rb
@@ -22,9 +22,10 @@ if ARGV.length != 3 then
   exit( 1 )
 end
 
-## [ruby director command]
+
 # Derive a class from SimpleITK Command class to be used to observe
 # events and report progress.
+## [ruby director command]
 class MyCommand < Simpleitk::Command
   def initialize(po)
     # Explicit call to supoer class initlaizer is required to


### PR DESCRIPTION
The documentation is a duplicate of the Doxygen page with some minor
modifications. The doxygen markup is also used in the sphinx
documentation. Before we can remove the doxygen page we need to
figure out how to link between the doxygen generated pages to the
sphinx generated pages on readthedocs. There are references from some
classes to the documentation in the sphinx/doxygen example page.

Change-Id: Ic15f4e6f51f3079a4ade058bfe4003fccbe1f599