### PR TITLE
ENH: Use return instead of raising StopIteration (PEP 479)

### DIFF
--- a/Testing/Unit/Python/ImageIndexingTest.py
+++ b/Testing/Unit/Python/ImageIndexingTest.py
@@ -97,6 +97,9 @@ class TestImageIndexingInterface(unittest.TestCase):
         self.assertRaises(IndexError, lambda : img[1] )
         self.assertRaises(IndexError, lambda : img[1,1,1] )
 
+        # check empty image
+        self.assertImageNDArrayEquals(img[-1:0,-1:0], nda[-1:0,-1:0])
+
 
     def test_3d_extract(self):
          """testing __getitem__ for extrating 2D slices from 3D image"""

--- a/Wrapping/Python/Python.i
+++ b/Wrapping/Python/Python.i
@@ -293,7 +293,7 @@
         def __iter__( self ):
 
             if len(self) == 0:
-              raise StopIteration
+              return
 
             dim = self.GetDimension()
             size = self.GetSize()


### PR DESCRIPTION
In Python 3.7, raising StopIteration results in a runtime error as [described here](https://docs.python.org/3/whatsnew/3.7.html):

> PEP 479 is enabled for all code in Python 3.7, meaning that StopIteration exceptions raised directly or indirectly in coroutines and generators are transformed into RuntimeError exceptions. (Contributed by Yury Selivanov in bpo-32670.)

The new behaviour would cause some SimpleITK tests to fail when using Python 3.7 (full PEP is [described here](https://www.python.org/dev/peps/pep-0479/)). This commit uses `return` instead of` raise StopIteration` to end Python iterators as recommended by PEP 479. Tested on Linux, Mac, and Windows using Python 2.7, 3.5, 3.6, and 3.7.