### PR TITLE
Add template for disambiguation in TypeList with GCC

### DIFF
--- a/CMake/sitkCheckTemplateDisambiguation.cmake
+++ b/CMake/sitkCheckTemplateDisambiguation.cmake
@@ -1,0 +1,12 @@
+# CMake Module to check for usage of the `template` keyword to
+# disambiguate dependent name look ups.
+#
+# More information can be found about this usage case here:
+#  http://en.cppreference.com/w/cpp/language/dependent_name Under the
+# heading "The typename disambiguator for dependent names".
+
+
+
+try_compile(SITK_HAS_TEMPLATE_DISAMBIGUATOR_DEPENDENT_NAME
+  "${PROJECT_BINARY_DIR}/CMakeTmp"
+  "${CMAKE_CURRENT_LIST_DIR}/sitkCheckTemplateDisambiguation.cxx")

--- a/CMake/sitkCheckTemplateDisambiguation.cxx
+++ b/CMake/sitkCheckTemplateDisambiguation.cxx
@@ -1,0 +1,24 @@
+template<typename T>
+struct A
+{
+  template <typename U>
+  void f() {};
+};
+
+template<typename T>
+void g()
+{
+  A<T> obj;
+
+  // The following `template` keyword is required by C++0x, but some
+  // compilers don't allow it.
+  obj.template f<T>();
+}
+
+
+int main(void)
+{
+  g<int>();
+
+  return 0;
+}

--- a/Code/Common/CMakeLists.txt
+++ b/Code/Common/CMakeLists.txt
@@ -8,6 +8,8 @@ set( SITK_INT64_PIXELIDS ${SimpleITK_INT64_PIXELIDS} )
 set( SITK_4D_IMAGES ${SimpleITK_4D_IMAGES} )
 set( SITK_EXPLICIT_INSTANTIATION ${SimpleITK_EXPLICIT_INSTANTIATION} )
 
+include(sitkCheckTemplateDisambiguation)
+
 configure_file( "src/sitkConfigure.h.in" "include/sitkConfigure.h" )
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/include/sitkConfigure.h"
   DESTINATION "${SimpleITK_INSTALL_INCLUDE_DIR}"

--- a/Code/Common/include/sitkMacro.h
+++ b/Code/Common/include/sitkMacro.h
@@ -68,6 +68,13 @@
 #define SITK_NOEXCEPT throw()
 #endif
 
+#if defined(SITK_HAS_TEMPLATE_DISAMBIGUATOR_DEPENDENT_NAME)
+#define CLANG_TEMPLATE template
+#else
+#define CLANG_TEMPLATE
+#endif
+
+
 
 #if  !defined(SITK_RETURN_SELF_TYPE_HEADER)
 #define SITK_RETURN_SELF_TYPE_HEADER Self &

--- a/Code/Common/src/sitkConfigure.h.in
+++ b/Code/Common/src/sitkConfigure.h.in
@@ -44,16 +44,14 @@
 #cmakedefine SITK_HAS_TR1_TYPE_TRAITS
 #cmakedefine SITK_HAS_TR1_UNORDERED_MAP
 
+// defined if compiler supports using template keyword to disambiguate
+// dependent names
+#cmakedefine SITK_HAS_TEMPLATE_DISAMBIGUATOR_DEPENDENT_NAME
+
 #cmakedefine SITK_INT64_PIXELIDS
 #cmakedefine SITK_4D_IMAGES
 
 #cmakedefine SITK_EXPLICIT_INSTANTIATION
-
-#if defined(__clang__)
-#define CLANG_TEMPLATE template
-#else
-#define CLANG_TEMPLATE
-#endif
 
 // Include ITK version reported in CMake with SITK prefix, so that
 // SimpleITK dosen't need ITK header in our headers.


### PR DESCRIPTION
GCC 7 now requires template keyword for disambiguation in the
TypeLists. This has been required by clang, and supported by GCC, but
not supported by older MSVC.

closes #249 