### PR TITLE
Do not create /.git folder when the project is configured

### DIFF
--- a/CMake/sitkCheckSourceTree.cmake
+++ b/CMake/sitkCheckSourceTree.cmake
@@ -3,8 +3,8 @@ if(EXISTS "${SimpleITK_SOURCE_DIR}/.git/config" AND
     NOT EXISTS "${SimpleITK_SOURCE_DIR}/.git/hooks/pre-commit")
   # Silently ignore the error if the hooks directory is read-only.
   execute_process(
-    COMMAND ${CMAKE_COMMAND} -E copy ${ITK_SOURCE_DIR}/CMake/pre-commit
-                                     ${ITK_SOURCE_DIR}/.git/hooks/pre-commit
+    COMMAND ${CMAKE_COMMAND} -E copy ${SimpleITK_SOURCE_DIR}/CMake/pre-commit
+                                     ${SimpleITK_SOURCE_DIR}/.git/hooks/pre-commit
     OUTPUT_VARIABLE _output
     ERROR_VARIABLE  _output
     RESULT_VARIABLE _result


### PR DESCRIPTION
A .git folder kept popping up on in the root folder of my and many of my coworkers' computers.
It was really annoying, because it confused git clients to think that all folder is under revision control
and we had to delete the folder manually. After that the .git folder appeared again, and again...
It remained a mystery for several years ... until now.

We've finally found the culprit: it was a copy-paste error in sitkCheckSourceTree.cmake.
This commit fixes the issue.