### PR TITLE
sitkLanguageOptions: Improve setting of default value for wrap options

### DIFF
--- a/CMake/sitkLanguageOptions.cmake
+++ b/CMake/sitkLanguageOptions.cmake
@@ -15,25 +15,15 @@ sitk_check_dynamic_lookup(MODULE
   SITK_UNDEFINED_SYMBOLS_ALLOWED
   )
 
+if ( SITK_UNDEFINED_SYMBOLS_ALLOWED )
+  set( _REQUIRED_LIBRARY "QUIET" )
+else ( )
+  set( _REQUIRED_LIBRARY "REQUIRED" )
+endif ( )
+
+
 option(WRAP_DEFAULT "The default initial value for wrapping a language when it is detected on the system." ON)
 mark_as_advanced(WRAP_DEFAULT)
-
-#
-# Macro to set "_QUIET" and "_QUIET_LIBRARY" based on the first
-# argument being defined and true, to either REQUIRED or QUIET.
-#
-macro(set_QUIET var)
-  if ( DEFINED  ${var} AND ${var} )
-    set( _QUIET "REQUIRED" )
-  else()
-    set( _QUIET "QUIET" )
-  endif()
-  if ( SITK_UNDEFINED_SYMBOLS_ALLOWED )
-    set( _QUIET_LIBRARY "QUIET" )
-  else()
-    set( _QUIET_LIBRARY ${_QUIET} )
-  endif()
-endmacro()
 
 #
 # Setup the option for each language
@@ -42,21 +32,25 @@ endmacro()
 #-----------------------------------------------------------
 # Lua
 
-set_QUIET( WRAP_LUA )
-find_package ( Lua ${_QUIET} )
-
-if ( LUA_FOUND )
-  set( WRAP_LUA_DEFAULT ${WRAP_DEFAULT} )
-else()
+if ( DEFINED WRAP_LUA )
+  set ( WRAP_LUA_DEFAULT ${WRAP_LUA} )
+elseif ( NOT WRAP_DEFAULT )
   set( WRAP_LUA_DEFAULT OFF )
-endif()
-
-set( LUA_ADDITIONAL_LIBRARIES "" CACHE STRING "Additional libraries which may be needed for lua such as readline.")
-mark_as_advanced( LUA_ADDITIONAL_LIBRARIES )
+else ( )
+  find_package ( Lua QUIET )
+  if ( LUA_FOUND )
+    set( WRAP_LUA_DEFAULT ${WRAP_DEFAULT} )
+  else ( )
+    set( WRAP_LUA_DEFAULT OFF )
+  endif ( )
+endif ( )
 
 option ( WRAP_LUA "Wrap Lua" ${WRAP_LUA_DEFAULT} )
 
 if ( WRAP_LUA )
+  set( LUA_ADDITIONAL_LIBRARIES "" CACHE STRING "Additional libraries which may be needed for lua such as readline.")
+  mark_as_advanced( LUA_ADDITIONAL_LIBRARIES )
+  find_package ( Lua REQUIRED )
   find_package( LuaInterp REQUIRED )
   list( APPEND SITK_LANGUAGES_VARS
     LUA_EXECUTABLE
@@ -69,31 +63,42 @@ if ( WRAP_LUA )
 endif()
 
 
+
 #-----------------------------------------------------------
 # Python
 
-set_QUIET( WRAP_PYTHON )
-find_package ( PythonInterp ${_QUIET})
-if ( PYTHONINTERP_FOUND )
-  find_package ( PythonLibs ${PYTHON_VERSION_STRING} EXACT ${_QUIET_LIBRARY} )
-else ()
-  find_package ( PythonLibs ${_QUIET_LIBRARY} )
-endif()
-
-if ( PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND
-    AND (PYTHON_VERSION_STRING VERSION_EQUAL PYTHONLIBS_VERSION_STRING) )
-  set( WRAP_PYTHON_DEFAULT ${WRAP_DEFAULT} )
-else()
-  set( WRAP_PYTHON_DEFAULT OFF )
-endif()
+if ( DEFINED WRAP_PYTHON )
+  set ( WRAP_PYTHON_DEFAULT ${WRAP_PYTHON} )
+elseif ( NOT WRAP_DEFAULT )
+  set ( WRAP_PYTHON_DEFAULT OFF )
+else ( )
+  find_package ( PythonInterp QUIET)
+  if ( PYTHONINTERP_FOUND )
+    find_package ( PythonLibs ${PYTHON_VERSION_STRING} EXACT QUIET )
+  else ()
+    find_package ( PythonLibs QUIET )
+  endif ( )
+  if ( PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND
+      AND (PYTHON_VERSION_STRING VERSION_EQUAL PYTHONLIBS_VERSION_STRING) )
+    set( WRAP_PYTHON_DEFAULT ${WRAP_DEFAULT} )
+  else ( )
+    set( WRAP_PYTHON_DEFAULT OFF )
+  endif ( )
+endif ( )
 
 option( WRAP_PYTHON "Wrap Python" ${WRAP_PYTHON_DEFAULT} )
 
-if ( WRAP_PYTHON AND PYTHON_VERSION_STRING VERSION_LESS 2.7 )
-  message( WARNING "Python version less than 2.7: \"${PYTHON_VERSION_STRING}\"." )
-endif()
-
 if ( WRAP_PYTHON )
+  find_package ( PythonInterp REQUIRED)
+  if ( PYTHONINTERP_FOUND )
+    find_package ( PythonLibs ${PYTHON_VERSION_STRING} EXACT ${_REQUIRED_LIBRARY} )
+  else ()
+    find_package ( PythonLibs ${_REQUIRED_LIBRARY} )
+  endif()
+  if ( PYTHON_VERSION_STRING VERSION_LESS 2.7 )
+    message( WARNING "Python version less than 2.7: \"${PYTHON_VERSION_STRING}\"." )
+  endif()
+
   list( APPEND SITK_LANGUAGES_VARS
     PYTHON_DEBUG_LIBRARY
     PYTHON_EXECUTABLE
@@ -114,18 +119,25 @@ endif ()
 #-----------------------------------------------------------
 # Java
 
-set_QUIET( WRAP_JAVA )
-find_package ( Java COMPONENTS Development Runtime ${_QUIET} )
-find_package ( JNI ${_QUIET} )
-if ( JAVA_FOUND AND JNI_FOUND )
-  set( WRAP_JAVA_DEFAULT ${WRAP_DEFAULT} )
-else ( ${JAVA_FOUND} AND JNI_FOUND )
-  set( WRAP_JAVA_DEFAULT OFF )
+if ( DEFINED WRAP_JAVA )
+  set( WRAP_JAVA_DEFAULT ${WRAP_JAVA} )
+elseif ( NOT WRAP_DEFAULT )
+  set ( WRAP_JAVA_DEFAULT OFF )
+else ( )
+  find_package ( Java COMPONENTS Development Runtime QUIET )
+  find_package ( JNI QUIET )
+  if ( JAVA_FOUND AND JNI_FOUND )
+    set( WRAP_JAVA_DEFAULT ${WRAP_DEFAULT} )
+  else ( ${JAVA_FOUND} AND JNI_FOUND )
+    set( WRAP_JAVA_DEFAULT OFF )
+  endif ( )
 endif ( )
 
 option ( WRAP_JAVA "Wrap Java" ${WRAP_JAVA_DEFAULT} )
 
 if ( WRAP_JAVA )
+  find_package ( Java COMPONENTS Development Runtime REQUIRED )
+  find_package ( JNI REQUIRED )
   list( APPEND SITK_LANGUAGES_VARS
     Java_JAVA_EXECUTABLE
     Java_JAVAC_EXECUTABLE
@@ -154,19 +166,23 @@ endif()
 #-----------------------------------------------------------
 # Tcl
 
-set_QUIET(WRAP_TCL)
-
-find_package ( TCL ${_QUIET} )
-
-if ( TCL_FOUND )
-  set ( WRAP_TCL_DEFAULT ${WRAP_DEFAULT} )
-else ( )
+if ( DEFINED WRAP_TCL)
+  set( WRAP_TCL_DEFAULT ${WRAP_TCL} )
+elseif ( NOT WRAP_DEFAULT )
   set ( WRAP_TCL_DEFAULT OFF )
+else ( )
+  find_package ( TCL QUIET )
+  if ( TCL_FOUND )
+    set ( WRAP_TCL_DEFAULT ${WRAP_DEFAULT} )
+  else ( )
+    set ( WRAP_TCL_DEFAULT OFF )
+  endif ( )
 endif ( )
 
 option ( WRAP_TCL "Wrap Tcl" ${WRAP_TCL_DEFAULT} )
 
 if ( WRAP_TCL )
+  find_package ( TCL REQUIRED )
   list( APPEND SITK_LANGUAGES_VARS
     TCL_LIBRARY
     TCL_INCLUDE_PATH
@@ -175,24 +191,29 @@ if ( WRAP_TCL )
     TK_INCLUDE_PATH
     TK_WISH
     )
-endif()
+endif ( )
 
 
 #-----------------------------------------------------------
 # Ruby
 
-set_QUIET( WRAP_RUBY )
-
-find_package ( Ruby ${_QUIET} )
-if ( RUBY_FOUND )
-  set ( WRAP_RUBY_DEFAULT ${WRAP_DEFAULT} )
-else ( )
+if ( DEFINED WRAP_RUBY )
+  set ( WRAP_RUBY_DEFAULT ${WRAP_RUBY} )
+elseif ( NOT WRAP_DEFAULT )
   set ( WRAP_RUBY_DEFAULT OFF )
+else()
+  find_package ( Ruby QUIET )
+  if ( RUBY_FOUND )
+    set ( WRAP_RUBY_DEFAULT ${WRAP_DEFAULT} )
+  else ( )
+    set ( WRAP_RUBY_DEFAULT OFF )
+  endif ( )
 endif ( )
 
 option ( WRAP_RUBY "Wrap Ruby" ${WRAP_RUBY_DEFAULT} )
 
 if ( WRAP_RUBY )
+  find_package ( Ruby REQUIRED )
   list( APPEND SITK_LANGUAGES_VARS
     RUBY_EXECUTABLE
     RUBY_INCLUDE_DIRS
@@ -207,18 +228,23 @@ endif()
 #-----------------------------------------------------------
 #  CSharp
 
-set_QUIET( WRAP_CSHARP )
-
-find_package( CSharp ${_QUIET} )
-if ( CSHARP_FOUND AND NOT MINGW )
-  set ( WRAP_CSHARP_DEFAULT ${WRAP_DEFAULT} )
-else ()
+if ( DEFINED WRAP_CSHARP)
+  set ( WRAP_CSHARP_DEFAULT ${WRAP_CSHARP} )
+elseif ( NOT WRAP_DEFAULT )
   set ( WRAP_CSHARP_DEFAULT OFF )
-endif ()
+else ( )
+  find_package( CSharp QUIET )
+  if ( CSHARP_FOUND AND NOT MINGW )
+    set ( WRAP_CSHARP_DEFAULT ${WRAP_DEFAULT} )
+  else ()
+    set ( WRAP_CSHARP_DEFAULT OFF )
+  endif ()
+endif ( )
 
 option ( WRAP_CSHARP "Wrap C#" ${WRAP_CSHARP_DEFAULT} )
 
 if ( WRAP_CSHARP )
+  find_package( CSharp REQUIRED )
   list( APPEND SITK_LANGUAGES_VARS
     CSHARP_COMPILER
     CSHARP_INTERPRETER
@@ -230,18 +256,23 @@ endif()
 #-----------------------------------------------------------
 #  R
 
-set_QUIET( WRAP_R )
-
-find_package(R ${_QUIET})
-if ( R_FOUND AND NOT WIN32 )
-  set ( WRAP_R_DEFAULT ${WRAP_DEFAULT} )
-else( )
+if ( DEFINED WRAP_R)
+  set ( WRAP_R_DEFAULT ${WRAP_R} )
+elseif ( NOT WRAP_DEFAULT )
   set ( WRAP_R_DEFAULT OFF )
-endif( )
+else()
+  find_package(R QUIET)
+  if ( R_FOUND AND NOT WIN32 )
+    set ( WRAP_R_DEFAULT ${WRAP_DEFAULT} )
+  else( )
+    set ( WRAP_R_DEFAULT OFF )
+  endif( )
+endif()
 
 option ( WRAP_R "Wrap R" ${WRAP_R_DEFAULT} )
 
 if ( WRAP_R )
+  find_package(R REQUIRED)
   list( APPEND SITK_LANGUAGES_VARS
     R_INCLUDE_DIR
     R_LIBRARIES


### PR DESCRIPTION
This commit makes sure no calls to "find_package(<languageName>)" are
done if the option WRAP_<languageName> is explicitly set to OFF.

Indeed, systematically calling "find_package()" can have side-effect.
See https://discourse.slicer.org/t/nightly-mac-slicer-4-9-0-2018-03-13-macosx-amd64-does-not-open/2313/7

Change-Id: If58a333b29feef5055f03a4612443020e2a6afa7