### PR TITLE
Fix Rpackaging failure to copy packaging directory

### DIFF
--- a/Wrapping/R/CMakeLists.txt
+++ b/Wrapping/R/CMakeLists.txt
@@ -48,7 +48,7 @@ endif()
 # copy the R files a binary package
 file( COPY "${CMAKE_CURRENT_SOURCE_DIR}/Packaging"
   DESTINATION "${CMAKE_CURRENT_BINARY_DIR}"
-  REGEX "(.*\\.in)|(.*\\.md5)" EXCLUDE )
+  REGEX "(.*\\.in$)|(.*\\.md5$)|(.*\\.sha512$)" EXCLUDE )
 
 
 set(SimpleITKR_VERSION "${SimpleITK_VERSION_MAJOR}.${SimpleITK_VERSION_MINOR}")
@@ -78,7 +78,7 @@ file( GLOB_RECURSE image_links RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_C
 
 foreach(link ${image_links})
   string( REGEX REPLACE "\\.md5$" "" link ${link} )
-  ExternalData_Expand_Arguments(  SimpleITKRpackageData
+  ExternalData_Expand_Arguments( SimpleITKRpackageData
     image_location
     DATA{${link}}
     )
@@ -93,10 +93,11 @@ file( GLOB_RECURSE doc_links RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CUR
 
 foreach(link ${doc_links})
   string( REGEX REPLACE "\\.md5$" "" link ${link} )
-  ExternalData_Expand_Arguments(  SimpleITKRpackageData
+  ExternalData_Expand_Arguments( SimpleITKRpackageData
     doc_location
     DATA{${link}}
     )
+  file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/Packaging/SimpleITK/man/")
   set( EXTRACT_RMAN_COMMAND  ${EXTRACT_RMAN_COMMAND} COMMAND ${CMAKE_COMMAND} -E tar xzf ${doc_location}
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/Packaging/SimpleITK/man/" )
 endforeach()
@@ -110,6 +111,7 @@ add_dependencies( ${SWIG_MODULE_SimpleITK_TARGET_NAME} SimpleITKRpackageData )
 # copy sample images and extract documentation - used in vignette
 add_custom_command( TARGET ${SWIG_MODULE_SimpleITK_TARGET_NAME}
   PRE_BUILD
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/Packaging/SimpleITK/inst/extdata/"
   ${COPY_DATA_COMMAND}
   ${EXTRACT_RMAN_COMMAND}
   )


### PR DESCRIPTION
The default build directory for R packages include "R.INSTALL", which
matched the regular expression "*.in", which case insensitive file
systems. Add end of input marked to ensure file extension is at the
end of the string. Add sha512 exclusion too.