### PR TITLE
Improve test coverage for ImageViewer class.

### DIFF
--- a/Testing/Unit/CMakeLists.txt
+++ b/Testing/Unit/CMakeLists.txt
@@ -36,6 +36,10 @@ if ( SimpleITK_4D_IMAGES )
   list(APPEND SimpleITKUnitTestSource sitkImage4DTests.cxx )
 endif()
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/sitkImageViewerTest.h.in
+               ${CMAKE_CURRENT_BINARY_DIR}/sitkImageViewerTest.h ESCAPE_QUOTES)
+
+
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/CTest)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/PythonTests)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/LuaTests)
@@ -51,6 +55,10 @@ set( PythonVirtualenvHome  ${SimpleITK_BINARY_DIR}/Testing/Installation/PythonVi
 
 
 add_executable(SimpleITKUnitTestDriver0 SimpleITKUnitTestDriver.cxx ${SimpleITKUnitTestSource})
+target_include_directories(SimpleITKUnitTestDriver0
+  PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+)
 target_link_libraries ( SimpleITKUnitTestDriver0 GTest::GTest SimpleITKUnitTestBase ${SimpleITK_LIBRARIES} ${ITK_LIBRARIES} )
 target_compile_options( SimpleITKUnitTestDriver0
   PRIVATE

--- a/Testing/Unit/sitkImageViewerTest.cxx
+++ b/Testing/Unit/sitkImageViewerTest.cxx
@@ -18,7 +18,8 @@
 
 #include "sitkImageViewer.h"
 #include "SimpleITK.h"
-#include "SimpleITKTestHarness.h"
+#include "sitkImageViewerTest.h"
+#include <SimpleITKTestHarness.h>
 #include <itksys/SystemTools.hxx>
 
 
@@ -58,7 +59,9 @@ TEST(ImageViewerTest,Methods)
   iv.SetTitle("ImageViewerTest");
   EXPECT_EQ( iv.GetTitle(), "ImageViewerTest" );
 
+  EXPECT_EQ( iv.GetName(), "ImageViewer" );
 
+  //
   std::vector<std::string> words;
   words.push_back( std::string("alpha") );
   words.push_back( std::string("beta") );
@@ -73,6 +76,7 @@ TEST(ImageViewerTest,Methods)
   names = iv.GetGlobalDefaultExecutableNames();
   EXPECT_EQ( compare_word_lists(words, names), true );
 
+  //
   iv.SetGlobalDefaultDebug( true );
   EXPECT_EQ( iv.GetGlobalDefaultDebug(), true );
 
@@ -81,4 +85,20 @@ TEST(ImageViewerTest,Methods)
 
   iv.SetFileExtension( ".png" );
   EXPECT_EQ( iv.GetFileExtension(), ".png" );
+
+  unsigned int delay;
+  delay = iv.GetProcessDelay();
+
+#ifdef _WIN32
+  EXPECT_EQ( delay, 1 );
+#else
+  EXPECT_EQ( delay, 500 );
+#endif
+  iv.SetProcessDelay( delay );
+
+  //
+  itk::simple::Image img( 10,10, itk::simple::sitkUInt8 );
+  iv.SetGlobalDefaultDebug( true );
+  iv.SetCommand( CMAKE_COMMAND  " -E md5sum" );
+  iv.Execute( img );
   }

--- a/Testing/Unit/sitkImageViewerTest.h.in
+++ b/Testing/Unit/sitkImageViewerTest.h.in
@@ -1,0 +1,23 @@
+/*=========================================================================
+*
+*  Copyright Insight Software Consortium
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*         http://www.apache.org/licenses/LICENSE-2.0.txt
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*=========================================================================*/
+#ifndef __sitkImageViewerTest_h
+#define __sitkImageViewerTest_h
+
+#define CMAKE_COMMAND "@CMAKE_COMMAND@"
+
+#endif


### PR DESCRIPTION
The ImageViewer test now invokes the class's Execute method.
The greatly improves the coverage for the class's code.

Prior to calling Execute the display command is set to use
'cmake -E md5sum' which computes the md5sum on input image.
This avoids trying to pop up an ImageJ or Fiji viewer.