### PR TITLE
Set pointer to null after deleting

### DIFF
--- a/Testing/Unit/sitkCommonTests.cxx
+++ b/Testing/Unit/sitkCommonTests.cxx
@@ -305,7 +305,10 @@ TEST( ProcessObject, DeleteCommandActiveProcess )
     virtual void Execute( )
       {
         if ( m_Process.GetProgress() >= m_AbortAt )
+          {
           delete m_Cmd;
+          m_Cmd = SITK_NULLPTR;
+          }
       }
 
     float m_AbortAt;


### PR DESCRIPTION
ITKv5 multi-threading update cases multiple calls for update to 1.0
progress. The reveled a problem in the test which could try to delete
m_Cmd multiple time. Follow best practices and set pointers to deleted
memory to null.