### PR TITLE
Add access to number of valid point used during registration

### DIFF
--- a/Code/Registration/include/sitkImageRegistrationMethod.h
+++ b/Code/Registration/include/sitkImageRegistrationMethod.h
@@ -560,6 +560,16 @@ namespace simple
     double GetOptimizerConvergenceValue() const;
     double GetMetricValue() const;
 
+    /** Current number of points used of metric evaluation
+     *
+     * This is a active measurement connected to the registration
+     * processes during registration. This number is number of point
+     * in the virtual domain which overlap the fixed image and the
+     * moving image. It is valid for sparse or dense sampling. After
+     * execution of registration this will contain the last value.
+     */
+    uint64_t GetMetricNumberOfValidPoints() const;
+
 
     unsigned int GetCurrentLevel() const;
 
@@ -627,6 +637,7 @@ namespace simple
     nsstd::function<double()> m_pfGetOptimizerLearningRate;
     nsstd::function<double()> m_pfGetOptimizerConvergenceValue;
     nsstd::function<double()> m_pfGetMetricValue;
+    nsstd::function<uint64_t()> m_pfGetMetricNumberOfValidPoints;
     nsstd::function<std::vector<double>()> m_pfGetOptimizerScales;
     nsstd::function<std::string()> m_pfGetOptimizerStopConditionDescription;
 
@@ -766,6 +777,7 @@ namespace simple
     std::string m_StopConditionDescription;
     double m_MetricValue;
     unsigned int m_Iteration;
+    uint64_t m_NumberOfValidPoints;
 
     itk::ObjectToObjectOptimizerBaseTemplate<double> *m_ActiveOptimizer;
   };

--- a/Code/Registration/src/sitkImageRegistrationMethod.cxx
+++ b/Code/Registration/src/sitkImageRegistrationMethod.cxx
@@ -626,6 +626,15 @@ double ImageRegistrationMethod::GetMetricValue() const
   return m_MetricValue;
 }
 
+uint64_t ImageRegistrationMethod::GetMetricNumberOfValidPoints() const
+{
+  if(bool(this->m_pfGetMetricNumberOfValidPoints))
+    {
+    return this->m_pfGetMetricNumberOfValidPoints();
+    }
+  return m_NumberOfValidPoints;
+}
+
 std::vector<double> ImageRegistrationMethod::GetOptimizerScales() const
 {
   if(this->m_OptimizerScalesType==Manual)
@@ -922,6 +931,7 @@ Transform ImageRegistrationMethod::ExecuteInternal ( const Image &inFixed, const
 
     m_MetricValue = this->GetMetricValue();
     m_Iteration = this->GetOptimizerIteration();
+    m_NumberOfValidPoints = this->GetMetricNumberOfValidPoints();
 
     throw;
     }
@@ -932,6 +942,7 @@ Transform ImageRegistrationMethod::ExecuteInternal ( const Image &inFixed, const
 
   m_MetricValue = this->GetMetricValue();
   m_Iteration = this->GetOptimizerIteration();
+  m_NumberOfValidPoints = this->GetMetricNumberOfValidPoints();
 
   if (this->m_InitialTransformInPlace)
     {
@@ -1163,6 +1174,7 @@ void ImageRegistrationMethod::OnActiveProcessDelete( ) SITK_NOEXCEPT
   this->m_pfGetOptimizerLearningRate = SITK_NULLPTR;
   this->m_pfGetOptimizerConvergenceValue = SITK_NULLPTR;
   this->m_pfGetMetricValue = SITK_NULLPTR;
+  this->m_pfGetMetricNumberOfValidPoints = SITK_NULLPTR;
   this->m_pfGetOptimizerScales = SITK_NULLPTR;
   this->m_pfGetOptimizerStopConditionDescription = SITK_NULLPTR;
 

--- a/Code/Registration/src/sitkImageRegistrationMethod_CreateMetric.hxx
+++ b/Code/Registration/src/sitkImageRegistrationMethod_CreateMetric.hxx
@@ -32,6 +32,18 @@ namespace itk
 namespace simple
 {
 
+namespace
+{
+  struct NumberOfValidPointsCustomCast
+  {
+    template<typename TMetric>
+    static unsigned int CustomCast(const TMetric *metric)
+    {
+      return static_cast<uint64_t>(std::min<itk::SizeValueType>(metric->GetNumberOfValidPoints(), std::numeric_limits<uint64_t>::max()));
+    }
+  };
+}
+
 template <class TImageType>
 itk::ImageToImageMetricv4<TImageType,
                           TImageType,
@@ -52,6 +64,7 @@ ImageRegistrationMethod::CreateMetric( )
     typedef itk::ANTSNeighborhoodCorrelationImageToImageMetricv4<FixedImageType, MovingImageType > _MetricType;
 
       typename _MetricType::Pointer metric = _MetricType::New();
+      this->m_pfGetMetricNumberOfValidPoints = nsstd::bind(&NumberOfValidPointsCustomCast::CustomCast<_MetricType>,metric.GetPointer());
       typename _MetricType::RadiusType radius;
       radius.Fill( m_MetricRadius );
       metric->SetRadius( radius );
@@ -63,6 +76,7 @@ ImageRegistrationMethod::CreateMetric( )
       typedef itk::CorrelationImageToImageMetricv4< FixedImageType, MovingImageType > _MetricType;
 
       typename _MetricType::Pointer metric = _MetricType::New();
+      this->m_pfGetMetricNumberOfValidPoints = nsstd::bind(&NumberOfValidPointsCustomCast::CustomCast<_MetricType>,metric.GetPointer());
       metric->Register();
       return metric.GetPointer();
     }
@@ -70,6 +84,7 @@ ImageRegistrationMethod::CreateMetric( )
     {
       typedef itk::DemonsImageToImageMetricv4< FixedImageType, MovingImageType > _MetricType;
       typename _MetricType::Pointer metric = _MetricType::New();
+      this->m_pfGetMetricNumberOfValidPoints = nsstd::bind(&NumberOfValidPointsCustomCast::CustomCast<_MetricType>,metric.GetPointer());
       metric->SetIntensityDifferenceThreshold(m_MetricIntensityDifferenceThreshold);
       metric->Register();
       return metric.GetPointer();
@@ -78,6 +93,7 @@ ImageRegistrationMethod::CreateMetric( )
     {
       typedef itk::JointHistogramMutualInformationImageToImageMetricv4< FixedImageType, MovingImageType > _MetricType;
       typename _MetricType::Pointer metric = _MetricType::New();
+      this->m_pfGetMetricNumberOfValidPoints = nsstd::bind(&NumberOfValidPointsCustomCast::CustomCast<_MetricType>,metric.GetPointer());
       metric->SetNumberOfHistogramBins(m_MetricNumberOfHistogramBins);
       metric->SetVarianceForJointPDFSmoothing(m_MetricVarianceForJointPDFSmoothing);
       metric->Register();
@@ -87,6 +103,7 @@ ImageRegistrationMethod::CreateMetric( )
     {
       typedef itk::MeanSquaresImageToImageMetricv4< FixedImageType, MovingImageType > _MetricType;
       typename _MetricType::Pointer metric = _MetricType::New();
+      this->m_pfGetMetricNumberOfValidPoints = nsstd::bind(&NumberOfValidPointsCustomCast::CustomCast<_MetricType>,metric.GetPointer());
       metric->Register();
       return metric.GetPointer();
     }
@@ -94,6 +111,7 @@ ImageRegistrationMethod::CreateMetric( )
     {
       typedef itk::MattesMutualInformationImageToImageMetricv4< FixedImageType, MovingImageType > _MetricType;
       typename _MetricType::Pointer metric = _MetricType::New();
+      this->m_pfGetMetricNumberOfValidPoints = nsstd::bind(&NumberOfValidPointsCustomCast::CustomCast<_MetricType>,metric.GetPointer());
       metric->SetNumberOfHistogramBins(m_MetricNumberOfHistogramBins);
       metric->Register();
       return metric.GetPointer();

--- a/Testing/Unit/sitkImageRegistrationMethodTests.cxx
+++ b/Testing/Unit/sitkImageRegistrationMethodTests.cxx
@@ -61,6 +61,10 @@ public:
         {
         std::cout << " ( " << m_Method.GetOptimizerConvergenceValue() << " )";
         }
+      if (m_Method.GetMetricNumberOfValidPoints() != 0u)
+        {
+        std::cout << " [ #" << m_Method.GetMetricNumberOfValidPoints() << " ]";
+        }
       std::cout << std::endl;
 
       std::cout.copyfmt(state);
@@ -1096,7 +1100,11 @@ TEST_F(sitkRegistrationMethodTest, Optimizer_Sampling)
   R.SetMetricSamplingPercentage(.02,1u);
 
   outTx1 = R.Execute(fixedImage, movingImage);
+  EXPECT_GT( R.GetMetricNumberOfValidPoints(), 1200u );
+  EXPECT_LT( R.GetMetricNumberOfValidPoints(), 1300u );
   outTx2 = R.Execute(fixedImage, movingImage);
+  EXPECT_GT( R.GetMetricNumberOfValidPoints(), 1200u );
+  EXPECT_LT( R.GetMetricNumberOfValidPoints(), 1300u );
 
   EXPECT_VECTOR_DOUBLE_NEAR(outTx1.GetParameters(), outTx1.GetParameters(), 1e-10)  << "Same registration with fixed seed and regular sampling";
 
@@ -1105,7 +1113,12 @@ TEST_F(sitkRegistrationMethodTest, Optimizer_Sampling)
   R.SetMetricSamplingPercentage(.02,sitk::sitkWallClock);
 
   outTx1 = R.Execute(fixedImage, movingImage);
+  EXPECT_GT( R.GetMetricNumberOfValidPoints(), 9*fixedImage.GetNumberOfPixels()/10 );
+  EXPECT_LT( R.GetMetricNumberOfValidPoints(), fixedImage.GetNumberOfPixels() );
   outTx2 = R.Execute(fixedImage, movingImage);
+  EXPECT_GT( R.GetMetricNumberOfValidPoints(), 9*fixedImage.GetNumberOfPixels()/10 );
+  EXPECT_LT( R.GetMetricNumberOfValidPoints(), fixedImage.GetNumberOfPixels() );
+
 
   EXPECT_VECTOR_DOUBLE_NEAR(outTx1.GetParameters(), outTx1.GetParameters(), 1e-10)  << "Same registration with fixed seed and regular sampling";
 


### PR DESCRIPTION
Add ImageRegistrationMethod::GetMetricNumberOfValidPoints with is
actively connected to the registration metric, and the value is save
after execution.

During registration it can be useful to know the number of point
used. This could be either to monitor overlap or to evaluate the
complexity of metric evaluation.