### PR TITLE
Updated the link for the tutorial

### DIFF
--- a/Documentation/docs/source/installation.rst
+++ b/Documentation/docs/source/installation.rst
@@ -10,7 +10,7 @@ Additionally, there are several recommended third-party software
 packages.
 
 After you have installed SimpleITK, please look to the
-`Tutorial <ITK_Release_4/Outreach/Conferences/MICCAI 2011/SimpleITK>`__
+`Tutorial <http://simpleitk.github.io/ISBI2018_TUTORIAL/>`__
 or the `Doxygen <http://www.itk.org/SimpleITKDoxygen/html/>`__ pages for
 more information.
 


### PR DESCRIPTION
Changed the link for the tutorial on the Installation page from the broken link (ITK_Release_4/Outreach/Conferences/MICCAI 2011/SimpleITK) to http://simpleitk.github.io/ISBI2018_TUTORIAL/