### PR TITLE
Azure Coverage reduce linking parallelism

### DIFF
--- a/Testing/CI/Azure/azure-pipelines-coverage.yml
+++ b/Testing/CI/Azure/azure-pipelines-coverage.yml
@@ -49,6 +49,8 @@ jobs:
               BUILD_EXAMPLES:BOOL=OFF
               BUILD_SHARED_LIBS:BOOL=OFF
               BUILD_TESTING:BOOL=ON
+              CMAKE_JOB_POOLS:STRING=link=1
+              CMAKE_JOB_POOL_LINK:STRING=link
               CMAKE_CXX_FLAGS:STRING=-g -O0 -fprofile-arcs -ftest-coverage
               CMAKE_C_FLAGS:STRING=-g -O0 -fprofile-arcs -ftest-coverage
               CMAKE_EXE_LINKER_FLAGS:STRING=-g -O0 -fprofile-arcs -ftest-coverage


### PR DESCRIPTION
The system is running out of memory during linking, so only do one
linkage at a time.