### PR TITLE
Add user Applications to show search path

### DIFF
--- a/Code/IO/src/sitkImageViewer.cxx
+++ b/Code/IO/src/sitkImageViewer.cxx
@@ -174,6 +174,12 @@ void ImageViewer::initializeDefaults()
   m_GlobalDefaultSearchPath.push_back(  "/Developer/" );
   m_GlobalDefaultSearchPath.push_back(  "/opt/" );
   m_GlobalDefaultSearchPath.push_back(  "/usr/local/" );
+  std::string homedir;
+  if ( itksys::SystemTools::GetEnv ( "HOME", homedir ) )
+    {
+    m_GlobalDefaultSearchPath.push_back( homedir + "/Applications/" );
+    }
+
 
 #else
 

--- a/Code/IO/src/sitkShow.cxx
+++ b/Code/IO/src/sitkShow.cxx
@@ -411,6 +411,12 @@ namespace itk
   paths.push_back( "/Developer" );
   paths.push_back( "/opt/" + directory );
   paths.push_back( "/usr/local/" + directory );
+  std::string homedir;
+  if ( itksys::SystemTools::GetEnv ( "HOME", homedir ) )
+    {
+    paths.push_back( homedir + "/Applications/" + directory );
+    }
+
 
   ExecutableName = itksys::SystemTools::FindDirectory( name.c_str(), paths );
 


### PR DESCRIPTION
When a user on Mac OSX does not have admin privileges, the Fiji.app
should be placed in ~/Applications. Search for this too.