### PR TITLE
COMP: Update statistics filter without indexed inputs

### DIFF
--- a/Code/BasicFilters/json/MinimumMaximumImageFilter.json
+++ b/Code/BasicFilters/json/MinimumMaximumImageFilter.json
@@ -2,11 +2,17 @@
   "name" : "MinimumMaximumImageFilter",
   "template_code_filename" : "ImageFilter",
   "template_test_filename" : "ImageFilter",
-  "number_of_inputs" : 1,
+  "number_of_inputs" : 0,
   "pixel_types" : "BasicPixelIDTypeList",
   "filter_type" : "itk::MinimumMaximumImageFilter<InputImageType>",
   "no_procedure" : true,
   "no_return_image" : true,
+  "inputs" : [
+    {
+      "name" : "Image",
+      "type" : "Image"
+    }
+  ],
   "members" : [],
   "measurements" : [
     {

--- a/Code/BasicFilters/json/StatisticsImageFilter.json
+++ b/Code/BasicFilters/json/StatisticsImageFilter.json
@@ -2,12 +2,18 @@
   "name" : "StatisticsImageFilter",
   "template_code_filename" : "ImageFilter",
   "template_test_filename" : "ImageFilter",
-  "number_of_inputs" : 1,
+  "number_of_inputs" : 0,
   "doc" : "Docs",
   "pixel_types" : "BasicPixelIDTypeList",
   "filter_type" : "itk::StatisticsImageFilter<InputImageType>",
   "no_procedure" : true,
   "no_return_image" : true,
+  "inputs" : [
+    {
+      "name" : "Image",
+      "type" : "Image"
+    }
+  ],
   "members" : [],
   "measurements" : [
     {


### PR DESCRIPTION
Updates to ITKv5 removed the generic image indexed inputs
methods. Updated the affected filters to use the names input
interface.