### PR TITLE
Reduce the tolerance for a LandmarkBasedTransformInitializer test

### DIFF
--- a/Testing/Unit/sitkBasicFiltersTests.cxx
+++ b/Testing/Unit/sitkBasicFiltersTests.cxx
@@ -693,10 +693,10 @@ TEST(BasicFilters,LandmarkBasedTransformInitializer) {
   EXPECT_ANY_THROW( filter.Execute( sitk::VersorTransform() ) );
 
   out = filter.Execute( sitk::VersorRigid3DTransform() );
-  EXPECT_VECTOR_DOUBLE_NEAR(v6(0.0, 0.0, 0.0, 0.0, 0.0, 0.0), out.GetParameters(), 1e-25);
+  EXPECT_VECTOR_DOUBLE_NEAR(v6(0.0, 0.0, 0.0, 0.0, 0.0, 0.0), out.GetParameters(), 1e-15);
 
   out = filter.Execute( sitk::ScaleVersor3DTransform() );
-  EXPECT_VECTOR_DOUBLE_NEAR(v9(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0), out.GetParameters(), 1e-25);
+  EXPECT_VECTOR_DOUBLE_NEAR(v9(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0), out.GetParameters(), 1e-15);
 
 
   out = filter.Execute( sitk::AffineTransform(2) );


### PR DESCRIPTION
With GCC 5.3.1 compiled with "-m32" for i386 architecture the
following test failures occurred:

/scratch/dashboards/SimpleITK-RHEL7-devtool-4-next-m32/SimpleITK/Testing/Unit/sitkBasicFiltersTests.cxx:696:
Failure
The RMS difference between v6(0.0, 0.0, 0.0, 0.0, 0.0, 0.0) and
out.GetParameters() is 2.6893281883974999e-17,
  which exceeds 1e-25

/scratch/dashboards/SimpleITK-RHEL7-devtool-4-next-m32/SimpleITK/Testing/Unit/sitkBasicFiltersTests.cxx:699:
Failure
The RMS difference between v9(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0,
1.0) and out.GetParameters() is 2.6893281883974999e-17,
  which exceeds 1e-25

The difference in tolerance is due to different floating point
precision of FPUs used.