### PR TITLE
Add ITK_GIT_TAG and ITK_GIT_REPOSITORY variables for Superbuild

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -41,17 +41,22 @@ VariableListToArgs( ITK_VARS  ep_itk_args )
 
 
 set(proj ITK)  ## Use ITK convention of calling it ITK
-if(NOT DEFINED ITK_REPOSITORY)
-  set(ITK_REPOSITORY "${git_protocol}://itk.org/ITK.git")
-endif()
+
+
+set(ITK_GIT_REPOSITORY "${git_protocol}://itk.org/ITK.git" CACHE STRING "URL of ITK Git repository")
+mark_as_advanced(ITK_GIT_REPOSITORY)
+sitk_legacy_naming(ITK_GIT_REPOSITORY ITK_REPOSITORY)
+
+# NOTE: it is very important to update the ITK_DIR path with the ITK version
+set(ITK_GIT_TAG "v4.12.0" CACHE STRING "Tag in ITK git repo")
+mark_as_advanced(ITK_GIT_TAG)
+set(ITK_TAG_COMMAND GIT_TAG "${ITK_GIT_TAG}")
 
 set(ITK_USE_GIT_PROTOCOL 0)
 if("${git_protocol}" STREQUAL "git")
   set(ITK_USE_GIT_PROTOCOL 1)
 endif()
 
-# NOTE: it is very important to update the ITK_DIR path with the ITK version
-set(ITK_TAG_COMMAND GIT_TAG v4.12.0) # 4.12.0 tag
 
 if( ${BUILD_SHARED_LIBS} )
   set( ITK_BUILD_SHARED_LIBS ON )
@@ -66,7 +71,7 @@ endif()
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/${proj}-build/CMakeCacheInit.txt" "${ep_itk_cache}\n${ep_common_cache}" )
 
 ExternalProject_Add(${proj}
-  GIT_REPOSITORY ${ITK_REPOSITORY}
+  GIT_REPOSITORY ${ITK_GIT_REPOSITORY}
   ${ITK_TAG_COMMAND}
   UPDATE_COMMAND ""
   SOURCE_DIR ${proj}


### PR DESCRIPTION
Adding these advanced options to the SimpleITK Superbuild allows for
easy experimentation against development versions of ITK and usage of
faster repository. The ITK_REPOSITORY variable is now a legacy option
in favor of ITK_GIT_REPOSITORY.