### PR TITLE
Unset CMake cache variables like ^SimpleITKBasicFiltersGeneratedSource_

### DIFF
--- a/CMake/sitkGenerateFilterSource.cmake
+++ b/CMake/sitkGenerateFilterSource.cmake
@@ -218,7 +218,7 @@ macro(generate_filter_source)
   get_cmake_property( _varNames VARIABLES )
   foreach (_varName ${_varNames})
     if(_varName MATCHES "^SimpleITKBasicFiltersGeneratedSource_")
-      unset(${varName} CACHE)
+      unset(${_varName} CACHE)
     endif()
   endforeach()
 


### PR DESCRIPTION
This variable was just accumulating in length with each CMake
configuration.