### PR TITLE
ENH: Adding new example illustrating new SimpleITK IO.

### DIFF
--- a/Examples/AdvancedImageReading/AdvancedImageReading.R
+++ b/Examples/AdvancedImageReading/AdvancedImageReading.R
@@ -1,0 +1,112 @@
+#=========================================================================
+#
+#  Copyright Insight Software Consortium
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#=========================================================================
+# Run with:
+#
+# Rscript --vanilla AdvancedImageReading.R
+#
+
+library(SimpleITK)
+
+args <- commandArgs( TRUE )
+
+if (length(args) < 1) {
+   write('Usage arguments: <image_file_name>', stderr())
+   quit(save="no", status=1)
+}
+
+# Find out which image IOs are supported
+file_reader <- ImageFileReader()
+image_ios <- file_reader$GetRegisteredImageIOs()
+cat('The supported image IOs are: ', image_ios, '\n')
+cat(rep('-',20),'\n', sep='')
+
+# Force the use of a specific IO.
+file_reader$SetImageIO('JPEGImageIO')
+file_reader$SetFileName(args[1])
+image <- tryCatch(file_reader$Execute(),
+                  warning = function(err) {
+                      message(err)
+                      cat('\n',rep('-',20),'\n', sep='')
+                  }
+                  )
+
+#try(image <- file_reader$Execute())
+#cat(rep('-',20),'\n', sep='')
+
+# Read image information without reading the bulk data.
+file_reader <- ImageFileReader()
+file_reader$SetFileName(args[1])
+file_reader$ReadImageInformation()
+cat('image size:', file_reader$GetSize(), '\n')
+cat('image spacing:', file_reader$GetSpacing(), '\n')
+# Some files have a rich meta-data dictionary (e.g. DICOM)
+for(key in file_reader$GetMetaDataKeys())
+{
+  cat(paste0(key, ': ', file_reader$GetMetaData(key), '\n'))
+}
+cat(rep('-',20),'\n', sep='')
+
+# When low on memory, we can incrementally work on sub-images. The following
+# subtracts two images (ok, the same image) by reading them as multiple sub-images.
+
+image1_file_name <- args[1]
+image2_file_name <- args[1]
+
+parts <- 5 # Number of sub-regions we use
+
+file_reader <- ImageFileReader()
+file_reader$SetFileName(image1_file_name)
+file_reader$ReadImageInformation()
+image_size <- file_reader$GetSize()
+
+result_img <- Image(file_reader$GetSize(), file_reader$GetPixelID(), file_reader$GetNumberOfComponents())
+result_img$SetSpacing(file_reader$GetSpacing())
+result_img$SetOrigin(file_reader$GetOrigin())
+result_img$SetDirection(file_reader$GetDirection())
+
+extract_size <- file_reader$GetSize()
+extract_size[-1] <- extract_size[-1]%/%parts
+current_index <- rep(0,file_reader$GetDimension())
+for(i in 1:parts)
+{
+  if(i == parts)
+  {
+    extract_size[-1] <- image_size[-1] - current_index[-1]
+  }
+  file_reader$SetFileName(image1_file_name)
+  file_reader$SetExtractIndex(current_index)
+  file_reader$SetExtractSize(extract_size)
+  sub_image1 <- file_reader$Execute()
+
+  file_reader$SetFileName(image2_file_name)
+  file_reader$SetExtractIndex(current_index)
+  file_reader$SetExtractSize(extract_size)
+  sub_image2 <- file_reader$Execute()
+  result_img <- Paste(result_img, sub_image1 - sub_image2, extract_size, rep(0,file_reader$GetDimension()), current_index)
+  current_index[-1] <- current_index[-1] + extract_size[-1]
+}
+
+rm(sub_image1, sub_image2)
+
+# Check that our iterative approach is equivalent to reading the whole images.
+if(any(as.array(result_img - ReadImage(image1_file_name) + ReadImage(image2_file_name))!=0))
+{
+  cat('Subtraction error.\n')
+  quit(save="no", status=1)
+}
+quit(save="no", status=0)

--- a/Examples/AdvancedImageReading/AdvancedImageReading.R
+++ b/Examples/AdvancedImageReading/AdvancedImageReading.R
@@ -29,25 +29,6 @@ if (length(args) < 1) {
    quit(save="no", status=1)
 }
 
-# Find out which image IOs are supported
-file_reader <- ImageFileReader()
-image_ios <- file_reader$GetRegisteredImageIOs()
-cat('The supported image IOs are: ', image_ios, '\n')
-cat(rep('-',20),'\n', sep='')
-
-# Force the use of a specific IO.
-file_reader$SetImageIO('JPEGImageIO')
-file_reader$SetFileName(args[1])
-image <- tryCatch(file_reader$Execute(),
-                  warning = function(err) {
-                      message(err)
-                      cat('\n',rep('-',20),'\n', sep='')
-                  }
-                  )
-
-#try(image <- file_reader$Execute())
-#cat(rep('-',20),'\n', sep='')
-
 # Read image information without reading the bulk data.
 file_reader <- ImageFileReader()
 file_reader$SetFileName(args[1])

--- a/Examples/AdvancedImageReading/AdvancedImageReading.py
+++ b/Examples/AdvancedImageReading/AdvancedImageReading.py
@@ -29,21 +29,6 @@ if len(sys.argv)<2:
     print('Usage: ' + __file__ + ' image_file_name', file=sys.stderr)
     sys.exit(1)
 
-# Find out which image IOs are supported
-file_reader = sitk.ImageFileReader()
-image_ios_tuple = file_reader.GetRegisteredImageIOs()
-print("The supported image IOs are: " + str(image_ios_tuple))
-print('-'*20)
-
-# Force the use of a specific IO.
-file_reader.SetImageIO('JPEGImageIO')
-file_reader.SetFileName(sys.argv[1])
-try:
-    image = file_reader.Execute()
-except Exception as err:
-    print('Reading failed: ', err)
-    print('-'*20)
-
 # Read image information without reading the bulk data.
 file_reader = sitk.ImageFileReader()
 file_reader.SetFileName(sys.argv[1])

--- a/Examples/AdvancedImageReading/AdvancedImageReading.py
+++ b/Examples/AdvancedImageReading/AdvancedImageReading.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+#=========================================================================
+#
+#  Copyright Insight Software Consortium
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#=========================================================================
+
+from __future__ import print_function
+
+import sys
+import numpy as np
+import SimpleITK as sitk
+
+
+if len(sys.argv)<2:
+    print('Wrong number of arguments.', file=sys.stderr)
+    print('Usage: ' + __file__ + ' image_file_name', file=sys.stderr)
+    sys.exit(1)
+
+# Find out which image IOs are supported
+file_reader = sitk.ImageFileReader()
+image_ios_tuple = file_reader.GetRegisteredImageIOs()
+print("The supported image IOs are: " + str(image_ios_tuple))
+print('-'*20)
+
+# Force the use of a specific IO.
+file_reader.SetImageIO('JPEGImageIO')
+file_reader.SetFileName(sys.argv[1])
+try:
+    image = file_reader.Execute()
+except Exception as err:
+    print('Reading failed: ', err)
+    print('-'*20)
+
+# Read image information without reading the bulk data.
+file_reader = sitk.ImageFileReader()
+file_reader.SetFileName(sys.argv[1])
+file_reader.ReadImageInformation()
+print('image size: {0}\nimage spacing: {1}'.format(file_reader.GetSize(), file_reader.GetSpacing()))
+# Some files have a rich meta-data dictionary (e.g. DICOM)
+for key in file_reader.GetMetaDataKeys():
+    print(key + ': ' + file_reader.GetMetaData(key))
+print('-'*20)
+
+# When low on memory, we can incrementally work on sub-images. The following
+# subtracts two images (ok, the same image) by reading them as multiple sub-images.
+
+image1_file_name = sys.argv[1]
+image2_file_name = sys.argv[1]
+
+parts = 5 # Number of sub-regions we use
+
+file_reader = sitk.ImageFileReader()
+file_reader.SetFileName(image1_file_name)
+file_reader.ReadImageInformation()
+image_size = file_reader.GetSize()
+
+result_img = sitk.Image(file_reader.GetSize(), file_reader.GetPixelID(), file_reader.GetNumberOfComponents())
+result_img.SetSpacing(file_reader.GetSpacing())
+result_img.SetOrigin(file_reader.GetOrigin())
+result_img.SetDirection(file_reader.GetDirection())
+
+extract_size = list(file_reader.GetSize())
+extract_size[-1] = extract_size[-1]//parts
+current_index = [0]*file_reader.GetDimension()
+for i in range(parts):
+    if i == (parts-1):
+        extract_size[-1] = image_size[-1] - current_index[-1]
+    file_reader.SetFileName(image1_file_name)
+    file_reader.SetExtractIndex(current_index)
+    file_reader.SetExtractSize(extract_size)
+    sub_image1 = file_reader.Execute()
+
+    file_reader.SetFileName(image2_file_name)
+    file_reader.SetExtractIndex(current_index)
+    file_reader.SetExtractSize(extract_size)
+    sub_image2 = file_reader.Execute()
+    result_img = sitk.Paste(result_img, sub_image1 - sub_image2, extract_size, [0]*file_reader.GetDimension(), current_index)
+    current_index[-1] += extract_size[-1]
+del sub_image1
+del sub_image2
+
+# Check that our iterative approach is equivalent to reading the whole images.
+if np.any(sitk.GetArrayViewFromImage(result_img - sitk.ReadImage(image1_file_name) + sitk.ReadImage(image2_file_name))):
+    print('Subtraction error.')
+    sys.exit(1)
+sys.exit(0)

--- a/Examples/AdvancedImageReading/CMakeLists.txt
+++ b/Examples/AdvancedImageReading/CMakeLists.txt
@@ -1,0 +1,12 @@
+
+if(NOT BUILD_TESTING)
+  return()
+endif()
+
+sitk_add_python_test( Example.AdvancedImageReading
+  "${CMAKE_CURRENT_SOURCE_DIR}/AdvancedImageReading.py"
+  DATA{${SimpleITK_DATA_ROOT}/Input/BrainProtonDensitySlice.png} )
+
+sitk_add_python_test( Example.AdvancedImageReading
+  "${CMAKE_CURRENT_SOURCE_DIR}/AdvancedImageReading.R"
+  DATA{${SimpleITK_DATA_ROOT}/Input/BrainProtonDensitySlice.png} )

--- a/Examples/AdvancedImageReading/Documentation.rst
+++ b/Examples/AdvancedImageReading/Documentation.rst
@@ -1,0 +1,60 @@
+.. _lbl_advanced_image_reading:
+
+Advanced Image Reading
+==============================
+
+Overview
+--------
+
+This example illustrates advanced image reading options:
+  1. Explicitly selecting a specific IO for reading.
+  2. Querying an image for its meta-data without reading the bulk intensity data.
+  3. Reading a sub-region of an image.
+
+Selecting a Specific IO
+++++++++++++++++++++++++
+When using the default settings for the `ImageFileReader class <https://itk.org/SimpleITKDoxygen/html/classitk_1_1simple_1_1ImageFileReader.html>`_ or
+the `ReadImage <https://itk.org/SimpleITKDoxygen/html/namespaceitk_1_1simple.html#ae3b678b5b043c5a8c93aa616d5ee574c>`_ function
+you have minimal control over the reading. That is, the specific IO mechanism is
+determined automatically based on the file type and the whole file is read into
+memory.
+
+In some cases there are multiple IO classes that support reading the same image
+format and you do not know which one was used. For example the 'SCIFIOImageIO'
+and 'JPEGImageIO' both support reading JPEG images. The SCIFIOImageIO reading
+is much slower than the JPEGImageIO. With the advanced reading approach you can
+find out which IO classes are supported by the ImageFileReader and indicate which
+one you want to use.
+
+Querying an image for its meta-data
+++++++++++++++++++++++++++++++++++++
+
+In some cases you may only want to read an image's meta-data without reading the
+bulk intensity data into memory. For instance, if you want to display image
+information (e.g. patient name) to a user in a GUI which then allows them to
+select a specific image.
+
+Reading an image sub-region
++++++++++++++++++++++++++++
+In some cases you are only interested in reading a sub-region of an image. This
+may be due to memory constraints or if it is known that the relevant content is
+always in a sub region of the image.
+
+
+
+Code
+----
+
+.. tabs::
+
+  .. tab:: Python
+
+    .. literalinclude:: AdvancedImageReading.py
+       :language: python
+       :lines: 19-
+
+  .. tab:: R
+
+    .. literalinclude:: AdvancedImageReading.R
+       :language: R
+       :lines: 22-

--- a/Examples/AdvancedImageReading/Documentation.rst
+++ b/Examples/AdvancedImageReading/Documentation.rst
@@ -7,30 +7,16 @@ Overview
 --------
 
 This example illustrates advanced image reading options:
-  1. Explicitly selecting a specific IO for reading.
-  2. Querying an image for its meta-data without reading the bulk intensity data.
-  3. Reading a sub-region of an image.
 
-Selecting a Specific IO
-++++++++++++++++++++++++
-When using the default settings for the `ImageFileReader class <https://itk.org/SimpleITKDoxygen/html/classitk_1_1simple_1_1ImageFileReader.html>`_ or
-the `ReadImage <https://itk.org/SimpleITKDoxygen/html/namespaceitk_1_1simple.html#ae3b678b5b043c5a8c93aa616d5ee574c>`_ function
-you have minimal control over the reading. That is, the specific IO mechanism is
-determined automatically based on the file type and the whole file is read into
-memory.
-
-In some cases there are multiple IO classes that support reading the same image
-format and you do not know which one was used. For example the 'SCIFIOImageIO'
-and 'JPEGImageIO' both support reading JPEG images. The SCIFIOImageIO reading
-is much slower than the JPEGImageIO. With the advanced reading approach you can
-find out which IO classes are supported by the ImageFileReader and indicate which
-one you want to use.
+  1. Querying an image for its meta-data without reading the bulk intensity data.
+  2. Reading a sub-region of an image.
 
 Querying an image for its meta-data
 ++++++++++++++++++++++++++++++++++++
 
 In some cases you may only want to read an image's meta-data without reading the
-bulk intensity data into memory. For instance, if you want to display image
+bulk intensity data into memory. For instance, if you want to read subregions of
+an image and not the whole image or if you want to display image
 information (e.g. patient name) to a user in a GUI which then allows them to
 select a specific image.
 
@@ -38,7 +24,16 @@ Reading an image sub-region
 +++++++++++++++++++++++++++
 In some cases you are only interested in reading a sub-region of an image. This
 may be due to memory constraints or if it is known that the relevant content is
-always in a sub region of the image.
+always in a sub region of the image. If the specific image IO used for this operation
+supports streaming then this will indeed only read the sub-region, otherwise the whole
+image is read into memory and the sub-region is returned. The IOs that support
+streaming are:
+  1. TIFFImageIO (supports a subset of encodings)
+  2. MetaImageIO
+  3. NrrdImageIO
+  4. HDF5ImageIO (supports a subset of encodings)
+  5. MRCImageIO
+  6. VTKImageIO (supports a subset of encodings)
 
 
 

--- a/Examples/ImageIOSelection/CMakeLists.txt
+++ b/Examples/ImageIOSelection/CMakeLists.txt
@@ -1,0 +1,12 @@
+
+if(NOT BUILD_TESTING)
+  return()
+endif()
+
+sitk_add_python_test( Example.ImageIOSelection
+  "${CMAKE_CURRENT_SOURCE_DIR}/ImageIOSelection.py"
+  DATA{${SimpleITK_DATA_ROOT}/Input/BrainProtonDensitySlice.png} )
+
+sitk_add_python_test( Example.IOSelection
+  "${CMAKE_CURRENT_SOURCE_DIR}/ImageIOSelection.R"
+  DATA{${SimpleITK_DATA_ROOT}/Input/BrainProtonDensitySlice.png} )

--- a/Examples/ImageIOSelection/Documentation.rst
+++ b/Examples/ImageIOSelection/Documentation.rst
@@ -1,0 +1,39 @@
+.. _lbl_image_io_selection:
+
+IO Selection for Image Reading
+==============================
+
+Overview
+--------
+
+This example illustrates how to explicitly select a specific IO for image reading.
+
+When using the default settings for the `ImageFileReader class <https://itk.org/SimpleITKDoxygen/html/classitk_1_1simple_1_1ImageFileReader.html>`_ or
+the `ReadImage <https://itk.org/SimpleITKDoxygen/html/namespaceitk_1_1simple.html#ae3b678b5b043c5a8c93aa616d5ee574c>`_ function
+you have minimal control over the reading. That is, the specific IO mechanism is
+determined automatically based on the file type and the file is read into
+memory.
+
+In some cases there are multiple IO classes that support reading the same image
+format and you do not know which one was used. For example the 'SCIFIOImageIO'
+and 'JPEGImageIO' both support reading JPEG images. As these are different implementations
+they may vary in performance and in the support of the features associated with the specific
+format. As a consequence, you may want or need to select one implementation over the other.
+Explicitly selecting the IO allows you to do so.
+
+Code
+----
+
+.. tabs::
+
+  .. tab:: Python
+
+    .. literalinclude:: ImageIOSelection.py
+       :language: python
+       :lines: 19-
+
+  .. tab:: R
+
+    .. literalinclude:: ImageIOSelection.R
+       :language: R
+       :lines: 22-

--- a/Examples/ImageIOSelection/ImageIOSelection.R
+++ b/Examples/ImageIOSelection/ImageIOSelection.R
@@ -1,0 +1,56 @@
+#=========================================================================
+#
+#  Copyright Insight Software Consortium
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#=========================================================================
+# Run with:
+#
+# Rscript --vanilla IOSelection.R
+#
+
+library(SimpleITK)
+
+args <- commandArgs( TRUE )
+
+if (length(args) < 1) {
+   write('Usage arguments: <image_file_name>', stderr())
+   quit(save="no", status=1)
+}
+
+# Find out which image IOs are supported
+file_reader <- ImageFileReader()
+image_ios <- file_reader$GetRegisteredImageIOs()
+cat('The supported image IOs are: ', image_ios, '\n')
+cat(rep('-',20),'\n', sep='')
+
+# Another option is to just print the reader and see which
+# IOs are supported
+print(file_reader)
+cat(rep('-',20),'\n', sep='')
+
+# Force the use of a specific IO.
+file_reader$SetImageIO('PNGImageIO')
+file_reader$SetFileName(args[1])
+
+# If the IO doesn't support reading the image type it
+# will throw an exception.
+image <- tryCatch(file_reader$Execute(),
+                  warning = function(err) {
+                      message(err)
+                      quit(save="no", status=1)
+                  }
+                  )
+cat('Read image:',args[1],'\n')
+quit(save="no", status=0)

--- a/Examples/ImageIOSelection/ImageIOSelection.py
+++ b/Examples/ImageIOSelection/ImageIOSelection.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+#=========================================================================
+#
+#  Copyright Insight Software Consortium
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#=========================================================================
+
+from __future__ import print_function
+
+import sys
+import SimpleITK as sitk
+
+
+if len(sys.argv)<2:
+    print('Wrong number of arguments.', file=sys.stderr)
+    print('Usage: ' + __file__ + ' image_file_name', file=sys.stderr)
+    sys.exit(1)
+
+# Find out which image IOs are supported
+file_reader = sitk.ImageFileReader()
+image_ios_tuple = file_reader.GetRegisteredImageIOs()
+print("The supported image IOs are: " + str(image_ios_tuple))
+print('-'*20)
+
+# Another option is to just print the reader and see which
+# IOs are supported
+print(file_reader)
+print('-'*20)
+
+# Force the use of a specific IO. If the IO doesn't support
+# reading the image type it will throw an exception.
+file_reader.SetImageIO('PNGImageIO')
+file_reader.SetFileName(sys.argv[1])
+try:
+    image = file_reader.Execute()
+    print('Read image: ' + sys.argv[1])
+except Exception as err:
+    print('Reading failed: ', err)
+    sys.exit(1)
+
+sys.exit(0)

--- a/Examples/index.rst
+++ b/Examples/index.rst
@@ -28,3 +28,4 @@ Examples
   ITKIntegration/Documentation
   N4BiasFieldCorrection/Documentation
   SimpleGaussian/Documentation
+  AdvancedImageReading/Documentation

--- a/Examples/index.rst
+++ b/Examples/index.rst
@@ -29,3 +29,4 @@ Examples
   N4BiasFieldCorrection/Documentation
   SimpleGaussian/Documentation
   AdvancedImageReading/Documentation
+  ImageIOSelection/Documentation


### PR DESCRIPTION
Illustrating how to only read the meta-data information, set a
specific IO class from those supported and how to read sub-regions of
an image.