### PR TITLE
Add interface for reading image information and meta data

### DIFF
--- a/Code/IO/include/sitkImageFileReader.h
+++ b/Code/IO/include/sitkImageFileReader.h
@@ -31,11 +31,16 @@ namespace itk {
   namespace simple {
 
     /** \class ImageFileReader
-     * \brief Read a 2D or 3D image and return a smart pointer to a SimpleITK
-     * image
+     * \brief Read an image file and return a SimpleITK Image.
      *
-     * This reader handles scalar and vector images and returns an image with
-     * the same type as the file on disk.
+     * The reader can handle scalar images, and vector images. Pixel
+     * types such as RGB, RGBA are loaded as multi-component
+     * images with vector pixel types. Additionally, tensor images are
+     * loaded with the pixel type being a 1-d vector.
+     *
+     * An interface is also provided to access the information from
+     * the underlying itk::ImageIO. This information can be loaded
+     * with the ReadImageInformation method.
      *
      * \sa itk::simple::ReadImage for the procedural interface
      */
@@ -65,7 +70,7 @@ namespace itk {
       /** \brief Read only the meta-data and image information in the file.
        *
        * This method can be used to determine what the size and pixel
-       * type of an image file is with out reading the whole
+       * type of an image file is without reading the whole
        * image. Even if SimpleITK does not support an image of a
        * certain dimension or type, the meta-information can still be
        * read.
@@ -80,6 +85,10 @@ namespace itk {
        * is based of the file format, so the number of components for
        * internal types such as RGB or complex may not be described
        * the same as with SimpleITK's Image interface.
+       *
+       * The PixelID has been converted from the ITK type to
+       * SimpleITK's interpretation, and will not change when loaded
+       * as a SimpleITK Image.
        * @{
        */
       PixelIDValueEnum GetPixelID( void ) const;

--- a/Code/IO/include/sitkImageFileReader.h
+++ b/Code/IO/include/sitkImageFileReader.h
@@ -23,7 +23,11 @@
 #include "sitkImageReaderBase.h"
 #include "sitkMemberFunctionFactory.h"
 
+
 namespace itk {
+
+  class MetaDataDictionary;
+
   namespace simple {
 
     /** \class ImageFileReader
@@ -54,9 +58,73 @@ namespace itk {
 
       ImageFileReader();
 
+      // Interface methods to access image file's meta-data and image
+      // information after calling Execute or after calling
+      // MetaDataRead, which does not load the bulk pixel data.
+
+      /** \brief Read only the meta-data and image information in the file.
+       *
+       * This method can be used to determine what the size and pixel
+       * type of an image file is with out reading the whole
+       * image. Even if SimpleITK does not support an image of a
+       * certain dimension or type, the meta-information can still be
+       * read.
+       */
+      void ReadImageInformation(void);
+
+      /** \brief Image information methods updated via ReadImageInformation
+       *
+       * These accessor methods are valid after a call to ReadImageInformation
+       * or Execute. They contain the image information from the file
+       * via the itk::ImageIO. Information such as NumberOfComponents
+       * is based of the file format, so the number of components for
+       * internal types such as RGB or complex may not be described
+       * the same as with SimpleITK's Image interface.
+       * @{
+       */
+      PixelIDValueEnum GetPixelID( void ) const;
+      PixelIDValueType GetPixelIDValue( void ) const;
+      unsigned int GetDimension( void ) const;
+      unsigned int GetNumberOfComponents( void ) const;
+      const std::vector<double> &GetOrigin( void ) const;
+      const std::vector<double> &GetSpacing( void ) const;
+      const std::vector<double> &GetDirection() const;
+      const std::vector<uint64_t> &GetSize( void ) const;
+      /* @} */
+
+      /** \brief Get the meta-data dictionary keys
+       *
+       * This is only valid after successful ReadImageInformation or Execute
+       * of this filter.
+       *
+       * Returns a vector of keys to the key/value entries in the
+       * file's meta-data dictionary. Iterate through with these keys
+       * to get the values.
+       **/
+      std::vector<std::string> GetMetaDataKeys( void ) const;
+
+      /** \brief Query a meta-data dictionary for the existence of a key.
+       **/
+      bool HasMetaDataKey( const std::string &key ) const;
+
+      /** \brief Get the value of a meta-data dictionary entry as a string.
+       *
+       * If the key is not in the dictionary then an exception is
+       * thrown.
+       *
+       * String types in the dictionary are returned as their native
+       * string. Other types are printed to string before returning.
+       **/
+      std::string GetMetaData( const std::string &key ) const;
+
     protected:
 
       template <class TImageType> Image ExecuteInternal ( itk::ImageIOBase * );
+
+      /** Internal method which update's this classes stored meta-data
+       * and image information.
+       */
+      void UpdateImageInformationFromImageIO( const itk::ImageIOBase* iobase );
 
     private:
 
@@ -67,7 +135,23 @@ namespace itk {
       friend struct detail::MemberFunctionAddressor<MemberFunctionType>;
       nsstd::auto_ptr<detail::MemberFunctionFactory<MemberFunctionType> > m_MemberFactory;
 
+
+      nsstd::function<std::vector<std::string>()> m_pfGetMetaDataKeys;
+      nsstd::function<bool(const std::string &)> m_pfHasMetaDataKey;
+      nsstd::function<std::string(const std::string &)> m_pfGetMetaData;
+
       std::string m_FileName;
+
+      nsstd::auto_ptr<MetaDataDictionary> m_MetaDataDictionary;
+
+      PixelIDValueEnum     m_PixelType;
+      unsigned int         m_Dimension;
+      unsigned int         m_NumberOfComponents;
+      std::vector<double>  m_Direction;
+      std::vector<double>  m_Origin;
+      std::vector<double>  m_Spacing;
+
+      std::vector<uint64_t> m_Size;
     };
 
   /**

--- a/Code/IO/include/sitkImageReaderBase.h
+++ b/Code/IO/include/sitkImageReaderBase.h
@@ -79,13 +79,14 @@ class SmartPointer;
 
       void GetPixelIDFromImageIO( const std::string &fileName,
                                   PixelIDValueType &outPixelType,
-                                  unsigned int & outDimensions);
-      void GetPixelIDFromImageIO( itk::ImageIOBase* iobase,
+                                  unsigned int & outDimensions );
+      void GetPixelIDFromImageIO( const itk::ImageIOBase* iobase,
                                   PixelIDValueType &outPixelType,
-                                  unsigned int & outDimensions);
+                                  unsigned int & outDimensions );
 
-      unsigned int GetDimensionFromImageIO( const std::string &fileName, unsigned int i);
-      unsigned int GetDimensionFromImageIO( itk::ImageIOBase* iobase, unsigned int i);
+      unsigned int GetDimensionFromImageIO( const std::string &fileName, unsigned int i );
+      unsigned int GetDimensionFromImageIO( const itk::ImageIOBase* iobase, unsigned int i );
+
 
     private:
 

--- a/Code/IO/src/sitkImageFileReader.cxx
+++ b/Code/IO/src/sitkImageFileReader.cxx
@@ -220,18 +220,14 @@ namespace itk {
     {
 
       PixelIDValueType type = this->GetOutputPixelType();
-      unsigned int dimension = 0;
 
 
       itk::ImageIOBase::Pointer imageio = this->GetImageIOBase( this->m_FileName );
+      this->UpdateImageInformationFromImageIO(imageio);
+      const unsigned int dimension = this->GetDimension();
       if (type == sitkUnknown)
         {
-        this->GetPixelIDFromImageIO( imageio, type, dimension );
-        }
-      else
-        {
-        PixelIDValueType unused;
-        this->GetPixelIDFromImageIO( imageio, unused, dimension );
+        type = this->GetPixelIDValue();
         }
 
 #ifdef SITK_4D_IMAGES

--- a/Code/IO/src/sitkImageFileReader.cxx
+++ b/Code/IO/src/sitkImageFileReader.cxx
@@ -23,6 +23,7 @@
 
 #include <itkImageFileReader.h>
 
+#include "sitkMetaDataDictionaryCustomCast.hxx"
 
 namespace itk {
   namespace simple {
@@ -33,7 +34,10 @@ namespace itk {
       return reader.SetFileName ( filename ).SetOutputPixelType(outputPixelType).Execute();
     }
 
-    ImageFileReader::ImageFileReader()
+    ImageFileReader::ImageFileReader() :
+      m_PixelType(sitkUnknown),
+      m_Dimension(0),
+      m_NumberOfComponents(0)
       {
       // list of pixel types supported
       typedef NonLabelPixelIDTypeList PixelIDTypeList;
@@ -53,6 +57,16 @@ namespace itk {
       out << "  FileName: \"";
       this->ToStringHelper(out, this->m_FileName) << "\"" << std::endl;
 
+      out << "  Image Information:"
+          << "    PixelType: ";
+      this->ToStringHelper(out, this->m_PixelType) << std::endl;
+      out << "    Dimension: " << this->m_Dimension << std::endl;
+      out << "    NumberOfComponents: " << this->m_NumberOfComponents << std::endl;
+      out << "    Direction: " << this->m_Direction << std::endl;
+      out << "    Origin: " << this->m_Origin << std::endl;
+      out << "    Spacing: " << this->m_Spacing << std::endl;
+      out << "    Size: " << this->m_Size << std::endl;
+
       out << ImageReaderBase::ToString();
       return out.str();
     }
@@ -66,7 +80,144 @@ namespace itk {
       return this->m_FileName;
     }
 
-    Image ImageFileReader::Execute () {
+
+    void
+    ImageFileReader
+    ::UpdateImageInformationFromImageIO(const itk::ImageIOBase* iobase)
+    {
+      PixelIDValueType pixelType;
+      this->GetPixelIDFromImageIO(iobase, pixelType, m_Dimension);
+
+      std::vector<double> direction;
+
+      direction.reserve(m_Dimension*m_Dimension);
+
+      std::vector<double> origin(m_Dimension);
+      std::vector<double> spacing(m_Dimension);
+      std::vector<uint64_t> size(m_Dimension);
+      for( unsigned int i = 0; i < m_Dimension; ++i)
+        {
+        origin[i] = iobase->GetOrigin(i);
+        spacing[i] = iobase->GetSpacing(i);
+        size[i] = iobase->GetDimensions(i);
+        const  std::vector< double > temp_direction = iobase->GetDirection(i);
+        direction.insert(direction.end(), temp_direction.begin(), temp_direction.end());
+        }
+
+      // release functions bound to old meta data dictionary
+      if (m_MetaDataDictionary.get())
+        {
+        this->m_pfGetMetaDataKeys = SITK_NULLPTR;
+        this->m_pfHasMetaDataKey = SITK_NULLPTR;
+        this->m_pfGetMetaData =  SITK_NULLPTR;
+        }
+
+      this->m_MetaDataDictionary.reset(new MetaDataDictionary(iobase->GetMetaDataDictionary()));
+
+      m_PixelType = static_cast<PixelIDValueEnum>(pixelType);
+
+      // Should this be as reported by ImageIO, or as reported by sitk::Image?
+      m_NumberOfComponents = iobase->GetNumberOfComponents();
+
+      using std::swap;
+      swap(direction, m_Direction);
+      swap(origin, m_Origin);
+      swap(spacing, m_Spacing);
+      swap(size, m_Size);
+
+      this->m_pfGetMetaDataKeys = nsstd::bind(&MetaDataDictionary::GetKeys, this->m_MetaDataDictionary.get());
+      this->m_pfHasMetaDataKey = nsstd::bind(&MetaDataDictionary::HasKey, this->m_MetaDataDictionary.get(), nsstd::placeholders::_1);
+      this->m_pfGetMetaData = nsstd::bind(&GetMetaDataDictionaryCustomCast::CustomCast, this->m_MetaDataDictionary.get(), nsstd::placeholders::_1);
+    }
+
+    PixelIDValueEnum
+    ImageFileReader
+    ::GetPixelID( void ) const
+    {
+      return this->m_PixelType;
+    }
+
+    PixelIDValueType
+    ImageFileReader
+    ::GetPixelIDValue( void ) const
+    {
+      return this->m_PixelType;
+    }
+
+    unsigned int
+    ImageFileReader
+    ::GetDimension( void ) const
+    {
+      return this->m_Dimension;
+    }
+
+    unsigned int
+    ImageFileReader
+    ::GetNumberOfComponents( void ) const
+    {
+      return this->m_NumberOfComponents;
+    }
+
+    const std::vector<double> &
+    ImageFileReader
+    ::GetOrigin( void ) const
+    {
+      return this->m_Origin;
+    }
+
+    const std::vector<double> &
+    ImageFileReader
+    ::GetSpacing( void ) const
+    {
+      return this->m_Spacing;
+    }
+
+    const std::vector<double> &
+    ImageFileReader
+    ::GetDirection() const
+    {
+      return this->m_Direction;
+    }
+
+    const std::vector<uint64_t> &
+    ImageFileReader
+    ::GetSize( void ) const
+    {
+      return this->m_Size;
+    }
+
+    void
+    ImageFileReader
+    ::ReadImageInformation( void )
+    {
+      itk::ImageIOBase::Pointer imageio = this->GetImageIOBase( this->m_FileName );
+      this->UpdateImageInformationFromImageIO(imageio);
+    }
+
+
+    std::vector<std::string>
+    ImageFileReader
+    ::GetMetaDataKeys( void ) const
+    {
+      return this->m_pfGetMetaDataKeys();
+    }
+
+    bool
+    ImageFileReader
+    ::HasMetaDataKey( const std::string &key ) const
+    {
+      return this->m_pfHasMetaDataKey(key);
+    }
+
+    std::string
+    ImageFileReader
+    ::GetMetaData( const std::string &key ) const
+    {
+      return this->m_pfGetMetaData(key);
+    }
+
+    Image ImageFileReader::Execute ()
+    {
 
       PixelIDValueType type = this->GetOutputPixelType();
       unsigned int dimension = 0;

--- a/Code/IO/src/sitkImageFileReader.cxx
+++ b/Code/IO/src/sitkImageFileReader.cxx
@@ -116,7 +116,7 @@ namespace itk {
 
       m_PixelType = static_cast<PixelIDValueEnum>(pixelType);
 
-      // Should this be as reported by ImageIO, or as reported by sitk::Image?
+      // Use the number of components as reported by the itk::Image
       m_NumberOfComponents = iobase->GetNumberOfComponents();
 
       using std::swap;

--- a/Code/IO/src/sitkImageReaderBase.cxx
+++ b/Code/IO/src/sitkImageReaderBase.cxx
@@ -156,7 +156,7 @@ ImageReaderBase
 
 void
 ImageReaderBase
-::GetPixelIDFromImageIO( ImageIOBase *iobase,
+::GetPixelIDFromImageIO( const ImageIOBase *iobase,
                          PixelIDValueType &outPixelType,
                          unsigned int & outDimensions )
 {
@@ -203,7 +203,7 @@ ImageReaderBase
 
 unsigned int
 ImageReaderBase
-::GetDimensionFromImageIO( itk::ImageIOBase* iobase, unsigned int i)
+::GetDimensionFromImageIO( const itk::ImageIOBase* iobase, unsigned int i)
 {
   return iobase->GetDimensions(i);
 }

--- a/Code/IO/src/sitkImageSeriesReader.cxx
+++ b/Code/IO/src/sitkImageSeriesReader.cxx
@@ -66,7 +66,7 @@ namespace itk {
 
   ImageSeriesReader::ImageSeriesReader()
     :
-    m_Filter(NULL),
+    m_Filter(SITK_NULLPTR),
     m_MetaDataDictionaryArrayUpdate(false)
     {
 
@@ -81,7 +81,7 @@ namespace itk {
 
   ImageSeriesReader::~ImageSeriesReader()
   {
-  if (this->m_Filter != NULL)
+  if (this->m_Filter != SITK_NULLPTR)
     {
       m_Filter->UnRegister();
     }
@@ -230,13 +230,13 @@ struct GetMetaDataCustomCast
     reader->SetMetaDataDictionaryArrayUpdate(m_MetaDataDictionaryArrayUpdate);
 
     // release the old filter ( and output data )
-    if ( this->m_Filter != NULL)
+    if ( this->m_Filter != SITK_NULLPTR)
       {
       this->m_pfGetMetaDataKeys = SITK_NULLPTR;
       this->m_pfHasMetaDataKey = SITK_NULLPTR;
       this->m_pfGetMetaData =  SITK_NULLPTR;
       this->m_Filter->UnRegister();
-      this->m_Filter = NULL;
+      this->m_Filter = SITK_NULLPTR;
       }
 
 

--- a/Code/IO/src/sitkImageSeriesReader.cxx
+++ b/Code/IO/src/sitkImageSeriesReader.cxx
@@ -169,7 +169,6 @@ namespace itk {
     }
 
 
-
   template <class TImageType> Image
   ImageSeriesReader::ExecuteInternal( itk::ImageIOBase* imageio )
     {

--- a/Code/IO/src/sitkImageSeriesReader.cxx
+++ b/Code/IO/src/sitkImageSeriesReader.cxx
@@ -25,6 +25,7 @@
 #include <itkImageSeriesReader.h>
 
 #include "itkGDCMSeriesFileNames.h"
+#include "sitkMetaDataDictionaryCustomCast.hxx"
 
 namespace itk {
   namespace simple {
@@ -168,49 +169,6 @@ namespace itk {
     }
 
 
-//
-// Custom Casts
-//
-namespace {
-template<typename FilterType>
-struct GetMetaDataKeysCustomCast
-{
-  static std::vector<std::string> CustomCast( const FilterType *f, int i)
-  {
-    const typename FilterType::DictionaryArrayType &mda = *f->GetMetaDataDictionaryArray();
-    return mda.at(i)->GetKeys();
-  }
-};
-
-template<typename FilterType>
-struct HasMetaDataKeyCustomCast
-{
-  static bool CustomCast( const FilterType *f, int i, const std::string &k)
-  {
-    const typename FilterType::DictionaryArrayType &mda = *f->GetMetaDataDictionaryArray();
-    return mda.at(i)->HasKey(k);
-  }
-};
-
-template<typename FilterType>
-struct GetMetaDataCustomCast
-{
-  static std::string CustomCast( const FilterType *f, int i, const std::string &k)
-  {
-    const typename FilterType::DictionaryArrayType &mda = *f->GetMetaDataDictionaryArray();
-
-    std::string value;
-    if (ExposeMetaData(*mda.at(i), k, value))
-      {
-      return value;
-      }
-
-    std::ostringstream ss;
-    mda.at(i)->Get(k)->Print(ss);
-    return ss.str();
-  }
-};
-}
 
   template <class TImageType> Image
   ImageSeriesReader::ExecuteInternal( itk::ImageIOBase* imageio )

--- a/Code/IO/src/sitkMetaDataDictionaryCustomCast.hxx
+++ b/Code/IO/src/sitkMetaDataDictionaryCustomCast.hxx
@@ -53,8 +53,6 @@ struct HasMetaDataKeyCustomCast
     }
 };
 
-
-
 struct GetMetaDataDictionaryCustomCast
 {
   static std::string CustomCast( const MetaDataDictionary *md, const std::string &k)

--- a/Code/IO/src/sitkMetaDataDictionaryCustomCast.hxx
+++ b/Code/IO/src/sitkMetaDataDictionaryCustomCast.hxx
@@ -1,0 +1,90 @@
+/*=========================================================================
+*
+*  Copyright Insight Software Consortium
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*         http://www.apache.org/licenses/LICENSE-2.0.txt
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*=========================================================================*/
+
+#ifndef sitkMetaDataDictionaryCustomCast_h
+#define sitkMetaDataDictionaryCustomCast_h
+#include <vector>
+#include <string>
+#include <sstream>
+#include <itkMetaDataDictionary.h>
+#include <itkMetaDataObject.h>
+
+
+namespace itk {
+namespace simple {
+
+
+//
+// Custom Casts
+//
+namespace {
+template<typename FilterType>
+struct GetMetaDataKeysCustomCast
+{
+  static std::vector<std::string> CustomCast( const FilterType *f, int i)
+    {
+      const typename FilterType::DictionaryArrayType &mda = *f->GetMetaDataDictionaryArray();
+      return mda.at(i)->GetKeys();
+    }
+};
+
+template<typename FilterType>
+struct HasMetaDataKeyCustomCast
+{
+  static bool CustomCast( const FilterType *f, int i, const std::string &k)
+    {
+      const typename FilterType::DictionaryArrayType &mda = *f->GetMetaDataDictionaryArray();
+      return mda.at(i)->HasKey(k);
+    }
+};
+
+
+
+struct GetMetaDataDictionaryCustomCast
+{
+  static std::string CustomCast( const MetaDataDictionary *md, const std::string &k)
+    {
+      std::string value;
+      if (ExposeMetaData(*md, k, value))
+        {
+        return value;
+        }
+
+      std::ostringstream ss;
+      md->Get(k)->Print(ss);
+      return ss.str();
+    }
+};
+
+template<typename FilterType>
+struct GetMetaDataCustomCast
+{
+  static std::string CustomCast( const FilterType *f, int i, const std::string &k)
+    {
+      const typename FilterType::DictionaryArrayType &mda = *f->GetMetaDataDictionaryArray();
+
+      return GetMetaDataDictionaryCustomCast::CustomCast(mda.at(i), k);
+
+    }
+};
+
+}
+}
+}
+
+#endif

--- a/Code/IO/src/sitkMetaDataDictionaryCustomCast.hxx
+++ b/Code/IO/src/sitkMetaDataDictionaryCustomCast.hxx
@@ -16,8 +16,8 @@
 *
 *=========================================================================*/
 
-#ifndef sitkMetaDataDictionaryCustomCast_h
-#define sitkMetaDataDictionaryCustomCast_h
+#ifndef sitkMetaDataDictionaryCustomCast_hxx
+#define sitkMetaDataDictionaryCustomCast_hxx
 #include <vector>
 #include <string>
 #include <sstream>

--- a/Examples/DicomImagePrintTags/DicomImagePrintTags.R
+++ b/Examples/DicomImagePrintTags/DicomImagePrintTags.R
@@ -29,11 +29,22 @@ if (length(args) <  1) {
    quit(1)
 }
 
-inputImage <- ReadImage(args[[1]])
+reader <- ImageFileReader()
 
-keys <- inputImage$GetMetaDataKeys()
+reader$SetFileName(args[[1]])
+reader$LoadPrivateTagsOn()
+
+reader$ReadImageInformation()
+
+keys <- reader$GetMetaDataKeys()
 
 for ( k in keys)
 {
- print(sprintf("(%s) = \"%s\"", k, inputImage$GetMetaData(k)))
+ print(sprintf("(%s) = \"%s\"", k, reader$GetMetaData(k)))
 }
+
+cat("Image Size: ", reader$GetSize(), '\n')
+
+pixelType = GetPixelIDValueAsString(reader$GetPixelID())
+
+cat("Image PixelType: ", pixelType, '\n')

--- a/Examples/DicomImagePrintTags/DicomImagePrintTags.py
+++ b/Examples/DicomImagePrintTags/DicomImagePrintTags.py
@@ -31,8 +31,11 @@ reader = sitk.ImageFileReader()
 reader.SetFileName( sys.argv[1] )
 reader.LoadPrivateTagsOn();
 
-inputImage = reader.Execute()
+reader.ReadImageInformation();
 
-for k in inputImage.GetMetaDataKeys():
-    v = inputImage.GetMetaData(k)
+for k in reader.GetMetaDataKeys():
+    v = reader.GetMetaData(k)
     print("({0}) = = \"{1}\"".format(k,v))
+
+print("Image Size: {0}".format(reader.GetSize()));
+print("Image PixelType: {0}".format(sitk.GetPixelIDValueAsString(reader.GetPixelID())));

--- a/Examples/DicomImagePrintTags/Documentation.rst
+++ b/Examples/DicomImagePrintTags/Documentation.rst
@@ -6,13 +6,13 @@ Read Image Meta-Data Dictionary and Print
 Overview
 --------
 
-This example illustrates how to read only an image's information and meta-data dictionary then access the meta-data dictionary via the `ImageFileReader <https://itk.org/SimpleITKDoxygen/html/classitk_1_1simple_1_1ImageFileReader.html>`_.
+This example illustrates how to read only an image's information and meta-data dictionary without loading the pixel content via the `ImageFileReader <https://itk.org/SimpleITKDoxygen/html/classitk_1_1simple_1_1ImageFileReader.html>`_.
 
-Reading an entire image can be a memory and time intensive operation if the image is large or there are many files to read. The image information and meta-data dictionary can be read without the bulk data by using the ImageFilerReader's object oriented interface, and use the ImageFileReader::ReadImageInformation method.
+Reading an entire image can be a memory and time intensive operation if the image is large or many files must be read. The image information and meta-data dictionary can be read without the bulk data by using the ImageFilerReader's object oriented interface, with use of the ImageFileReader::ReadImageInformation method.
 
-Most image types do not have a meta-data dictionary. The most common case for images with a dictionary is DICOM, but also the fields from a TIFF, NIFTI, MetaIO and other file formats load some of their information into the meta-data dictionary. When reading a whole image the meta-data dictionary is loaded into an image, but is not propagated through filters.
+While all file formats support loading image information such as size, pixel type, origin, and spacing many image types do not have a meta-data dictionary. The most common case for images with a dictionary is DICOM, but also the fields from a TIFF, NIFTI, MetaIO and other file formats can be loaded into the meta-data dictionary.
 
- For efficiency, the default DICOM reader settings will only load public tags (even group numbers). In the example we explicitly set the reader to load private tags (odd group numbers). For further information on DICOM data elements see the standard part 5, `Data Structures and Encoding <http://dicom.nema.org/medical/dicom/current/output/pdf/part05.pdf>`_.
+For efficiency, the default DICOM reader settings will only load public tags (even group numbers). In the example we explicitly set the reader to load private tags (odd group numbers). For further information on DICOM data elements see the standard part 5, `Data Structures and Encoding <http://dicom.nema.org/medical/dicom/current/output/pdf/part05.pdf>`_.
 
 See also :ref:`lbl_dicom_series_read_modify_write`, :ref:`lbl_dicom_series_reader`.
 

--- a/Examples/DicomImagePrintTags/Documentation.rst
+++ b/Examples/DicomImagePrintTags/Documentation.rst
@@ -1,14 +1,18 @@
 .. _lbl_print_image_meta_data_dictionary:
 
-Print Image Meta-Data Dictionary
-================================
+Read Image Meta-Data Dictionary and Print
+=========================================
 
 Overview
 --------
 
-This example illustrates how to read an image and access its meta-data dictionary. Most image types do not have a meta-data dictionary. The most common case for images with a dictionary is DICOM. For efficiency, the default reader settings will only load public DICOM tags (even group numbers). In the example we explicitly set the reader to load private tags (odd group numbers).
+This example illustrates how to read only an image's information and meta-data dictionary then access the meta-data dictionary via the `ImageFileReader <https://itk.org/SimpleITKDoxygen/html/classitk_1_1simple_1_1ImageFileReader.html>`_.
 
-For further information on DICOM data elements see the standard part 5, `Data Structures and Encoding <http://dicom.nema.org/medical/dicom/current/output/pdf/part05.pdf>`_.
+Reading an entire image can be a memory and time intensive operation if the image is large or there are many files to read. The image information and meta-data dictionary can be read without the bulk data by using the ImageFilerReader's object oriented interface, and use the ImageFileReader::ReadImageInformation method.
+
+Most image types do not have a meta-data dictionary. The most common case for images with a dictionary is DICOM, but also the fields from a TIFF, NIFTI, MetaIO and other file formats load some of their information into the meta-data dictionary. When reading a whole image the meta-data dictionary is loaded into an image, but is not propagated through filters.
+
+ For efficiency, the default DICOM reader settings will only load public tags (even group numbers). In the example we explicitly set the reader to load private tags (odd group numbers). For further information on DICOM data elements see the standard part 5, `Data Structures and Encoding <http://dicom.nema.org/medical/dicom/current/output/pdf/part05.pdf>`_.
 
 See also :ref:`lbl_dicom_series_read_modify_write`, :ref:`lbl_dicom_series_reader`.
 

--- a/Testing/Unit/sitkImageIOTests.cxx
+++ b/Testing/Unit/sitkImageIOTests.cxx
@@ -483,8 +483,8 @@ TEST(IO, ImageFileReader_ImageInformation )
   reader.SetFileName(dicomFile1);
   EXPECT_EQ(reader.GetPixelID(), sitk::sitkUnknown);
   EXPECT_EQ(reader.GetPixelIDValue(), sitk::sitkUnknown);
-  EXPECT_EQ(reader.GetDimension(), 0);
-  EXPECT_EQ(reader.GetNumberOfComponents(), 0);
+  EXPECT_EQ(reader.GetDimension(), 0u);
+  EXPECT_EQ(reader.GetNumberOfComponents(), 0u);
   EXPECT_VECTOR_DOUBLE_NEAR(reader.GetOrigin(), std::vector<double>(), 1e-8);
   EXPECT_VECTOR_DOUBLE_NEAR(reader.GetSpacing(), std::vector<double>(), 1e-8);
   EXPECT_VECTOR_DOUBLE_NEAR(reader.GetDirection(), std::vector<double>(), 1e-8);
@@ -498,8 +498,8 @@ TEST(IO, ImageFileReader_ImageInformation )
 
   EXPECT_EQ(reader.GetPixelID(), sitk::sitkInt16);
   EXPECT_EQ(reader.GetPixelIDValue(), sitk::sitkInt16);
-  EXPECT_EQ(reader.GetDimension(), 3);
-  EXPECT_EQ(reader.GetNumberOfComponents(), 1);
+  EXPECT_EQ(reader.GetDimension(), 3u);
+  EXPECT_EQ(reader.GetNumberOfComponents(), 1u);
   EXPECT_VECTOR_DOUBLE_NEAR(reader.GetOrigin(), v3(-112, -21.687999, 126.894000 ), 1e-6);
   EXPECT_VECTOR_DOUBLE_NEAR(reader.GetSpacing(), v3(0.859375, 0.8593899, 1.600000 ), 1e-6);
   EXPECT_VECTOR_DOUBLE_NEAR(reader.GetDirection(), v9(1, 0, 0,
@@ -521,8 +521,8 @@ TEST(IO, ImageFileReader_ImageInformation )
 
   EXPECT_EQ(reader.GetPixelID(), sitk::sitkVectorUInt8);
   EXPECT_EQ(reader.GetPixelIDValue(), sitk::sitkVectorUInt8);
-  EXPECT_EQ(reader.GetDimension(), 2);
-  EXPECT_EQ(reader.GetNumberOfComponents(), 3);
+  EXPECT_EQ(reader.GetDimension(), 2u);
+  EXPECT_EQ(reader.GetNumberOfComponents(), 3u);
   EXPECT_VECTOR_DOUBLE_NEAR(reader.GetOrigin(), v2(0.0, 0.0), 1e-8);
   EXPECT_VECTOR_DOUBLE_NEAR(reader.GetSpacing(), v2(1.0, 1.0 ), 1e-8);
   EXPECT_VECTOR_DOUBLE_NEAR(reader.GetDirection(), v4(1.0, 0.0, 0.0, 1.0 ), 1e-8);

--- a/Testing/Unit/sitkImageIOTests.cxx
+++ b/Testing/Unit/sitkImageIOTests.cxx
@@ -515,7 +515,7 @@ TEST(IO, ImageFileReader_ImageInformation )
     }
   EXPECT_EQ(reader.GetMetaData( "0008|0031"), "153128");
 
-  // Check that a  reader updates exiting information
+  // Checks that a  reader updates exiting information
   reader.SetFileName(file2);
   reader.Execute();
 


### PR DESCRIPTION
To support only reading an image's header or meta-data, new interface
methods are added to the reading base class. This will allow a user to
obtain information about the image without reading the image's bulk
data.