### PR TITLE
Use MultiThreader typedef for future ITK compatibility.

### DIFF
--- a/Code/Common/src/sitkProcessObject.cxx
+++ b/Code/Common/src/sitkProcessObject.cxx
@@ -267,13 +267,13 @@ void ProcessObject::SetGlobalDefaultDirectionTolerance(double tolerance)
 
 void ProcessObject::SetGlobalDefaultNumberOfThreads(unsigned int n)
 {
-  MultiThreader::SetGlobalDefaultNumberOfThreads(n);
+  itk::ProcessObject::MultiThreaderType::SetGlobalDefaultNumberOfThreads(n);
 }
 
 
 unsigned int ProcessObject::GetGlobalDefaultNumberOfThreads()
 {
-  return MultiThreader::GetGlobalDefaultNumberOfThreads();
+  return itk::ProcessObject::MultiThreaderType::GetGlobalDefaultNumberOfThreads();
 }
 
 


### PR DESCRIPTION
The patch enable compilation with ITK 4.13 and the current development
version of ITK 5.0. The new version is changing the base multi-theader
class.