### PR TITLE
Fix R package data with SimpleITK_FORBID_DOWNLOADS enabled

### DIFF
--- a/Wrapping/R/CMakeLists.txt
+++ b/Wrapping/R/CMakeLists.txt
@@ -69,52 +69,49 @@ configure_file(
     "${CMAKE_CURRENT_BINARY_DIR}/Packaging/SimpleITK/DESCRIPTION"
     @ONLY )
 
-# download sample images and tar of Rd files, if allowed
-if(NOT SimpleITK_FORBID_DOWNLOADS)
-  include(sitkExternalData)
+# Use ExternalData module to either download data to get from local
+# data store.
+include(sitkExternalData)
 
+file( GLOB_RECURSE image_links RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/Packaging/SimpleITK/data/*.md5" )
 
-  file( GLOB_RECURSE image_links RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/Packaging/SimpleITK/data/*.md5" )
-
-  foreach(link ${image_links})
-    string( REGEX REPLACE "\\.md5$" "" link ${link} )
-    ExternalData_Expand_Arguments(  SimpleITKRpackageData
-      image_location
-      DATA{${link}}
-      )
-    set( COPY_DATA_COMMAND ${COPY_DATA_COMMAND} COMMAND ${CMAKE_COMMAND} -E copy ${image_location} ${CMAKE_CURRENT_BINARY_DIR}/Packaging/SimpleITK/data/ )
-  endforeach()
-
-
-  # The downloaded tar ball of documentation has been generated with
-  # the "Utilities/GenerateDocs/SwigDocUpdate.sh". This documentation
-  # should be generated for each release.
-  file( GLOB_RECURSE doc_links RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/Packaging/SimpleITK/man/*.md5" )
-
-  foreach(link ${doc_links})
-    string( REGEX REPLACE "\\.md5$" "" link ${link} )
-    ExternalData_Expand_Arguments(  SimpleITKRpackageData
-      doc_location
-      DATA{${link}}
-      )
-    set( EXTRACT_RMAN_COMMAND  ${EXTRACT_RMAN_COMMAND} COMMAND ${CMAKE_COMMAND} -E tar xzf ${doc_location}
-      WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/Packaging/SimpleITK/man/" )
-  endforeach()
-
-
-  if(COMMAND ExternalData_Add_Target )
-    ExternalData_Add_Target( SimpleITKRpackageData )
-  endif()
-  add_dependencies( ${SWIG_MODULE_SimpleITK_TARGET_NAME} SimpleITKRpackageData )
-
-  # copy sample images and extract documentation - used in vignette
-  add_custom_command( TARGET ${SWIG_MODULE_SimpleITK_TARGET_NAME}
-    PRE_BUILD
-      ${COPY_DATA_COMMAND}
-      ${EXTRACT_RMAN_COMMAND}
+foreach(link ${image_links})
+  string( REGEX REPLACE "\\.md5$" "" link ${link} )
+  ExternalData_Expand_Arguments(  SimpleITKRpackageData
+    image_location
+    DATA{${link}}
     )
+  set( COPY_DATA_COMMAND ${COPY_DATA_COMMAND} COMMAND ${CMAKE_COMMAND} -E copy ${image_location} ${CMAKE_CURRENT_BINARY_DIR}/Packaging/SimpleITK/data/ )
+endforeach()
 
+
+# The downloaded tar ball of documentation has been generated with
+# the "Utilities/GenerateDocs/SwigDocUpdate.sh". This documentation
+# should be generated for each release.
+file( GLOB_RECURSE doc_links RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/Packaging/SimpleITK/man/*.md5" )
+
+foreach(link ${doc_links})
+  string( REGEX REPLACE "\\.md5$" "" link ${link} )
+  ExternalData_Expand_Arguments(  SimpleITKRpackageData
+    doc_location
+    DATA{${link}}
+    )
+  set( EXTRACT_RMAN_COMMAND  ${EXTRACT_RMAN_COMMAND} COMMAND ${CMAKE_COMMAND} -E tar xzf ${doc_location}
+    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/Packaging/SimpleITK/man/" )
+endforeach()
+
+
+if(COMMAND ExternalData_Add_Target )
+  ExternalData_Add_Target( SimpleITKRpackageData )
 endif()
+add_dependencies( ${SWIG_MODULE_SimpleITK_TARGET_NAME} SimpleITKRpackageData )
+
+# copy sample images and extract documentation - used in vignette
+add_custom_command( TARGET ${SWIG_MODULE_SimpleITK_TARGET_NAME}
+  PRE_BUILD
+  ${COPY_DATA_COMMAND}
+  ${EXTRACT_RMAN_COMMAND}
+  )
 
 if(BUILD_SHARED_LIBS AND DEFINED SimpleITK_LIBRARY_OUTPUT_DIRECTORY)
   if(TARGET itkTestDriver)


### PR DESCRIPTION
The R packaging data is specified with the ExternalData CMake
mechanism. These function already support the
SimpleITK_FORBID_DOWNLOADS option by only supporting local data stores
and not URLs. So the conditional around the R packaging data has been
removed to enable the R packing data and documentation when only a
local data store is available.