### PR TITLE
Use hash for external-data key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,15 @@ jobs:
     steps:
       - checkout:
           path : ~/SimpleITK
+      - run:
+          name: Generate external data hash
+          command: |
+             cd SimpleITK
+             git log -n 1 ${CTEST_SOURCE_DIRECTORY}/Testing/Data/ | tee /home/circleci/external-data.hashable
       - restore_cache:
           keys:
-            - external-data
+            - 'v1-external-data-{{ checksum "/home/circleci/external-data.hashable" }}'
+            - 'v1-external-data'
       - restore_cache:
           keys:
             - ccache-{{ arch }}-{{ .Branch }}
@@ -77,5 +83,5 @@ jobs:
           key: 'ccache-{{ arch }}-{{ .Branch }}-{{ epoch }}'
           paths: [ "/home/circleci/.ccache" ]
       - save_cache:
-          key: 'external-data'
+          key: 'v1-external-data-{{ checksum "/home/circleci/external-data.hashable" }}'
           paths: [ "/home/circleci/.ExternalData" ]


### PR DESCRIPTION
The external data was never being updated. Now we use the a check some
of the last commit message to the "Testing/Data" directory so that the
cache will be updated when the Testing data is updated.