### PR TITLE
BUG: Fix setting of LBFGSB lowerbound

### DIFF
--- a/Code/Registration/src/sitkImageRegistrationMethod_CreateOptimizer.cxx
+++ b/Code/Registration/src/sitkImageRegistrationMethod_CreateOptimizer.cxx
@@ -214,7 +214,7 @@ namespace simple
       _OptimizerType::BoundValueType upperBound( numberOfTransformParameters );
 
       boundSelection.Fill( sitkToITK[flag] );
-      lowerBound.Fill( this->m_OptimizerUpperBound );
+      lowerBound.Fill( this->m_OptimizerLowerBound );
       upperBound.Fill( this->m_OptimizerUpperBound );
 
       optimizer->SetBoundSelection( boundSelection );


### PR DESCRIPTION
The incorrect bound was used for setting itk's lower bound. This has
been corrected and a test has been added to verify the functionality.