### PR TITLE
Change to vector argument for sigma and variance of Gaussian

### DIFF
--- a/Code/BasicFilters/include/sitkAdditionalProcedures.h
+++ b/Code/BasicFilters/include/sitkAdditionalProcedures.h
@@ -100,6 +100,29 @@ SITKBasicFilters_EXPORT Image PatchBasedDenoising (const Image& image1,
 #endif
 
 
+
+
+    /**
+     * \brief Blurs an image by separable convolution with discrete gaussian kernels. This filter performs Gaussian blurring by separable convolution of an image and a discrete Gaussian operator (kernel).
+     *
+     * This function directly calls the execute method of DiscreteGaussianImageFilter
+     * in order to support a procedural API
+     *
+     * \sa itk::simple::DiscreteGaussianImageFilter for the object oriented interface
+     */
+     SITKBasicFilters_EXPORT Image DiscreteGaussian ( const Image& image1, double variance, unsigned int maximumKernelWidth = 32u, double maximumError =  0.01, bool useImageSpacing = true );
+
+
+    /**
+     * \brief Computes the smoothing of an image by convolution with the Gaussian kernels implemented as IIR filters.
+     *
+     * This function directly calls the execute method of SmoothingRecursiveGaussianImageFilter
+     * in order to support a procedural API
+     *
+     * \sa itk::simple::SmoothingRecursiveGaussianImageFilter for the object oriented interface
+     */
+     SITKBasicFilters_EXPORT Image SmoothingRecursiveGaussian ( const Image& image1, double sigma, bool normalizeAcrossScale = false );
+
 }
 }
 #endif

--- a/Code/BasicFilters/json/DiscreteGaussianImageFilter.json
+++ b/Code/BasicFilters/json/DiscreteGaussianImageFilter.json
@@ -9,7 +9,10 @@
     {
       "name" : "Variance",
       "type" : "double",
-      "default" : "1.0",
+      "default" : "std::vector<double>(3,1.0)",
+      "dim_vec" : 1,
+      "set_as_scalar" : 1,
+      "itk_type" : "typename FilterType::ArrayType",
       "briefdescriptionSet" : "",
       "detaileddescriptionSet" : "",
       "briefdescriptionGet" : "",
@@ -27,7 +30,10 @@
     {
       "name" : "MaximumError",
       "type" : "double",
-      "default" : "0.01",
+      "default" : "std::vector<double>(3, 0.01)",
+      "dim_vec" : 1,
+      "set_as_scalar" : 1,
+      "itk_type" : "typename FilterType::ArrayType",
       "briefdescriptionSet" : "",
       "detaileddescriptionSet" : "",
       "briefdescriptionGet" : "",
@@ -68,7 +74,14 @@
       "settings" : [
         {
           "parameter" : "Variance",
-          "value" : "100.0"
+          "value" : "100.0",
+          "type" : "double",
+          "dim_vec" : 1,
+          "value" : [
+            100.0,
+            100.0,
+            100.0
+          ]
         },
         {
           "parameter" : "MaximumKernelWidth",

--- a/Code/BasicFilters/json/GaussianImageSource.json
+++ b/Code/BasicFilters/json/GaussianImageSource.json
@@ -74,7 +74,12 @@
       "default" : "std::vector<double>()",
       "doc" : "Passing a zero sized array, defaults to identiy matrix. The size of the array must exactly match the direction matrix for the dimension of the image.",
       "custom_itk_cast" : "filter->SetDirection( sitkSTLToITKDirection<typename FilterType::DirectionType>( this->m_Direction ) );"
-    }
+    },
+      {
+"name" : "Normalized",
+"type" : "bool",
+"default" : "false"
+}
   ],
   "tests" : [
     {

--- a/Code/BasicFilters/json/SmoothingRecursiveGaussianImageFilter.json
+++ b/Code/BasicFilters/json/SmoothingRecursiveGaussianImageFilter.json
@@ -10,7 +10,11 @@
     {
       "name" : "Sigma",
       "type" : "double",
-      "default" : "1.0",
+      "default" : "std::vector<double>(3,1.0)",
+      "dim_vec" : 1,
+      "set_as_scalar" : 1,
+      "itk_type" : "typename FilterType::SigmaArrayType",
+      "custom_itk_cast" :  "typename FilterType::SigmaArrayType itkVecSigma = sitkSTLVectorToITK<typename FilterType::SigmaArrayType>( this->GetSigma() );\n  filter->SetSigmaArray( itkVecSigma );",
       "doc" : "",
       "briefdescriptionSet" : "",
       "detaileddescriptionSet" : "Set Sigma value. Sigma is measured in the units of image spacing. You may use the method SetSigma to set the same value across each axis or use the method SetSigmaArray if you need different values along each axis.",
@@ -44,7 +48,13 @@
       "settings" : [
         {
           "parameter" : "Sigma",
-          "value" : "5.0"
+          "type" : "double",
+          "dim_vec" : 1,
+          "value" : [
+            5.0,
+            5.0,
+            5.0
+          ]
         }
       ],
       "tolerance" : 1e-05,

--- a/Code/BasicFilters/src/sitkAdditionalProcedures.cxx
+++ b/Code/BasicFilters/src/sitkAdditionalProcedures.cxx
@@ -19,6 +19,8 @@
 #include "sitkAdditionalProcedures.h"
 #include "sitkResampleImageFilter.h"
 #include "sitkPatchBasedDenoisingImageFilter.h"
+#include "sitkDiscreteGaussianImageFilter.h"
+#include "sitkSmoothingRecursiveGaussianImageFilter.h"
 
 namespace itk {
 namespace simple {
@@ -133,6 +135,33 @@ SITKBasicFilters_EXPORT Image PatchBasedDenoising (const Image& image1,
 
   return filter.Execute ( image1 );
 }
+
+
+//
+// Function to run the Execute method of this filter
+//
+Image DiscreteGaussian ( const Image& image1, double variance, unsigned int maximumKernelWidth, double maximumError, bool useImageSpacing )
+{
+  DiscreteGaussianImageFilter filter;
+  filter.SetVariance(variance);
+  filter.SetMaximumKernelWidth(maximumKernelWidth);
+  filter.SetMaximumError(maximumError);
+  filter.SetUseImageSpacing(useImageSpacing);
+  return filter.Execute ( image1 );
+}
+
+//
+// Function to run the Execute method of this filter
+//
+Image SmoothingRecursiveGaussian ( const Image& image1, double sigma, bool normalizeAcrossScale )
+{
+  SmoothingRecursiveGaussianImageFilter filter;
+  filter.SetSigma(sigma);
+  filter.SetNormalizeAcrossScale(normalizeAcrossScale);
+  return filter.Execute(image1);
+}
+
+
 
 }
 }


### PR DESCRIPTION
Enable setting of the sigmas/variance on a per axis basis for the
SmoothingRecursiveGaussianImageFilter and the
DiscreteGaussianImageFilter. This is done may changing the parameter
to be a "dim_vec". The scalar method for the object oriented interface
remains.

Additionally, the signature of scalar procedural remains as part of
the Additional procedural interface.

closes #163