### PR TITLE
Use native path for R_LIBS

### DIFF
--- a/CMake/sitkAddTest.cmake
+++ b/CMake/sitkAddTest.cmake
@@ -229,8 +229,9 @@ function(sitk_add_r_test name)
     ${ARGN}
     )
 
+  file(TO_NATIVE_PATH "${SimpleITK_BINARY_DIR}/Wrapping/R/R_libs" _native_path)
   set_property(TEST R.${name}
-    PROPERTY ENVIRONMENT R_LIBS=${SimpleITK_BINARY_DIR}/Wrapping/R/R_libs/
+    PROPERTY ENVIRONMENT R_LIBS=${_native_path}
     )
 endfunction()
 


### PR DESCRIPTION
The CMake style path for R_LIBS is not detecting as existing for R, so
it was ignored. Also the trailing slash must be removed on the windows
platform.