### PR TITLE
Added Java DicomSeriesReader example in documentation

### DIFF
--- a/Examples/DicomSeriesReader/CMakeLists.txt
+++ b/Examples/DicomSeriesReader/CMakeLists.txt
@@ -46,8 +46,8 @@ sitk_add_r_test( Example.DicomSeriesReader
   sitk_add_java_test( Example.DicomSeriesReader
     "${CMAKE_CURRENT_SOURCE_DIR}/DicomSeriesReader.java"
       DATA{${SimpleITK_DATA_ROOT}/Input/DicomSeries/,REGEX:Image[0-9]+.dcm}
-      "${SimpleITK_TEST_OUTPUT_DIR}/RDicomSeriesReader.nrrd"
+      "${SimpleITK_TEST_OUTPUT_DIR}/Java.DicomSeriesReader.nrrd"
     IMAGE_MD5_COMPARE
-      "${SimpleITK_TEST_OUTPUT_DIR}/RDicomSeriesReader.nrrd"
+      "${SimpleITK_TEST_OUTPUT_DIR}/Java.DicomSeriesReader.nrrd"
       "8e65f711d450b6b466c6d76a667ecb72"
     )

--- a/Examples/DicomSeriesReader/CMakeLists.txt
+++ b/Examples/DicomSeriesReader/CMakeLists.txt
@@ -43,3 +43,11 @@ sitk_add_r_test( Example.DicomSeriesReader
     "8e65f711d450b6b466c6d76a667ecb72"
   )
 
+  sitk_add_java_test( Example.DicomSeriesReader
+    "${CMAKE_CURRENT_SOURCE_DIR}/DicomSeriesReader.java"
+      DATA{${SimpleITK_DATA_ROOT}/Input/DicomSeries/,REGEX:Image[0-9]+.dcm}
+      "${SimpleITK_TEST_OUTPUT_DIR}/RDicomSeriesReader.nrrd"
+    IMAGE_MD5_COMPARE
+      "${SimpleITK_TEST_OUTPUT_DIR}/RDicomSeriesReader.nrrd"
+      "8e65f711d450b6b466c6d76a667ecb72"
+    )

--- a/Examples/DicomSeriesReader/DicomSeriesReader.java
+++ b/Examples/DicomSeriesReader/DicomSeriesReader.java
@@ -21,11 +21,11 @@ package examples;
 import org.itk.simple.*;
 
 public class DicomSeriesReader {
-  public static int test(String[] args) {
+  public static void main(String[] args) {
 
     if (args.length < 2) {
       System.out.println("Usage: DicomSeriesReader <input_directory> <output_file>");
-      return 1;
+      System.exit(1);
     }
 
     System.out.println("Reading Dicom directory: " + args[0]);
@@ -42,7 +42,5 @@ public class DicomSeriesReader {
     System.out.println("Writing " + args[1]);
 
     SimpleITK.writeImage(image, args[1]);
-
-    return 0;
   }
 }

--- a/Examples/DicomSeriesReader/DicomSeriesReader.java
+++ b/Examples/DicomSeriesReader/DicomSeriesReader.java
@@ -1,0 +1,48 @@
+/*=========================================================================
+*
+*  Copyright Insight Software Consortium
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*         http://www.apache.org/licenses/LICENSE-2.0.txt
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*=========================================================================*/
+
+package examples;
+
+import org.itk.simple.*;
+
+public class DicomSeriesReader {
+  public static int test(String[] args) {
+
+    if (args.length < 2) {
+      System.out.println("Usage: DicomSeriesReader <input_directory> <output_file>");
+      return 1;
+    }
+
+    System.out.println("Reading Dicom directory: " + args[0]);
+
+    ImageSeriesReader imageSeriesReader = new ImageSeriesReader();
+    final VectorString dicomNames = ImageSeriesReader.getGDCMSeriesFileNames(args[0]);
+    imageSeriesReader.setFileNames(dicomNames);
+
+    Image image = imageSeriesReader.execute();
+
+    VectorUInt32 size = image.getSize();
+    System.out.println("Image size: " + size.get(0) + " " + size.get(1) + " " + size.get(2));
+
+    System.out.println("Writing " + args[1]);
+
+    SimpleITK.writeImage(image, args[1]);
+
+    return 0;
+  }
+}

--- a/Examples/DicomSeriesReader/Documentation.rst
+++ b/Examples/DicomSeriesReader/Documentation.rst
@@ -23,6 +23,12 @@ Code
        :language: c++
        :lines: 18-
 
+  ..tab:: Java
+
+    .. literalinclude:: DicomSeriesReader.java
+       :language: java
+       :lines: 18-
+
   .. tab:: Lua
 
     .. literalinclude:: DicomSeriesReader.lua


### PR DESCRIPTION
Adds an implementation of the DicomSeriesReader example in Java. I've also updated the Documentation.rst file to accomodate this.