### PR TITLE
Fixed overflow issue in sitkSTLVectorToITKPointVector.

### DIFF
--- a/Code/Common/include/sitkTemplateFunctions.h
+++ b/Code/Common/include/sitkTemplateFunctions.h
@@ -70,7 +70,7 @@ TITKPointVector SITKCommon_HIDDEN sitkSTLVectorToITKPointVector( const std::vect
 
   unsigned int Dimension = itkPointVectorType::value_type::GetPointDimension();
 
-  for( unsigned int i = 0; i <= in.size()- Dimension; i += Dimension )
+  for( unsigned int i = 0; i + Dimension <= in.size(); i += Dimension )
     {
     typename itkPointVectorType::value_type pt(&in[i]);
     out.push_back(pt);


### PR DESCRIPTION
Resolves issue #368 . Unfortunately, the original code which caused the issue, invoking the LandmarkBasedTransformInitializer with empty point vectors will still give a result, though a corrupted one due to ITK's behavior (ITK silently performs 0.0/0.0 = Nan).