### PR TITLE
ENH: Improving formatting of DESCRIPTION file 

### DIFF
--- a/Wrapping/R/Packaging/SimpleITK/DESCRIPTION.in
+++ b/Wrapping/R/Packaging/SimpleITK/DESCRIPTION.in
@@ -1,17 +1,16 @@
 Package: SimpleITK
 Version: @SimpleITKR_VERSION@
 Date: @DATE@
-Title: Bindings to SimpleITK Image segmentation and registration toolkit
+Title: Bindings to SimpleITK Image Segmentation and Registration toolkit
 Authors@R: c(person("Richard", "Beare", role = c("aut", "cre"),
                       email = "Richard.Beare@ieee.org"),
                    person("Bradley", "Lowekamp", role = "aut",
                      email = "blowekamp@mail.nih.gov"),
 		     person("Ziv", "Yaniv", role="aut",
 		     email = "zivrafael.yaniv@nih.gov"))
-Author: Richard Beare, Bradley Lowekamp, plus loads of others
 Depends: R (>= 3.3)
 Imports: methods
-Description: This package is an interface to SimpleITK, which is a simplified
+Description: An interface to SimpleITK, which is a simplified
      interface to the Insight Toolkit (ITKv@ITK_VERSION_MAJOR@.@ITK_VERSION_MINOR@.@ITK_VERSION_PATCH@) for medical image segmentation
      and registration.
 License: Apache License 2.0


### PR DESCRIPTION
R CMD check --as-cran

complains about title formatting (case) and the use of "This package" at the start of description.