### PR TITLE
Use SITK_NULLPTR for c++11 compatibility for nullptr

### DIFF
--- a/Code/BasicFilters/src/sitkCreateInterpolator.hxx
+++ b/Code/BasicFilters/src/sitkCreateInterpolator.hxx
@@ -19,6 +19,7 @@
 #define sitkCreateInterpolator_hxx
 
 
+#include "sitkMacro.h"
 #include "sitkInterpolator.h"
 #include <itkNearestNeighborInterpolateImageFunction.h>
 #include <itkLinearInterpolateImageFunction.h>
@@ -140,7 +141,7 @@ CreateInterpolator( const TImageType *image, InterpolatorEnum itype )
       return RType( ConditionalCreateInterpolator<InterpolatorType>( typename IsBasic<TImageType>::Type() ) );
     }
     default:
-      return NULL;
+      return  SITK_NULLPTR;
     }
 
 }

--- a/Code/Common/include/sitkDualMemberFunctionFactory.hxx
+++ b/Code/Common/include/sitkDualMemberFunctionFactory.hxx
@@ -48,7 +48,7 @@ struct DualMemberFunctionInstantiater
   template <class TPixelIDType1, class TPixelIDType2>
   typename EnableIf< IsInstantiated<TPixelIDType1,VImageDimension>::Value &&
                      IsInstantiated<TPixelIDType2,VImageDimension>::Value >::Type
-  operator()( TPixelIDType1* t1=NULL, TPixelIDType2*t2=NULL ) const
+  operator()( TPixelIDType1* t1=SITK_NULLPTR, TPixelIDType2*t2=SITK_NULLPTR ) const
     {
       (void)t1;
       (void)t2;
@@ -57,7 +57,7 @@ struct DualMemberFunctionInstantiater
       typedef TAddressor                                                             AddressorType;
 
       AddressorType addressor;
-      m_Factory.Register(addressor.CLANG_TEMPLATE operator()<ImageType1, ImageType2>(), (ImageType1*)(NULL), (ImageType2*)(NULL) );
+      m_Factory.Register(addressor.CLANG_TEMPLATE operator()<ImageType1, ImageType2>(), (ImageType1*)(SITK_NULLPTR), (ImageType2*)(SITK_NULLPTR) );
 
     }
 
@@ -65,7 +65,7 @@ struct DualMemberFunctionInstantiater
   template <class TPixelIDType1, class TPixelIDType2>
   typename DisableIf< IsInstantiated<TPixelIDType1,VImageDimension>::Value &&
                      IsInstantiated<TPixelIDType2,VImageDimension>::Value >::Type
-  operator()( TPixelIDType1*t1=NULL, TPixelIDType2*t2=NULL ) const
+  operator()( TPixelIDType1*t1=SITK_NULLPTR, TPixelIDType2*t2=SITK_NULLPTR ) const
     {
       (void)t1;
       (void)t2;

--- a/Code/Common/include/sitkImage.h
+++ b/Code/Common/include/sitkImage.h
@@ -104,7 +104,7 @@ namespace simple
      */
     template <typename TImageType>
     explicit Image( itk::SmartPointer<TImageType> image )
-      : m_PimpleImage( NULL )
+      : m_PimpleImage( SITK_NULLPTR )
       {
         sitkStaticAssert( ImageTypeToPixelIDValue<TImageType>::Result != (int)sitkUnknown,
                           "invalid pixel type" );
@@ -112,7 +112,7 @@ namespace simple
       }
     template <typename TImageType>
     explicit Image( TImageType* image )
-      : m_PimpleImage( NULL )
+      : m_PimpleImage( SITK_NULLPTR )
       {
         sitkStaticAssert( ImageTypeToPixelIDValue<TImageType>::Result != (int)sitkUnknown,
                           "invalid pixel type" );

--- a/Code/Common/include/sitkMacro.h
+++ b/Code/Common/include/sitkMacro.h
@@ -104,7 +104,7 @@ class GenericException;
       }                                                                 \
   }
 
-#if defined(SITK_HAS_CXX11_NULLPTR) && !defined(SITK_HAS_TR1_SUB_INCLUDE)
+#if defined(SITK_HAS_CXX11_NULLPTR)
 #define SITK_NULLPTR nullptr
 #else
 #define SITK_NULLPTR NULL

--- a/Code/Common/include/sitkMemberFunctionFactory.hxx
+++ b/Code/Common/include/sitkMemberFunctionFactory.hxx
@@ -49,21 +49,21 @@ struct MemberFunctionInstantiater
 
   template <class TPixelIDType>
   typename EnableIf< IsInstantiated<TPixelIDType, VImageDimension >::Value >::Type
-  operator()( TPixelIDType*id=NULL ) const
+  operator()( TPixelIDType*id=SITK_NULLPTR ) const
     {
       Unused( id );
       typedef typename PixelIDToImageType<TPixelIDType, VImageDimension>::ImageType ImageType;
       typedef TAddressor                                                            AddressorType;
 
       AddressorType addressor;
-      m_Factory.Register(addressor.CLANG_TEMPLATE operator()<ImageType>(), (ImageType*)(NULL));
+      m_Factory.Register(addressor.CLANG_TEMPLATE operator()<ImageType>(), (ImageType*)(SITK_NULLPTR));
 
     }
 
   // this methods is conditionally enabled when the PixelID is not instantiated
   template <class TPixelIDType>
   typename DisableIf< IsInstantiated<TPixelIDType, VImageDimension>::Value >::Type
-  operator()( TPixelIDType*id=NULL ) const
+  operator()( TPixelIDType*id=SITK_NULLPTR ) const
   {
     Unused( id );
   }

--- a/Code/Common/include/sitkTransform.h
+++ b/Code/Common/include/sitkTransform.h
@@ -96,10 +96,10 @@ public:
    */
   template<unsigned int NDimension>
   explicit Transform( itk::CompositeTransform< double, NDimension >* compositeTransform )
-    : m_PimpleTransform( NULL )
+    : m_PimpleTransform( SITK_NULLPTR )
     {
       sitkStaticAssert( NDimension == 2 || NDimension == 3, "Only 2D and 3D transforms are supported" );
-      if ( compositeTransform == NULL )
+      if ( compositeTransform == SITK_NULLPTR )
         {
         sitkExceptionMacro( "Unable to construct a null transform!" );
         }
@@ -236,7 +236,7 @@ protected:
 private:
 
   template< unsigned int VDimension>
-  void InternalInitialization( TransformEnum type, itk::TransformBase *base = NULL );
+  void InternalInitialization( TransformEnum type, itk::TransformBase *base = SITK_NULLPTR );
 
   struct TransformTryCastVisitor
   {

--- a/Code/Common/src/sitkDisplacementFieldTransform.cxx
+++ b/Code/Common/src/sitkDisplacementFieldTransform.cxx
@@ -327,7 +327,7 @@ Image DisplacementFieldTransform::InternalGetDisplacementField( const TDisplacem
   // field, but it does not have the correct reference count.
   typedef typename TDisplacementFieldTransform::DisplacementFieldType DisplacementFieldType;
   DisplacementFieldType *itkDisplacement = const_cast<DisplacementFieldType*>(itkDisplacementTx->GetDisplacementField());
-  if (itkDisplacement != NULL)
+  if (itkDisplacement != SITK_NULLPTR)
     {
     return Image(GetVectorImageFromImage(itkDisplacement));
     }
@@ -339,7 +339,7 @@ Image DisplacementFieldTransform::InternalGetInverseDisplacementField( const TDi
 {
   typedef typename TDisplacementFieldTransform::DisplacementFieldType DisplacementFieldType;
   DisplacementFieldType *itkDisplacement = const_cast<DisplacementFieldType*>(itkDisplacementTx->GetInverseDisplacementField());
-  if (itkDisplacement != NULL)
+  if (itkDisplacement != SITK_NULLPTR)
     {
     return Image(GetVectorImageFromImage(itkDisplacement));
     }

--- a/Code/Common/src/sitkExceptionObject.cxx
+++ b/Code/Common/src/sitkExceptionObject.cxx
@@ -30,7 +30,7 @@ namespace simple
 {
 
 GenericException::GenericException() SITK_NOEXCEPT
-  : m_PimpleException( NULL )
+  : m_PimpleException( SITK_NULLPTR )
 {}
 
 GenericException::GenericException( const GenericException &e ) SITK_NOEXCEPT
@@ -39,14 +39,14 @@ GenericException::GenericException( const GenericException &e ) SITK_NOEXCEPT
 {
   try
     {
-    if ( e.m_PimpleException != NULL )
+    if ( e.m_PimpleException != SITK_NULLPTR )
       {
       m_PimpleException =  new itk::ExceptionObject( *e.m_PimpleException );
       }
     }
   catch(...) // prevent exception from leaving constructor
     {
-    this->m_PimpleException = NULL;
+    this->m_PimpleException = SITK_NULLPTR;
     }
 }
 
@@ -58,7 +58,7 @@ GenericException::GenericException(const char *file, unsigned int lineNumber) SI
     }
   catch(...) // prevent exception from leaving constructor
     {
-    this->m_PimpleException = NULL;
+    this->m_PimpleException = SITK_NULLPTR;
     }
 }
 
@@ -71,7 +71,7 @@ GenericException::GenericException(const std::string & file, unsigned int lineNu
     }
   catch(...) // prevent exception from leaving constructor
     {
-    this->m_PimpleException = NULL;
+    this->m_PimpleException = SITK_NULLPTR;
     }
 }
 
@@ -86,7 +86,7 @@ GenericException::GenericException(const std::string & file,
     }
   catch(...) // prevent exception from leaving constructor
     {
-    this->m_PimpleException = NULL;
+    this->m_PimpleException = SITK_NULLPTR;
     }
 }
 
@@ -109,8 +109,8 @@ bool GenericException::operator==(const GenericException & orig) const
     {
     return this->m_PimpleException == orig.m_PimpleException;
     }
-  else if (  this->m_PimpleException == NULL &&
-             orig.m_PimpleException == NULL )
+  else if (  this->m_PimpleException == SITK_NULLPTR &&
+             orig.m_PimpleException == SITK_NULLPTR )
     {
     return true;
     }

--- a/Code/Common/src/sitkImage.cxx
+++ b/Code/Common/src/sitkImage.cxx
@@ -33,11 +33,11 @@ namespace itk
   Image::~Image( )
   {
     delete this->m_PimpleImage;
-    this->m_PimpleImage = NULL;
+    this->m_PimpleImage = SITK_NULLPTR;
   }
 
   Image::Image( )
-    : m_PimpleImage( NULL )
+    : m_PimpleImage( SITK_NULLPTR )
   {
     Allocate ( 0, 0, 0, 0, sitkUInt8, 1 );
   }
@@ -58,19 +58,19 @@ namespace itk
   }
 
     Image::Image( unsigned int Width, unsigned int Height, PixelIDValueEnum ValueEnum )
-      : m_PimpleImage( NULL )
+      : m_PimpleImage( SITK_NULLPTR )
     {
       Allocate ( Width, Height, 0, 0, ValueEnum, 0 );
     }
 
     Image::Image( unsigned int Width, unsigned int Height, unsigned int Depth, PixelIDValueEnum ValueEnum )
-      : m_PimpleImage( NULL )
+      : m_PimpleImage( SITK_NULLPTR )
     {
       Allocate ( Width, Height, Depth, 0, ValueEnum, 0 );
     }
 
     Image::Image( const std::vector< unsigned int > &size, PixelIDValueEnum ValueEnum, unsigned int numberOfComponents )
-      : m_PimpleImage( NULL )
+      : m_PimpleImage( SITK_NULLPTR )
     {
       if ( size.size() == 2 )
         {

--- a/Code/Common/src/sitkImage.hxx
+++ b/Code/Common/src/sitkImage.hxx
@@ -64,7 +64,7 @@ namespace itk
   {
     // no need to check if null
     delete this->m_PimpleImage;
-    this->m_PimpleImage = NULL;
+    this->m_PimpleImage = SITK_NULLPTR;
 
     this->m_PimpleImage = new PimpleImage<TImageType>( image );
   }
@@ -110,7 +110,7 @@ namespace itk
     image->FillBuffer ( itk::NumericTraits<typename TImageType::PixelType>::Zero );
 
     delete this->m_PimpleImage;
-    this->m_PimpleImage = NULL;
+    this->m_PimpleImage = SITK_NULLPTR;
     m_PimpleImage =  new PimpleImage<TImageType>( image );
   }
 
@@ -158,7 +158,7 @@ namespace itk
     image->FillBuffer ( zero );
 
     delete this->m_PimpleImage;
-    this->m_PimpleImage = NULL;
+    this->m_PimpleImage = SITK_NULLPTR;
 
     m_PimpleImage = new PimpleImage<TImageType>( image );
   }
@@ -203,7 +203,7 @@ namespace itk
     image->SetBackgroundValue( 0 );
 
     delete this->m_PimpleImage;
-    this->m_PimpleImage = NULL;
+    this->m_PimpleImage = SITK_NULLPTR;
 
     m_PimpleImage = new PimpleImage<TImageType>( image );
   }

--- a/Code/Common/src/sitkPimpleImageBase.hxx
+++ b/Code/Common/src/sitkPimpleImageBase.hxx
@@ -63,7 +63,7 @@ namespace itk
         sitkStaticAssert( ImageTypeToPixelIDValue<ImageType>::Result != (int)sitkUnknown,
                           "invalid pixel type" );
 
-        if ( image == NULL )
+        if ( image == SITK_NULLPTR )
           {
           sitkExceptionMacro( << "Unable to initialize an image with NULL" );
           }

--- a/Code/Common/src/sitkProcessObject.cxx
+++ b/Code/Common/src/sitkProcessObject.cxx
@@ -103,7 +103,7 @@ private:
 ProcessObject::ProcessObject ()
   : m_Debug(ProcessObject::GetGlobalDefaultDebug()),
     m_NumberOfThreads(ProcessObject::GetGlobalDefaultNumberOfThreads()),
-    m_ActiveProcess(NULL),
+    m_ActiveProcess(SITK_NULLPTR),
     m_ProgressMeasurement(0.0)
 {
 }
@@ -399,7 +399,7 @@ void ProcessObject::PreUpdate(itk::ProcessObject *p)
     }
   catch (...)
     {
-    this->m_ActiveProcess = NULL;
+    this->m_ActiveProcess = SITK_NULLPTR;
     throw;
     }
 
@@ -480,7 +480,7 @@ void ProcessObject::OnActiveProcessDelete( )
       i->m_ITKTag = std::numeric_limits<unsigned long>::max();
       }
 
-  this->m_ActiveProcess = NULL;
+  this->m_ActiveProcess = SITK_NULLPTR;
 }
 
 

--- a/Code/Common/src/sitkTransform.cxx
+++ b/Code/Common/src/sitkTransform.cxx
@@ -176,7 +176,7 @@ public:
   void Execute(const itk::Object*, const itk::EventObject&) SITK_OVERRIDE {}
 
 protected:
-  HolderCommand() : m_Object(NULL) {};
+  HolderCommand() : m_Object(SITK_NULLPTR) {};
   ~HolderCommand() { delete m_Object;}
 
 private:
@@ -195,19 +195,19 @@ private:
 //
 
 Transform::Transform( )
-  : m_PimpleTransform( NULL )
+  : m_PimpleTransform( SITK_NULLPTR )
   {
     m_PimpleTransform = new PimpleTransform<itk::IdentityTransform< double, 3 > >();
   }
 
 Transform::Transform( itk::TransformBase *transformBase )
-  : m_PimpleTransform( NULL )
+  : m_PimpleTransform( SITK_NULLPTR )
 {
   this->InternalInitialization( transformBase );
 }
 
   Transform::Transform( unsigned int dimensions, TransformEnum type)
-    : m_PimpleTransform( NULL )
+    : m_PimpleTransform( SITK_NULLPTR )
   {
     if ( dimensions == 2 )
       {
@@ -227,11 +227,11 @@ Transform::Transform( itk::TransformBase *transformBase )
   Transform::~Transform()
   {
     delete m_PimpleTransform;
-    this->m_PimpleTransform = NULL;
+    this->m_PimpleTransform = SITK_NULLPTR;
   }
 
   Transform::Transform( const Transform &txf )
-    : m_PimpleTransform( NULL )
+    : m_PimpleTransform( SITK_NULLPTR )
   {
     Self::SetPimpleTransform( txf.m_PimpleTransform->ShallowCopy() );
   }
@@ -246,7 +246,7 @@ Transform::Transform( itk::TransformBase *transformBase )
 
 
 Transform::Transform( Image &image, TransformEnum txType )
-    : m_PimpleTransform( NULL )
+    : m_PimpleTransform( SITK_NULLPTR )
   {
 
 
@@ -372,7 +372,7 @@ void Transform::MakeUnique( void )
 Transform::Transform( PimpleTransformBase *pimpleTransform )
     : m_PimpleTransform( pimpleTransform )
   {
-    if ( pimpleTransform == NULL )
+    if ( pimpleTransform == SITK_NULLPTR )
       {
       sitkExceptionMacro("Invalid NULL PimpleTransform!");
       }
@@ -581,7 +581,7 @@ void Transform::SetPimpleTransform( PimpleTransformBase *pimpleTransform )
     nsstd::auto_ptr<PimpleTransformBase> temp;
     {
     // See if a new pimple transform can be created
-    PimpleTransformBase *p = NULL;
+    PimpleTransformBase *p = SITK_NULLPTR;
     if (!this->m_PimpleTransform->GetInverse(p))
       {
       return false;

--- a/Code/Registration/src/sitkCreateInterpolator.hxx
+++ b/Code/Registration/src/sitkCreateInterpolator.hxx
@@ -140,7 +140,7 @@ CreateInterpolator( const TImageType *image, InterpolatorEnum itype )
       return RType( ConditionalCreateInterpolator<InterpolatorType>( typename IsBasic<TImageType>::Type() ) );
     }
     default:
-      return NULL;
+      return SITK_NULLPTR;
     }
 
 }


### PR DESCRIPTION
This addresses compiler issues against ITK 5.0 for implicit
construction for SmartPointers.