### PR TITLE
Remove Azure fetch depth to fix sitkSourceVersion

### DIFF
--- a/Testing/CI/Azure/azure-pipelines-batch.yml
+++ b/Testing/CI/Azure/azure-pipelines-batch.yml
@@ -16,7 +16,6 @@ jobs:
     steps:
       - checkout: self
         clean: true
-        fetchDepth: 5
       - script: |
           if DEFINED SYSTEM_PULLREQUEST_SOURCECOMMITID git checkout $(System.PullRequest.SourceCommitId)
         displayName: Checkout pull request HEAD

--- a/Testing/CI/Azure/azure-pipelines.yml
+++ b/Testing/CI/Azure/azure-pipelines.yml
@@ -19,7 +19,6 @@ jobs:
     steps:
       - checkout: self
         clean: true
-        fetchDepth: 5
       - bash: |
           set -x
           if [ -n "$(System.PullRequest.SourceCommitId)" ]; then
@@ -85,7 +84,6 @@ jobs:
     steps:
       - checkout: self
         clean: true
-        fetchDepth: 5
       - bash: |
           set -x
           if [ -n "$(System.PullRequest.SourceCommitId)" ]; then
@@ -152,7 +150,6 @@ jobs:
     steps:
       - checkout: self
         clean: true
-        fetchDepth: 5
       - script: |
           if DEFINED SYSTEM_PULLREQUEST_SOURCECOMMITID git checkout $(System.PullRequest.SourceCommitId)
         displayName: Checkout pull request HEAD


### PR DESCRIPTION
Address the following build warning:
CMake/sitkSourceVersion.cmake:62 (message):
   git tag: "-128-NOTFOUND" does not match expected version format!
Call Stack (most recent call first):
  Version.cmake:17 (include)
  CMakeLists.txt:23 (include)