### PR TITLE
Additional R cmake link options for building the R package under windows

### DIFF
--- a/CMake/sitkLanguageOptions.cmake
+++ b/CMake/sitkLanguageOptions.cmake
@@ -229,10 +229,12 @@ endif( )
 option ( WRAP_R "Wrap R" ${WRAP_R_DEFAULT} )
 
 if ( WRAP_R )
+	set (R_EXTRA_LINK_FLAGS "" CACHE STRING "Extra flags required for linking the R library") 
   list( APPEND SITK_LANGUAGES_VARS
     R_INCLUDE_DIR
     R_LIBRARIES
     R_LIBRARY_BASE
+    R_EXTRA_LINK_FLAGS
     R_COMMAND
     RSCRIPT_EXECUTABLE )
 endif()

--- a/Wrapping/R/CMakeLists.txt
+++ b/Wrapping/R/CMakeLists.txt
@@ -28,7 +28,7 @@ target_include_directories( ${SWIG_MODULE_SimpleITK_TARGET_NAME}
 set_source_files_properties(${swig_generated_file_fullname} PROPERTIES COMPILE_FLAGS "-w")
 
 # set the output directory for the R library to the binary packaging location
-set_target_properties( ${SWIG_MODULE_SimpleITK_TARGET_NAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Packaging/SimpleITK/src/)
+set_target_properties( ${SWIG_MODULE_SimpleITK_TARGET_NAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Packaging/SimpleITK/src/ LINK_FLAGS "${R_EXTRA_LINK_FLAGS}")
 
 sitk_strip_target( ${SWIG_MODULE_SimpleITK_TARGET_NAME} )
 set(SWIG_MODULE_SimpleITKR_TARGET_NAME "${SWIG_MODULE_SimpleITK_TARGET_NAME}")


### PR DESCRIPTION
I've added an extra CMAKE variable to contain the windows link extras. I couldn't get it to work any other way. The final cmake config command will be:

cmake -G Ninja ../SimpleITK/SuperBuild \
-DCMAKE_CXX_FLAGS="--param ggc-min-expand=0 --param ggc-min-heapsize=2648000" \
-DR_COMMAND="${R64}" -DR_LIBRARY_BASE="${R64DLL}" \
-DR_EXTRA_LINK_FLAGS="-s -static-libgcc -static-libstdc++ -static -lpthread"\
 -DWRAP_R=ON -DWRAP_DEFAULT=OFF 

This eliminates the windows-specific parts from the cmake files.
