### PR TITLE
Add CTest suppression for clang unused -ansi flag

### DIFF
--- a/CMake/CTestCustom.cmake.in
+++ b/CMake/CTestCustom.cmake.in
@@ -55,6 +55,9 @@ SET(CTEST_CUSTOM_WARNING_EXCEPTION
   # Warning when compiling ITK v4.5.1 with clang
   "clang: warning: argument unused during.*-fno-ipa-cp-clone"
 
+  # Warning when compiling SWIG
+  "clang: warning: argument unused.*-ansi"
+
   # Warning from RHEL5 GCC 4.1 about visibility change
   "warning: lowering visibility of .* to match its type"
 


### PR DESCRIPTION
This warning occurs during compilation of SWIG.