### PR TITLE
Adding tabs to the code examples.

### DIFF
--- a/Documentation/docs/requirements.txt
+++ b/Documentation/docs/requirements.txt
@@ -1,0 +1,1 @@
+sphinx-tabs

--- a/Examples/CSharp/Documentation.rst
+++ b/Examples/CSharp/Documentation.rst
@@ -10,9 +10,6 @@ Code
 ----
 
 
-CSharp
-......
-
 .. literalinclude:: ImageGetBuffer.cs
    :language: c#
    :lines: 18-

--- a/Examples/DemonsRegistration1/Documentation.rst
+++ b/Examples/DemonsRegistration1/Documentation.rst
@@ -27,16 +27,16 @@ See also: :ref:`lbl_demons_registration2`.
 Code
 ----
 
-C++
-...
+.. tabs::
 
-.. literalinclude:: DemonsRegistration1.cxx
-   :language: c++
-   :lines: 18-
+  .. tab:: C++
 
-Python
-......
+    .. literalinclude:: DemonsRegistration1.cxx
+       :language: c++
+       :lines: 18-
 
-.. literalinclude:: DemonsRegistration1.py
-   :language: python
-   :lines: 1,19-
+  .. tab:: Python
+
+    .. literalinclude:: DemonsRegistration1.py
+       :language: python
+       :lines: 1,19-

--- a/Examples/DemonsRegistration2/Documentation.rst
+++ b/Examples/DemonsRegistration2/Documentation.rst
@@ -26,16 +26,16 @@ See also: :ref:`lbl_demons_registration1`.
 Code
 ----
 
-C++
-...
+.. tabs::
 
-.. literalinclude:: DemonsRegistration2.cxx
-   :language: c++
-   :lines: 18-
+  .. tab:: C++
 
-Python
-......
+    .. literalinclude:: DemonsRegistration2.cxx
+       :language: c++
+       :lines: 18-
 
-.. literalinclude:: DemonsRegistration2.py
-   :language: python
-   :lines: 1,19-
+  .. tab:: Python
+
+    .. literalinclude:: DemonsRegistration2.py
+       :language: python
+       :lines: 1,19-

--- a/Examples/DicomImagePrintTags/Documentation.rst
+++ b/Examples/DicomImagePrintTags/Documentation.rst
@@ -19,16 +19,16 @@ See also :ref:`lbl_dicom_series_read_modify_write`, :ref:`lbl_dicom_series_reade
 Code
 ----
 
-Python
-......
+.. tabs::
 
-.. literalinclude:: DicomImagePrintTags.py
-   :language: python
-   :lines: 1,19-
+  .. tab:: Python
 
-R
-.
+    .. literalinclude:: DicomImagePrintTags.py
+       :language: python
+       :lines: 1,19-
 
-.. literalinclude:: DicomImagePrintTags.R
-   :language: r
-   :lines: 18-
+  .. tab:: R
+
+    .. literalinclude:: DicomImagePrintTags.R
+       :language: r
+       :lines: 18-

--- a/Examples/DicomSeriesFromArray/Documentation.rst
+++ b/Examples/DicomSeriesFromArray/Documentation.rst
@@ -17,10 +17,11 @@ See also :ref:`lbl_print_image_meta_data_dictionary`, :ref:`lbl_dicom_series_rea
 Code
 ----
 
-Python
-......
+.. tabs::
 
-.. literalinclude:: DicomSeriesFromArray.py
-   :language: python
-   :lines: 1,19-
+  .. tab:: Python
+
+    .. literalinclude:: DicomSeriesFromArray.py
+       :language: python
+       :lines: 19-
 

--- a/Examples/DicomSeriesReadModifyWrite/Documentation.rst
+++ b/Examples/DicomSeriesReadModifyWrite/Documentation.rst
@@ -19,17 +19,16 @@ See also :ref:`lbl_print_image_meta_data_dictionary`, :ref:`lbl_dicom_series_rea
 Code
 ----
 
-Python
-......
+.. tabs::
 
-.. literalinclude:: DicomSeriesReadModifySeriesWrite.py
-   :language: python
-   :lines: 1,19-
+  .. tab:: Python
 
+    .. literalinclude:: DicomSeriesReadModifySeriesWrite.py
+       :language: python
+       :lines: 19-
 
-R
-.
+  .. tab:: R
 
-.. literalinclude:: DicomSeriesReadModifySeriesWrite.R
-   :language: r
-   :lines:  18-
+    .. literalinclude:: DicomSeriesReadModifySeriesWrite.R
+       :language: r
+       :lines:  18-

--- a/Examples/DicomSeriesReader/Documentation.rst
+++ b/Examples/DicomSeriesReader/Documentation.rst
@@ -15,30 +15,28 @@ See also :ref:`lbl_dicom_series_read_modify_write`, :ref:`lbl_print_image_meta_d
 Code
 ----
 
-C++
-...
+.. tabs::
 
-.. literalinclude:: DicomSeriesReader.cxx
-   :language: c++
-   :lines: 18-
+  .. tab:: C++
 
-Python
-......
+    .. literalinclude:: DicomSeriesReader.cxx
+       :language: c++
+       :lines: 18-
 
-.. literalinclude:: DicomSeriesReader.py
-   :language: python
-   :lines: 1,19-
+  .. tab:: Lua
 
+    .. literalinclude:: DicomSeriesReader.lua
+       :language: lua
+       :lines:  18-
 
-Lua
-...
+  .. tab:: Python
 
-.. literalinclude:: DicomSeriesReader.lua
-   :language: lua
-   :lines:  18-
+    .. literalinclude:: DicomSeriesReader.py
+       :language: python
+       :lines: 1,19-
 
-R
-.
-.. literalinclude:: DicomSeriesReader.R
-   :language: R
-   :lines:  23-
+  .. tab:: R
+
+    .. literalinclude:: DicomSeriesReader.R
+       :language: R
+       :lines:  23-

--- a/Examples/FilterProgressReporting/Documentation.rst
+++ b/Examples/FilterProgressReporting/Documentation.rst
@@ -43,33 +43,35 @@ derive classes from the Command class.  Thus a user may  override the
 Command class's Execute method for custom call-backs. The following
 languages support deriving classes from the Command class:
 
-Python
-......
-.. literalinclude:: FilterProgressReporting.py
-   :language: python
-   :start-after: [python director command]
-   :end-before: [python director command]
+.. tabs::
 
-Java
-....
-.. literalinclude:: FilterProgressReporting.java
-   :language: java
-   :start-after: [java director command]
-   :end-before: [java director command]
+  .. group-tab:: C#
 
-CSharp
-......
-.. literalinclude:: FilterProgressReporting.cs
-   :language: c#
-   :start-after: [csharp director command]
-   :end-before: [csharp director command]
+    .. literalinclude:: FilterProgressReporting.cs
+       :language: c#
+       :start-after: [csharp director command]
+       :end-before: [csharp director command]
 
-Ruby
-....
-.. literalinclude:: FilterProgressReporting.rb
-   :language: ruby
-   :start-after: [ruby director command]
-   :end-before: [ruby director command]
+  .. group-tab:: Java
+
+    .. literalinclude:: FilterProgressReporting.java
+       :language: java
+       :start-after: [java director command]
+       :end-before: [java director command]
+
+  .. group-tab:: Python
+
+    .. literalinclude:: FilterProgressReporting.py
+       :language: python
+       :start-after: [python director command]
+       :end-before: [python director command]
+
+  .. group-tab:: Ruby
+
+    .. literalinclude:: FilterProgressReporting.rb
+       :language: ruby
+       :start-after: [ruby director command]
+       :end-before: [ruby director command]
 
 
 Command Functions and Lambdas for Wrapped Languages
@@ -80,63 +82,61 @@ often easier to simply define a callback inline with a lambda
 function. The following language supports inline function definitions
 for functions for the ProcessObject::AddCommand method:
 
-Python
-......
-.. literalinclude:: FilterProgressReporting.py
-   :language: python
-   :start-after: [python lambda command]
-   :end-before: [python lambda command]
+.. tabs::
 
-R
-.
-.. literalinclude:: FilterProgressReporting.R
-   :language: r
-   :start-after: [R lambda command]
-   :end-before: [R lambda command]
+  .. group-tab:: Python
+
+    .. literalinclude:: FilterProgressReporting.py
+       :language: python
+       :start-after: [python lambda command]
+       :end-before: [python lambda command]
+
+  .. group-tab:: R
+
+    .. literalinclude:: FilterProgressReporting.R
+       :language: r
+       :start-after: [R lambda command]
+       :end-before: [R lambda command]
 
 
 
 Code
 ----
 
-C++
-...
+.. tabs::
 
-.. literalinclude:: FilterProgressReporting.cxx
-   :language: c++
-   :lines: 18-
+  .. group-tab:: CSharp
 
-Python
-......
+    .. literalinclude:: FilterProgressReporting.cs
+       :language: c#
+       :lines: 18-
 
-.. literalinclude:: FilterProgressReporting.py
-   :language: python
-   :lines: 1,19-
+  .. group-tab:: C++
 
-CSharp
-......
+    .. literalinclude:: FilterProgressReporting.cxx
+       :language: c++
+       :lines: 18-
 
-.. literalinclude:: FilterProgressReporting.cs
-   :language: c#
-   :lines: 18-
+  .. group-tab:: Java
 
-Java
-....
+    .. literalinclude:: FilterProgressReporting.java
+       :language: java
+       :lines: 18-
 
-.. literalinclude:: FilterProgressReporting.java
-   :language: java
-   :lines: 18-
+  .. group-tab:: Python
 
-R
-.
+    .. literalinclude:: FilterProgressReporting.py
+       :language: python
+       :lines: 1,19-
 
-.. literalinclude:: FilterProgressReporting.R
-   :language: r
-   :lines:  18-
+  .. group-tab:: R
 
-Ruby
-....
+    .. literalinclude:: FilterProgressReporting.R
+       :language: r
+       :lines:  18-
 
-.. literalinclude:: FilterProgressReporting.rb
-   :language: ruby
-   :lines:  18-
+  .. group-tab:: Ruby
+
+    .. literalinclude:: FilterProgressReporting.rb
+       :language: ruby
+       :lines:  18-

--- a/Examples/HelloWorld/Documentation.rst
+++ b/Examples/HelloWorld/Documentation.rst
@@ -13,58 +13,51 @@ display with image with ImageJ.
 Code
 ----
 
-C++
-...
+.. tabs::
+  .. tab:: C#
 
-.. literalinclude:: HelloWorld.cxx
-   :language: c++
-   :lines: 18-
+    .. literalinclude:: HelloWorld.cs
+       :language: c#
+       :lines: 18-
 
-Python
-......
+  .. tab:: C++
 
-.. literalinclude:: HelloWorld.py
-   :language: python
-   :lines: 1,19-
+    .. literalinclude:: HelloWorld.cxx
+       :language: c++
+       :lines: 18-
 
-CSharp
-......
+  .. tab:: Java
 
-.. literalinclude:: HelloWorld.cs
-   :language: c#
-   :lines: 18-
+    .. literalinclude:: HelloWorld.java
+       :language: java
+       :lines: 18-
 
-Java
-....
+  .. tab:: Lua
 
-.. literalinclude:: HelloWorld.java
-   :language: java
-   :lines: 18-
+    .. literalinclude:: HelloWorld.lua
+       :language: lua
+       :lines:  18-
 
-Lua
-...
+  .. tab:: Python
 
-.. literalinclude:: HelloWorld.lua
-   :language: lua
-   :lines:  18-
+    .. literalinclude:: HelloWorld.py
+       :language: python
+       :lines: 1,19-
 
-R
-.
+  .. tab:: R
 
-.. literalinclude:: HelloWorld.R
-   :language: r
-   :lines:  18-
+    .. literalinclude:: HelloWorld.R
+       :language: r
+       :lines:  19-
 
-Ruby
-....
+  .. tab:: Ruby
 
-.. literalinclude:: HelloWorld.rb
-   :language: ruby
-   :lines:  18-
+    .. literalinclude:: HelloWorld.rb
+       :language: ruby
+       :lines:  18-
 
-Tcl
-...
+  .. tab:: Tcl
 
-.. literalinclude:: HelloWorld.tcl
-   :language: tcl
-   :lines: 18-
+    .. literalinclude:: HelloWorld.tcl
+       :language: tcl
+       :lines: 18-

--- a/Examples/ITKIntegration/Documentation.rst
+++ b/Examples/ITKIntegration/Documentation.rst
@@ -9,9 +9,10 @@ Overview
 Code
 ----
 
-C++
-...
+.. tabs ::
 
-.. literalinclude:: ITKIntegration.cxx
-   :language: c++
-   :lines: 18-
+  .. tab:: C++
+
+    .. literalinclude:: ITKIntegration.cxx
+       :language: c++
+       :lines: 18-

--- a/Examples/ImageRegistrationMethod1/Documentation.rst
+++ b/Examples/ImageRegistrationMethod1/Documentation.rst
@@ -11,44 +11,40 @@ Overview
 Code
 ----
 
-C++
-...
+.. tabs::
 
-.. literalinclude:: ImageRegistrationMethod1.cxx
-   :language: c++
-   :lines: 18-
+  .. tab:: C#
 
-Python
-......
+    .. literalinclude:: ImageRegistrationMethod1.cs
+       :language: c#
+       :lines: 18-
 
-.. literalinclude:: ImageRegistrationMethod1.py
-   :language: python
-   :lines: 1,19-
+  .. tab:: C++
 
-CSharp
-......
+    .. literalinclude:: ImageRegistrationMethod1.cxx
+       :language: c++
+       :lines: 18-
 
-.. literalinclude:: ImageRegistrationMethod1.cs
-   :language: c#
-   :lines: 18-
+  .. tab:: Java
 
-Java
-....
+    .. literalinclude:: ImageRegistrationMethod1.java
+       :language: java
+       :lines: 18-
 
-.. literalinclude:: ImageRegistrationMethod1.java
-   :language: java
-   :lines: 18-
+  .. tab:: Lua
 
-Lua
-...
+    .. literalinclude:: ImageRegistrationMethod1.lua
+       :language: lua
+       :lines:  18-
 
-.. literalinclude:: ImageRegistrationMethod1.lua
-   :language: lua
-   :lines:  18-
+  .. tab:: Python
 
-R
-.
+    .. literalinclude:: ImageRegistrationMethod1.py
+       :language: python
+       :lines: 1,19-
 
-.. literalinclude:: ImageRegistrationMethod1.R
-   :language: r
-   :lines:  18-
+  .. tab:: R
+
+    .. literalinclude:: ImageRegistrationMethod1.R
+       :language: r
+       :lines:  18-

--- a/Examples/ImageRegistrationMethod2/Documentation.rst
+++ b/Examples/ImageRegistrationMethod2/Documentation.rst
@@ -10,16 +10,16 @@ Overview
 Code
 ----
 
-C++
-...
+.. tabs::
 
-.. literalinclude:: ImageRegistrationMethod2.cxx
-   :language: c++
-   :lines: 18-
+  .. tab:: C++
 
-Python
-......
+    .. literalinclude:: ImageRegistrationMethod2.cxx
+       :language: c++
+       :lines: 18-
 
-.. literalinclude:: ImageRegistrationMethod2.py
-   :language: python
-   :lines: 1,19-
+  .. tab:: Python
+
+    .. literalinclude:: ImageRegistrationMethod2.py
+       :language: python
+       :lines: 1,19-

--- a/Examples/ImageRegistrationMethod3/Documentation.rst
+++ b/Examples/ImageRegistrationMethod3/Documentation.rst
@@ -9,12 +9,10 @@ Overview
 Code
 ----
 
-C++
-...
+.. tabs::
 
-Python
-......
+  .. tab:: Python
 
-.. literalinclude:: ImageRegistrationMethod3.py
-   :language: python
-   :lines: 1,19-
+    .. literalinclude:: ImageRegistrationMethod3.py
+       :language: python
+       :lines: 1,19-

--- a/Examples/ImageRegistrationMethod4/Documentation.rst
+++ b/Examples/ImageRegistrationMethod4/Documentation.rst
@@ -9,9 +9,10 @@ Overview
 Code
 ----
 
-Python
-......
+.. tabs::
 
-.. literalinclude:: ImageRegistrationMethod4.py
-   :language: python
-   :lines: 1,19-
+  .. tab:: Python
+
+    .. literalinclude:: ImageRegistrationMethod4.py
+       :language: python
+       :lines: 1,19-

--- a/Examples/ImageRegistrationMethodBSpline1/Documentation.rst
+++ b/Examples/ImageRegistrationMethodBSpline1/Documentation.rst
@@ -9,16 +9,16 @@ Overview
 Code
 ----
 
-C++
-...
+.. tabs::
 
-.. literalinclude:: ImageRegistrationMethodBSpline1.cxx
-   :language: c++
-   :lines: 18-
+  .. tab:: C++
 
-Python
-......
+    .. literalinclude:: ImageRegistrationMethodBSpline1.cxx
+       :language: c++
+       :lines: 18-
 
-.. literalinclude:: ImageRegistrationMethodBSpline1.py
-   :language: python
-   :lines: 1,19-
+  .. tab:: Python
+
+    .. literalinclude:: ImageRegistrationMethodBSpline1.py
+       :language: python
+       :lines: 1,19-

--- a/Examples/ImageRegistrationMethodBSpline2/Documentation.rst
+++ b/Examples/ImageRegistrationMethodBSpline2/Documentation.rst
@@ -9,9 +9,10 @@ Overview
 Code
 ----
 
-Python
-......
+.. tabs::
 
-.. literalinclude:: ImageRegistrationMethodBSpline2.py
-   :language: python
-   :lines: 1,19-
+  .. tab:: Python
+
+    .. literalinclude:: ImageRegistrationMethodBSpline2.py
+       :language: python
+       :lines: 1,19-

--- a/Examples/ImageRegistrationMethodDisplacement1/Documentation.rst
+++ b/Examples/ImageRegistrationMethodDisplacement1/Documentation.rst
@@ -9,16 +9,16 @@ Overview
 Code
 ----
 
-C++
-...
+.. tabs::
 
-.. literalinclude:: ImageRegistrationMethodDisplacement1.cxx
-   :language: c++
-   :lines: 18-
+  .. tab:: C++
 
-Python
-......
+    .. literalinclude:: ImageRegistrationMethodDisplacement1.cxx
+       :language: c++
+       :lines: 18-
 
-.. literalinclude:: ImageRegistrationMethodDisplacement1.py
-   :language: python
-   :lines: 1,19-
+  .. tab:: Python
+
+    .. literalinclude:: ImageRegistrationMethodDisplacement1.py
+       :language: python
+       :lines: 1,19-

--- a/Examples/ImageRegistrationMethodExhaustive/Documentation.rst
+++ b/Examples/ImageRegistrationMethodExhaustive/Documentation.rst
@@ -9,9 +9,10 @@ Overview
 Code
 ----
 
-Python
-......
+.. tabs::
 
-.. literalinclude:: ImageRegistrationMethodExhaustive.py
-   :language: python
-   :lines: 1,19-
+  .. tab:: Python
+
+    .. literalinclude:: ImageRegistrationMethodExhaustive.py
+       :language: python
+       :lines: 1,19-

--- a/Examples/N4BiasFieldCorrection/Documentation.rst
+++ b/Examples/N4BiasFieldCorrection/Documentation.rst
@@ -9,9 +9,10 @@ Overview
 Code
 ----
 
-Python
-......
+.. tabs::
 
-.. literalinclude:: N4BiasFieldCorrection.py
-   :language: python
-   :lines: 1,19-
+  .. tab:: Python
+
+    .. literalinclude:: N4BiasFieldCorrection.py
+       :language: python
+       :lines: 1,19-

--- a/Examples/SimpleGaussian/Documentation.rst
+++ b/Examples/SimpleGaussian/Documentation.rst
@@ -19,58 +19,52 @@ parameters set by class member functions.
 Code
 ----
 
-C++
-...
+.. tabs::
 
-.. literalinclude:: SimpleGaussian.cxx
-   :language: c++
-   :lines: 18-
+  .. tab:: C#
 
-Python
-......
+    .. literalinclude:: SimpleGaussian.cs
+       :language: c#
+       :lines: 18-
 
-.. literalinclude:: SimpleGaussian.py
-   :language: python
-   :lines: 1,19-
+  .. tab:: C++
 
-CSharp
-......
+    .. literalinclude:: SimpleGaussian.cxx
+       :language: c++
+       :lines: 18-
 
-.. literalinclude:: SimpleGaussian.cs
-   :language: c#
-   :lines: 18-
+  .. tab:: Java
 
-Java
-....
+    .. literalinclude:: SimpleGaussian.java
+       :language: java
+       :lines: 18-
 
-.. literalinclude:: SimpleGaussian.java
-   :language: java
-   :lines: 18-
+  .. tab:: Lua
 
-Lua
-...
+    .. literalinclude:: SimpleGaussian.lua
+       :language: lua
+       :lines:  18-
 
-.. literalinclude:: SimpleGaussian.lua
-   :language: lua
-   :lines:  18-
+  .. tab:: Python
 
-R
-.
+    .. literalinclude:: SimpleGaussian.py
+       :language: python
+       :lines: 1,19-
 
-.. literalinclude:: SimpleGaussian.R
-   :language: r
-   :lines:  18-
+  .. tab:: R
 
-Ruby
-....
+    .. literalinclude:: SimpleGaussian.R
+       :language: r
+       :lines:  18-
 
-.. literalinclude:: SimpleGaussian.rb
-   :language: ruby
-   :lines:  18-
+  .. tab:: Ruby
 
-Tcl
-...
+    .. literalinclude:: SimpleGaussian.rb
+       :language: ruby
+       :lines:  18-
 
-.. literalinclude:: SimpleGaussian.tcl
-   :language: tcl
-   :lines: 18-
+  .. tab:: Tcl
+
+    .. literalinclude:: SimpleGaussian.tcl
+       :language: tcl
+       :lines: 18-

--- a/Examples/index.rst
+++ b/Examples/index.rst
@@ -4,7 +4,7 @@ Examples
 ========
 
 .. toctree::
-  :maxdepth: 2
+  :maxdepth: 1
 
 
   HelloWorld/Documentation

--- a/conf.py
+++ b/conf.py
@@ -155,3 +155,5 @@ texinfo_documents = [
      author, 'SimpleITK', 'One line description of project.',
      'Miscellaneous'),
 ]
+
+extensions = ['sphinx_tabs.tabs']

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,2 @@
+
+requirements_file: Documentation/docs/requirements.txt


### PR DESCRIPTION
Code examples now appear in tabs, in alphabetical order. This is done
using the sphinx-tabs extension
(https://github.com/djungelorm/sphinx-tabs).