### PR TITLE
Update ITK superbuild version along ITK v41.3 release

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -51,7 +51,7 @@ set(ITK_GIT_REPOSITORY "${git_protocol}://itk.org/ITK.git" CACHE STRING "URL of 
 mark_as_advanced(ITK_GIT_REPOSITORY)
 sitk_legacy_naming(ITK_GIT_REPOSITORY ITK_REPOSITORY)
 
-set(ITK_GIT_TAG "v4.13.0" CACHE STRING "Tag in ITK git repo")
+set(ITK_GIT_TAG "f255188244973c105545222bd072a8d5b66a7d7e" CACHE STRING "Tag in ITK git repo")
 mark_as_advanced(ITK_GIT_TAG)
 set(ITK_TAG_COMMAND GIT_TAG "${ITK_GIT_TAG}")
 


### PR DESCRIPTION
This contains the following patches:
71f56c7 BUG: Handle case where output image is zero sized
46814c9 BUG: Prevent concurrent read/write in output image
feb3c8f COMP: Fix VNL to compile with gcc8.
81cd816 COMP: fix warning about implicit double to bool conversion
80c09b3 COMP: Wrap MultiResolutionPDEDeformableRegistration for Pyramid filter types
0f7368d BUG: Add specification of OutputImage Type for TobogganImageFilter
6c54fda COMP: Detect Linux in itkMemoryUsageObserver.h on Alpine Linux
7443627 BUG: Wrap long long instead of long
8912e22 BUG: Prevent gdcm "missing implementation" error on macOS
408b9d1 COMP: Work around RegionGrow2DTest compiler error on ppc64le
a76df7c ENH: Add Python wrap file to itk::MultiResolutionPDEDeforableRegistration.
50c6212 COMP: Mangle HDF5 symbol names
5c0f6bc BUG: fixed crash on macOS under guardmalloc from RunOSCheck()
e946688 BUG: Add missing extensions to ImageIO
0fe114e BUG: fix itkFormatWarning in Python wrapping
f4d0719 COMP: Fixed some missing name mangling of libTIFF symbols
eca2c56 STYLE: arranged/alphabetized things to make subsequent changes reviewable
ec4661d BUG: Initializes CMAKE_DEBUG_POSTFIX to be empty
fac2ddc COMP: Update SimpleITKFilters for dependency issues
f8d81ee COMP: Worked around endless VS2015 Release compilation on Math::Floor
8e07c30 ENH: Ensure external module examples get added to current build tree
a37d85c BUG: Allow module examples to be enabled when built externally
88561d0 COMP: Enable pthreads shim with Emscripten
7da6ca0 COMP: Do not use absolute path to TestBigEndian.cmake in GDCM
0410c40 COMP: Use anonymous namespace for internal linkage
418559a ENH: Add wrapping for BSplineTransformInitializer