### PR TITLE
Use "build-and-test" job name for CDash reporting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build:
+  build-and-test:
     docker:
       - image: circleci/python:2.7
     working_directory: ~/
@@ -85,3 +85,9 @@ jobs:
       - save_cache:
           key: 'v1-external-data-{{ checksum "/home/circleci/external-data.hashable" }}'
           paths: [ "/home/circleci/.ExternalData" ]
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,11 +5,6 @@ jobs:
       - image: circleci/python:2.7
     working_directory: ~/
     resource_class: large
-    branches:
-      ignore:
-        - gh-pages
-        - dashboard
-        - hooks
     environment:
       CTEST_DASHBOARD_ROOT: /home/circleci
       CTEST_SOURCE_DIRECTORY: /home/circleci/SimpleITK
@@ -90,4 +85,10 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build-and-test
+        - build-and-test:
+            filters:
+              branches:
+                 ignore:
+                   - gh-pages
+                   - dashboard
+                   - hooks


### PR DESCRIPTION
Use the convention of "build-and-test" for the job name so that the
GitHub CDash status reporting can occur.