### PR TITLE
Remove internal function in ImageRegistrationMethod1

### DIFF
--- a/Examples/ImageRegistrationMethod1/Documentation.rst
+++ b/Examples/ImageRegistrationMethod1/Documentation.rst
@@ -1,5 +1,5 @@
-Image Registration Method1
-==========================
+Image Registration Method 1
+===========================
 
 .. include:: ../../Documentation/docs/source/registrationExamplePrefix.rst
 

--- a/Examples/ImageRegistrationMethod1/ImageRegistrationMethod1.R
+++ b/Examples/ImageRegistrationMethod1/ImageRegistrationMethod1.R
@@ -26,13 +26,10 @@ library(SimpleITK)
 
 commandIteration <- function(method)
 {
-     res <- function() {
-     msg <- paste("Optimizer iteration number ", method$GetOptimizerIteration(),
-                  " = ", method$GetMetricValue(), " : ", method$GetOptimizerPosition(),
-                  "\n" )
-     cat(msg)
-    }
-    return(res)
+    msg <- paste("Optimizer iteration number ", method$GetOptimizerIteration(),
+                 " = ", method$GetMetricValue(), " : ", method$GetOptimizerPosition(),
+                 "\n" )
+    cat(msg)
 }
 
 args <- commandArgs( TRUE )
@@ -52,7 +49,7 @@ Reg$SetOptimizerAsRegularStepGradientDescent(4.0, .01, 200 )
 Reg$SetInitialTransform(TranslationTransform(fixed$GetDimension()))
 Reg$SetInterpolator('sitkLinear')
 
-Reg$AddCommand('sitkIterationEvent', commandIteration(Reg))
+Reg$AddCommand('sitkIterationEvent', function() commandIteration(Reg))
 
 outTx = Reg$Execute(fixed, moving)
 


### PR DESCRIPTION
Replace internal commandIteration function with in-line lambda-like
function. Also rename title to match styling of similar examples.