### PR TITLE
Exclude files leading with a '.' from globs

### DIFF
--- a/CMake/sitkProjectLanguageCommon.cmake
+++ b/CMake/sitkProjectLanguageCommon.cmake
@@ -88,9 +88,9 @@ set(SimpleITK_WRAPPING_COMMON_DIR
 
 if ( CMAKE_PROJECT_NAME STREQUAL "SimpleITK" )
   file(GLOB SWIG_EXTRA_DEPS
-    "${SimpleITK_SOURCE_DIR}/Code/Common/include/*.h"
-    "${SimpleITK_SOURCE_DIR}/Code/Registration/include/*.h"
-    "${SimpleITK_SOURCE_DIR}/Code/IO/include/*.h")
+    "${SimpleITK_SOURCE_DIR}/Code/Common/include/[^.]*.h"
+    "${SimpleITK_SOURCE_DIR}/Code/Registration/include/[^.]*.h"
+    "${SimpleITK_SOURCE_DIR}/Code/IO/include/[^.]*.h")
   list( APPEND SWIG_EXTRA_DEPS
     "${SimpleITK_BINARY_DIR}/Code/BasicFilters/include/SimpleITKBasicFiltersGeneratedHeaders.h"
     ${SimpleITKBasicFiltersGeneratedHeader} )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,8 +169,8 @@ set ( GENERATED_TEST_SOURCE_LIST "" CACHE INTERNAL "" )
 
 # Create cached list of all template components
 file( GLOB template_components
-      ${SimpleITK_SOURCE_DIR}/ExpandTemplateGenerator/Components/*.h.in
-      ${SimpleITK_SOURCE_DIR}/ExpandTemplateGenerator/Components/*.cxx.in
+      ${SimpleITK_SOURCE_DIR}/ExpandTemplateGenerator/Components/[^.]*.h.in
+      ${SimpleITK_SOURCE_DIR}/ExpandTemplateGenerator/Components/[^.]*.cxx.in
     )
 set ( template_components ${template_components} CACHE INTERNAL "" )
 
@@ -455,14 +455,14 @@ install(EXPORT SimpleITKTargets
   COMPONENT Development)
 
 file( GLOB __files
-  ${CMAKE_SOURCE_DIR}/Code/BasicFilters/include/*.h
-  ${CMAKE_SOURCE_DIR}/Code/BasicFilters/include/*.hxx
-  ${CMAKE_SOURCE_DIR}/Code/Common/include/*.h
-  ${CMAKE_SOURCE_DIR}/Code/Common/include/*.hxx
-  ${CMAKE_SOURCE_DIR}/Code/IO/include/*.h
-  ${CMAKE_SOURCE_DIR}/Code/IO/include/*.hxx
-  ${CMAKE_SOURCE_DIR}/Code/Registration/include/*.h
-  ${CMAKE_SOURCE_DIR}/Code/Registration/include/*.hxx
+  ${CMAKE_SOURCE_DIR}/Code/BasicFilters/include/[^.]*.h
+  ${CMAKE_SOURCE_DIR}/Code/BasicFilters/include/[^.]*.hxx
+  ${CMAKE_SOURCE_DIR}/Code/Common/include/[^.]*.h
+  ${CMAKE_SOURCE_DIR}/Code/Common/include/[^.]*.hxx
+  ${CMAKE_SOURCE_DIR}/Code/IO/include/[^.]*.h
+  ${CMAKE_SOURCE_DIR}/Code/IO/include/[^.]*.hxx
+  ${CMAKE_SOURCE_DIR}/Code/Registration/include/[^.]*.h
+  ${CMAKE_SOURCE_DIR}/Code/Registration/include/[^.]*.hxx
   )
 
 install(FILES ${__files}


### PR DESCRIPTION
Including temporary files has caused problems with the dependency.