### PR TITLE
Azure ctest build line must be the last statement

### DIFF
--- a/Testing/CI/Azure/azure-pipelines-batch.yml
+++ b/Testing/CI/Azure/azure-pipelines-batch.yml
@@ -81,7 +81,6 @@ jobs:
             gcc --version
             ccache -p
             ctest -S "$(Build.SourcesDirectory)/Testing/CI/Azure/azure.cmake" -V
-            ccache --show-stats
           displayName: Build and test
           env:
             CTEST_OUTPUT_ON_FALURE: 1

--- a/Testing/CI/Azure/azure-pipelines-batch.yml
+++ b/Testing/CI/Azure/azure-pipelines-batch.yml
@@ -71,6 +71,11 @@ jobs:
     workspace:
       clean: all
     steps:
+        - bash: |
+            set -x
+            if [ -n "$(System.PullRequest.SourceCommitId)" ]; then
+              git checkout $(System.PullRequest.SourceCommitId)
+            fi
         - script: |
             git clone -b dashboard --single-branch $(Build.Repository.Uri) SimpleITK-dashboard
           displayName: Download dashboard scripts and testing data


### PR DESCRIPTION
The return value of the last statement executed in a script block
determines if the step passes or fails. So the ctest script must be run
as the last statement so that the build results will be the results of
the script step.