### PR TITLE
Propagate CMAKE_DISABLE_FIND_PACKAGE_* to SimpleITK superbuild

### DIFF
--- a/SuperBuild/SuperBuild.cmake
+++ b/SuperBuild/SuperBuild.cmake
@@ -386,6 +386,8 @@ foreach (_varName ${_varNames})
          _varName MATCHES "^BUILD_DOXYGEN$"
        OR
          _varName MATCHES "^DOXYGEN_"
+       OR
+         _varName MATCHES "^CMAKE_DISABLE_FIND_PACKAGE_"
          )
     message( STATUS "Passing variable \"${_varName}=${${_varName}}\" to SimpleITK external project.")
     list(APPEND SimpleITK_VARS ${_varName})


### PR DESCRIPTION
Calling find_package for all languages can have side effects, such as
on OSX, displaying a prompt to install Java. There must be a way to
disable searching for wrapped languages. This patch enables a standard
CMake variable to disable finding languages.

Suggested-by: Jean-Christophe Fillion-Robin <jchris.fillionr@kitware.com>

See #424 for suggestion