### PR TITLE
Adding wrapping for filters from remote LabelErodeDilate module

### DIFF
--- a/Code/BasicFilters/json/LabelSetDilateImageFilter.json
+++ b/Code/BasicFilters/json/LabelSetDilateImageFilter.json
@@ -1,0 +1,46 @@
+{
+  "name" : "LabelSetDilateImageFilter",
+  "template_code_filename" : "ImageFilter",
+  "template_test_filename" : "ImageFilter",
+  "number_of_inputs" : 1,
+  "pixel_types" : "IntegerPixelIDTypeList",
+  "members" : [
+    {
+      "name" : "Radius",
+      "type" : "unsigned int",
+      "default" : "std::vector<unsigned int>(3, 1)",
+      "dim_vec" : 1,
+      "set_as_scalar" : 1,
+      "doc" : "",
+      "itk_type" : "typename FilterType::RadiusType",
+      "briefdescriptionSet" : "",
+      "detaileddescriptionSet" : "Set the radius of the neighborhood used to compute the median.",
+      "briefdescriptionGet" : "",
+      "detaileddescriptionGet" : "Get the radius of the neighborhood used to compute the median"
+    },
+    {
+      "name" : "UseImageSpacing",
+      "type" : "bool",
+      "default" : "true",
+      "briefdescriptionSet" : "",
+      "detaileddescriptionSet" : "",
+      "briefdescriptionGet" : "",
+      "detaileddescriptionGet" : ""
+    }
+  ],
+  "custom_methods" : [],
+  "tests" : [
+    {
+      "tag" : "default",
+      "description" : "Simply run with default settings",
+      "settings" : [],
+      "md5hash" : "4c42732d6c4bd9e1bfab8ac2d7cd32e3",
+      "inputs" : [
+        "Input/2th_cthead1.mha"
+      ]
+    }
+  ],
+  "briefdescription" : "Class for binary morphological erosion of label images.",
+  "detaileddescription" : "This filter is threaded.\n\n\\see itkLabelSetDilateErodeImageFilter\n\n\\author Richard Beare, Department of Medicine, Monash University, Australia. Richard.Beare@monash.edu",
+  "itk_module" : "LabelErodeDilate"
+}

--- a/Code/BasicFilters/json/LabelSetErodeImageFilter.json
+++ b/Code/BasicFilters/json/LabelSetErodeImageFilter.json
@@ -1,0 +1,47 @@
+{
+  "name" : "LabelSetErodeImageFilter",
+  "template_code_filename" : "ImageFilter",
+  "template_test_filename" : "ImageFilter",
+  "number_of_inputs" : 1,
+  "pixel_types" : "IntegerPixelIDTypeList",
+  "members" : [
+    {
+      "name" : "Radius",
+      "type" : "unsigned int",
+      "default" : "std::vector<unsigned int>(3, 1)",
+      "dim_vec" : 1,
+      "set_as_scalar" : 1,
+      "doc" : "",
+      "itk_type" : "typename FilterType::RadiusType",
+      "briefdescriptionSet" : "",
+      "detaileddescriptionSet" : "Set the radius of the neighborhood used to compute the median.",
+      "briefdescriptionGet" : "",
+      "detaileddescriptionGet" : "Get the radius of the neighborhood used to compute the median"
+    },
+    {
+      "name" : "UseImageSpacing",
+      "type" : "bool",
+      "default" : "true",
+      "briefdescriptionSet" : "",
+      "detaileddescriptionSet" : "",
+      "briefdescriptionGet" : "",
+      "detaileddescriptionGet" : ""
+
+    }
+  ],
+  "custom_methods" : [],
+  "tests" : [
+    {
+      "tag" : "default",
+      "description" : "Simply run with default settings",
+      "settings" : [],
+      "md5hash" : "AA",
+      "inputs" : [
+        "Input/2th_cthead1.mha"
+      ]
+    }
+  ],
+  "briefdescription" : "Class for binary morphological erosion of label images.",
+  "detaileddescription" : "This filter will separate touching labels. If you don't want this then use a conventional binary erosion to mask the label image. This filter is threaded.\n\n\\see itkLabelSetDilateImageFilter\n\n\\author Richard Beare, Department of Medicine, Monash University, Australia. Richard.Beare@monash.edu",
+  "itk_module" : "LabelErodeDilate"
+}


### PR DESCRIPTION
These filters, LabelSetErodeImageFilter and LabelSetDilateImageFilter
can be enabled by building SimpleITK with this remote module
enabled. They will not be enabled by default nor with the binary
distributions.