### PR TITLE
formatting of license field so CRAN is happy

### DIFF
--- a/Wrapping/R/Packaging/SimpleITK/DESCRIPTION.in
+++ b/Wrapping/R/Packaging/SimpleITK/DESCRIPTION.in
@@ -14,7 +14,7 @@ Imports: methods
 Description: This package is an interface to SimpleITK, which is a simplified
      interface to the Insight Toolkit (ITKv@ITK_VERSION_MAJOR@.@ITK_VERSION_MINOR@.@ITK_VERSION_PATCH@) for medical image segmentation
      and registration.
-License: Apache 2.0
+License: Apache License 2.0
 URL: http://www.simpleitk.org, https://www.itk.org
 BugReports: https://issues.itk.org
 Maintainer: Richard Beare <Richard.Beare@ieee.org>


### PR DESCRIPTION
```r 
R CMD check 
```
is strict about the formatting of the license text. Leaving out "License" leads to "Unknown license" errors.