### PR TITLE
Fixed memory leak

### DIFF
--- a/Code/IO/src/sitkImageViewer.cxx
+++ b/Code/IO/src/sitkImageViewer.cxx
@@ -530,14 +530,16 @@ void ExecuteCommand( const std::vector<std::string> & cmdLine, const unsigned in
       // This first case is what we expect if everything went OK.
 
       // We want the other process to continue going
-      itksysProcess_Delete( kp ); // implicitly disowns
+      //itksysProcess_Delete( kp ); // implicitly disowns
       break;
 
     case itksysProcess_State_Exited:
       {
       int exitValue = itksysProcess_GetExitValue(kp);
+      localDebugMacro( << "Normal process exit.  exitValue = " << exitValue );
       if ( exitValue != 0 )
         {
+        itksysProcess_Delete( kp );
         sitkExceptionMacro (  << "Process returned " << exitValue << ".\n" << "Command line: " << cmdstream.str() );
         }
       }
@@ -573,6 +575,9 @@ void ExecuteCommand( const std::vector<std::string> & cmdLine, const unsigned in
       itksysProcess_Delete( kp );
       sitkExceptionMacro (  << "Unexpected process state!" << "\nCommand line: " << cmdstream.str() );
     }
+
+  localDebugMacro( << "Done.  Deleting process." );
+  itksysProcess_Delete( kp );
   }
 
 

--- a/Code/IO/src/sitkShow.cxx
+++ b/Code/IO/src/sitkShow.cxx
@@ -553,8 +553,10 @@ namespace itk
       case itksysProcess_State_Exited:
         {
         int exitValue = itksysProcess_GetExitValue(kp);
+        localDebugMacro( << "Normal process exit.  exitValue = " << exitValue );
         if ( exitValue != 0 )
           {
+          itksysProcess_Delete( kp );
           sitkExceptionMacro (  << "Process returned " << exitValue << ".\n" << "Command line: " << cmdstream.str() );
           }
         }
@@ -591,6 +593,7 @@ namespace itk
         sitkExceptionMacro (  << "Unexpected process state!" << "\nCommand line: " << cmdstream.str() );
       }
 
+    itksysProcess_Delete( kp );
   }
 
   void Show( const Image &image, const std::string& title, const bool debugOn)


### PR DESCRIPTION
When we've finished executing the display process, we weren't always
deleting the KWSys process object.