### PR TITLE
Set the default CMake policy to 3.10

### DIFF
--- a/CMake/sitkCheckCXX11.cmake
+++ b/CMake/sitkCheckCXX11.cmake
@@ -17,11 +17,6 @@
 
 include(CMakePushCheckState)
 
-
-if(POLICY CMP0067) # CMake 3.8.2
-  cmake_policy(SET CMP0067 NEW)
-endif()
-
 #
 # Function to wrap try compiles on the aggregate cxx test file1
 #

--- a/CMake/sitkProjectLanguageCommon.cmake
+++ b/CMake/sitkProjectLanguageCommon.cmake
@@ -1,7 +1,5 @@
 
 foreach(p
-    CMP0042 # CMake 3.0
-    CMP0063 # CMake 3.3.2
     )
   if(POLICY ${p})
     cmake_policy(SET ${p} NEW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,12 +6,9 @@ SET(MSVC_INCREMENTAL_DEFAULT ON)
 
 project ( SimpleITK )
 
-cmake_policy( VERSION 3.0 )
+cmake_policy( VERSION 3.10 )
 
 foreach(p
-    CMP0042 # CMake 3.0
-    CMP0063 # CMake 3.3.2
-    CMP0064 # CMake 3.4
     )
   if(POLICY ${p})
     cmake_policy(SET ${p} NEW)

--- a/Code/BasicFilters/src/CMakeLists.txt
+++ b/Code/BasicFilters/src/CMakeLists.txt
@@ -1,5 +1,4 @@
 set_source_files_properties ( ${SimpleITKBasicFiltersGeneratedSource} PROPERTIES GENERATED 1 )
-cmake_policy(SET CMP0057 NEW)
 
 # add_filter_library
 # This function is used to apply standard building options for the

--- a/SuperBuild/swig_configure_step.cmake.in
+++ b/SuperBuild/swig_configure_step.cmake.in
@@ -4,7 +4,7 @@
 # enviroment. If there is a problem with them in the future they can
 # be addressed in CMake with the same structure.
 
-cmake_policy(SET CMP0012 NEW)
+cmake_policy(VERSION 3.10.0)
 
 set(ENV{CC} "@CMAKE_C_COMPILER_LAUNCHER@ @CMAKE_C_COMPILER@")
 set(ENV{CFLAGS} "@CMAKE_C_FLAGS@ @CMAKE_C_FLAGS_RELEASE@")

--- a/Testing/Unit/Java/CMakeLists.txt
+++ b/Testing/Unit/Java/CMakeLists.txt
@@ -1,13 +1,4 @@
 
-foreach(p
-    CMP0064 # CMake 3.4
-    )
-  if(POLICY ${p})
-    cmake_policy(SET ${p} NEW)
-  endif()
-endforeach()
-
-
 #
 # Java Tests
 #

--- a/Testing/Unit/Python/CMakeLists.txt
+++ b/Testing/Unit/Python/CMakeLists.txt
@@ -1,12 +1,4 @@
 
-foreach(p
-    CMP0064 # CMake 3.4
-    )
-  if(POLICY ${p})
-    cmake_policy(SET ${p} NEW)
-  endif()
-endforeach()
-
 #
 # Python Tests
 #

--- a/Wrapping/Python/PythonVirtualEnvInstall.cmake.in
+++ b/Wrapping/Python/PythonVirtualEnvInstall.cmake.in
@@ -1,7 +1,5 @@
 
-if(POLICY CMP0012)
-  cmake_policy(SET CMP0012 NEW)
-endif()
+cmake_policy(VERSION 3.10.0)
 
 set(VIRTUALENV_ARGS --clear --no-pip)
 if ( "@SimpleITK_FORBID_DOWNLOADS@" )


### PR DESCRIPTION
Match the policy version to that of the required CMake version. Remove
explicitly setting policies that are the 3.10.0 default behavior.