### PR TITLE
Adding support for vector images in as.image conversion.

### DIFF
--- a/Wrapping/R/Packaging/SimpleITK/R/zA.R
+++ b/Wrapping/R/Packaging/SimpleITK/R/zA.R
@@ -242,8 +242,17 @@ setMethod('as.array', "_p_itk__simple__Image",
           )
 
 as.image <- function(arr, spacing=rep(1, length(dim(arr))),
-                     origin=rep(0,length(dim(arr))))
+                     origin=rep(0,length(dim(arr))),
+                     isVector=FALSE)
   {
-    size <- dim(arr)
-    return(ArrayAsIm(arr, size, spacing,origin))
+    data_len <- dim(arr)
+    if(isVector) {
+      size <- head(data_len, length(data_len)-1)
+      number_of_components <- tail(data_len, 1)
+    }
+    else {
+      size <- data_len
+      number_of_components <- 1
+    }
+    return(ArrayAsIm(arr, size, spacing, origin, number_of_components))
   }

--- a/Wrapping/R/R.i
+++ b/Wrapping/R/R.i
@@ -163,7 +163,8 @@ SEXP ImAsArray(itk::simple::Image src);
 itk::simple::Image ArrayAsIm(SEXP arr,
                              std::vector<unsigned int> size,
                              std::vector<double> spacing,
-                             std::vector<double> origin);
+                             std::vector<double> origin,
+                             unsigned int numberOfComponents);
 %}
 
 

--- a/Wrapping/R/sitkRArray.cxx
+++ b/Wrapping/R/sitkRArray.cxx
@@ -170,7 +170,8 @@ SEXP ImAsArray(itk::simple::Image src)
 itk::simple::Image ArrayAsIm(SEXP arr,
                              std::vector<unsigned int> size,
                              std::vector<double> spacing,
-                             std::vector<double> origin)
+                             std::vector<double> origin,
+                             unsigned int numberOfComponents)
 {
   // can't work out how to get the array size in C
   itk::simple::ImportImageFilter importer;
@@ -179,11 +180,11 @@ itk::simple::Image ArrayAsIm(SEXP arr,
   importer.SetSize( size );
   if (Rf_isReal(arr))
     {
-    importer.SetBufferAsDouble(NUMERIC_POINTER(arr));
+    importer.SetBufferAsDouble(NUMERIC_POINTER(arr), numberOfComponents);
     }
   else if (Rf_isInteger(arr) || Rf_isLogical(arr))
     {
-    importer.SetBufferAsInt32(INTEGER_POINTER(arr));
+    importer.SetBufferAsInt32(INTEGER_POINTER(arr), numberOfComponents);
     }
   else
     {


### PR DESCRIPTION
The as.image operation in R previously only supported scalar
images. The change in this commit adds a boolean isVector similar to
the Python implementation so that the given R array is interpreted as
a scalar or vector image accordingly.