### PR TITLE
circleci: Fix and simplify install of CMake

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,8 +24,7 @@ referenced:
       command: |
         sudo apt-get install -y rsync lua5.1 ccache kwstyle
         sudo pip install --upgrade pip
-        sudo pip install scikit-ci-addons
-        ci_addons circle/install_cmake.py 3.10.2
+        sudo pip install cmake==3.10.3
   generate-hash-step: &generate-hash-step
     run:
       name: Generate external data hash


### PR DESCRIPTION
Since using the "install_cmake.py" scikit-ci-addon is not supported
on CircleCI 2.0, this commit directly install the CMake wheel.