### PR TITLE
Correct Github ITK repo in CircleCI CMake configuration

### DIFF
--- a/.circleci/circleci.cmake
+++ b/.circleci/circleci.cmake
@@ -62,7 +62,7 @@ endif()
 
 
 SET (_dashboard_cache "
-    ITK_GIT_REPOSITORY:STRING=\"https://github.com/InsightSoftwareConsortium/ITK.git\"
+    ITK_GIT_REPOSITORY:STRING=https://github.com/InsightSoftwareConsortium/ITK.git
     BUILD_DOCUMENTS:BOOL=OFF
     BUILD_EXAMPLES:BOOL=OFF
     BUILD_SHARED_LIBS:BOOL=ON


### PR DESCRIPTION
The escaped quotes became part to the variable value.