### PR TITLE
Enable SimpleITK_4D_IMAGES by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,13 @@ option( SimpleITK_INT64_PIXELIDS "Instantiate 64-bit integer pixels, including u
 sitk_legacy_naming(SimpleITK_INT64_PIXELIDS)
 
 
-option( SimpleITK_4D_IMAGES "Add Image and I/O support for four spatial dimensions." OFF )
+
+set(SimpleITK_4D_IMAGES_DEFAULT OFF)
+# 1900 = VS 14.0 (Visual Studio 2015)
+if(MSVC_VERSION VERSION_LESS 1900)
+    set( SimpleITK_4D_IMAGES_DEFAULT OFF )
+  endif()
+option( SimpleITK_4D_IMAGES "Add Image and I/O support for four spatial dimensions." ${SimpleITK_4D_IMAGES_DEFAULT} )
 mark_as_advanced( SimpleITK_4D_IMAGES )
 sitk_legacy_naming(SimpleITK_4D_IMAGES)
 

--- a/SuperBuild/SuperBuild.cmake
+++ b/SuperBuild/SuperBuild.cmake
@@ -148,8 +148,14 @@ option(BUILD_SHARED_LIBS "Build SimpleITK ITK with shared libraries. This does n
 # as this option does not robustly work across platforms it will be marked as advanced
 mark_as_advanced( FORCE BUILD_SHARED_LIBS )
 
-option( SimpleITK_4D_IMAGES "Add Image and I/O support for four spatial dimensions." OFF )
+set(SimpleITK_4D_IMAGES_DEFAULT OFF)
+# 1900 = VS 14.0 (Visual Studio 2015)
+if(MSVC_VERSION VERSION_LESS 1900)
+    set( SimpleITK_4D_IMAGES_DEFAULT OFF )
+  endif()
+option( SimpleITK_4D_IMAGES "Add Image and I/O support for four spatial dimensions." ${SimpleITK_4D_IMAGES_DEFAULT} )
 mark_as_advanced( SimpleITK_4D_IMAGES )
+unset(SimpleITK_4D_IMAGES_DEFAULT)
 
 #-----------------------------------------------------------------------------
 # Setup build type


### PR DESCRIPTION
Enable IO and ExtractImageFilter to operate with 4D images. Older
versions of VS only have a 32-bit linker, so this option is disabled
with those older compilers.

closes #375 