### PR TITLE
Adding option to procedure ReadImage to specify the ImageIO

### DIFF
--- a/Code/IO/include/sitkImageFileReader.h
+++ b/Code/IO/include/sitkImageFileReader.h
@@ -226,12 +226,15 @@ namespace itk {
    * \brief ReadImage is a procedural interface to the ImageFileReader
    *     class which is convenient for most image reading tasks.
    *
-   *     For more complicated use cases such as requiring loading of
-   *     all tags, including private ones, from a DICOM file the
-   *     object oriented interface should be used. The reader can be explicitly
-   *     set to load all tags (LoadPrivateTagsOn()).
+   *  \param outputPixelType see ImageReaderBase::SetOutputPixelType
+   *  \param imageIO see ImageReaderBase::SetImageIO
+   *
+   * \sa itk::simple::ImageFileReader for reading a single file.
+   * \sa itk::simple::ImageSeriesReader for reading a series and meta-data dictionaries.
    */
-  SITKIO_EXPORT Image ReadImage ( const std::string &filename, PixelIDValueEnum outputPixelType = sitkUnknown );
+  SITKIO_EXPORT Image ReadImage ( const std::string &filename,
+                                  PixelIDValueEnum outputPixelType = sitkUnknown,
+                                  const std::string &imageIO = "");
   }
 }
 

--- a/Code/IO/include/sitkImageSeriesReader.h
+++ b/Code/IO/include/sitkImageSeriesReader.h
@@ -177,6 +177,9 @@ namespace itk {
    * \brief ReadImage is a procedural interface to the ImageSeriesReader
    *     class which is convenient for most image reading tasks.
    *
+   *  \param outputPixelType see ImageReaderBase::SetOutputPixelType
+   *  \param imageIO see ImageReaderBase::SetImageIO
+
    *     Note that when reading a series of images that have meta-data
    *     associated with them (e.g. a DICOM series) the resulting
    *     image will have an empty meta-data dictionary.
@@ -186,7 +189,9 @@ namespace itk {
    * \sa itk::simple::ImageFileReader for reading a single file.
    * \sa itk::simple::ImageSeriesReader for reading a series and meta-data dictionaries.
    */
-  SITKIO_EXPORT Image ReadImage ( const std::vector<std::string> &fileNames, PixelIDValueEnum outputPixelType=sitkUnknown );
+  SITKIO_EXPORT Image ReadImage ( const std::vector<std::string> &fileNames,
+                                  PixelIDValueEnum outputPixelType=sitkUnknown,
+                                  const std::string &imageIO="");
   }
 }
 

--- a/Code/IO/src/sitkImageFileReader.cxx
+++ b/Code/IO/src/sitkImageFileReader.cxx
@@ -62,10 +62,15 @@ namespace itk {
       }
   }
 
-  Image ReadImage ( const std::string &filename, PixelIDValueEnum outputPixelType )
+  Image ReadImage ( const std::string &filename,
+                    PixelIDValueEnum outputPixelType,
+                    const std::string &imageIO )
     {
       ImageFileReader reader;
-      return reader.SetFileName ( filename ).SetOutputPixelType(outputPixelType).Execute();
+      reader.SetFileName(filename);
+      reader.SetOutputPixelType(outputPixelType);
+      reader.SetImageIO(imageIO);
+      return reader.Execute();
     }
 
 

--- a/Code/IO/src/sitkImageSeriesReader.cxx
+++ b/Code/IO/src/sitkImageSeriesReader.cxx
@@ -30,10 +30,15 @@
 namespace itk {
   namespace simple {
 
-  Image ReadImage ( const std::vector<std::string> &filenames, PixelIDValueEnum outputPixelType )
+  Image ReadImage ( const std::vector<std::string> &filenames,
+                    PixelIDValueEnum outputPixelType,
+                    const std::string &imageIO )
     {
     ImageSeriesReader reader;
-    return reader.SetFileNames ( filenames ).SetOutputPixelType(outputPixelType).Execute();
+    reader.SetFileNames(filenames);
+    reader.SetOutputPixelType(outputPixelType);
+    reader.SetImageIO(imageIO);
+    return reader.Execute();
     }
 
 

--- a/Testing/Unit/sitkImageIOTests.cxx
+++ b/Testing/Unit/sitkImageIOTests.cxx
@@ -89,6 +89,13 @@ TEST(IO,ImageFileReader) {
   EXPECT_EQ( image.GetPixelID(), sitk::sitkVectorInt16 );
   EXPECT_EQ( sitk::Hash(image), "126ea8c3ef5573ca1e4e0deece920c2c4a4f38b5") << "Short to " <<  sitk::sitkVectorInt16;
 
+  EXPECT_NO_THROW(image=sitk::ReadImage( fileName, sitk::sitkInt32, "NrrdImageIO" ) );
+  EXPECT_EQ( image.GetPixelID(), sitk::sitkInt32 );
+  EXPECT_EQ( sitk::Hash(image), "f1045032b6862753b7e6b71771b552c40b8eaf32") << "Short to " <<  sitk::sitkInt32;
+
+  EXPECT_THROW(sitk::ReadImage( fileName, sitk::sitkInt32, "DoesNoExistImageIO" ), sitk::GenericException );
+  EXPECT_ANY_THROW(sitk::ReadImage( fileName, sitk::sitkInt32, "GDCMImageIO" ));
+
   reader.SetOutputPixelType( sitk::sitkVectorInt32 );
   EXPECT_EQ( reader.GetOutputPixelType(), sitk::sitkVectorInt32 );
 


### PR DESCRIPTION
By default the "" string for the imageIO parameter allows the IO to
automatically choose the ImageIO, if it is specified than that one
will be tempted to be constructed and used for reading.