### PR TITLE
Add support for slicing operations on 4D images

### DIFF
--- a/Code/BasicFilters/json/SliceImageFilter.json
+++ b/Code/BasicFilters/json/SliceImageFilter.json
@@ -4,6 +4,8 @@
   "template_test_filename" : "ImageFilter",
   "number_of_inputs" : 1,
   "pixel_types" : "NonLabelPixelIDTypeList",
+  "custom_register" : "#ifdef SITK_4D_IMAGES\n  this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 4 > ();\n  #endif\n  this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 3 > ();\n  this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 2 > ();",
+
   "members" : [
     {
       "name" : "Start",

--- a/Testing/Unit/Python/CMakeLists.txt
+++ b/Testing/Unit/Python/CMakeLists.txt
@@ -6,7 +6,7 @@ sitk_add_python_test( Test.ImageTests
   "${CMAKE_CURRENT_SOURCE_DIR}/sitkImageTests.py" )
 
 sitk_add_python_test( Test.ImageIndexing
-  "${CMAKE_CURRENT_SOURCE_DIR}/ImageIndexingTest.py" )
+  "${CMAKE_CURRENT_SOURCE_DIR}/sitkImageIndexingTest.py" )
 
 sitk_add_python_test( Test.IOTest
   "${CMAKE_CURRENT_SOURCE_DIR}/IOTest.py"

--- a/Testing/Unit/Python/sitkImageIndexingTest.py
+++ b/Testing/Unit/Python/sitkImageIndexingTest.py
@@ -102,7 +102,7 @@ class TestImageIndexingInterface(unittest.TestCase):
 
 
     def test_3d_extract(self):
-         """testing __getitem__ for extrating 2D slices from 3D image"""
+         """testing __getitem__ for extracting 2D slices from 3D image"""
 
          nda = np.linspace(0, 59, 60 ).reshape(3,4,5)
 
@@ -124,7 +124,7 @@ class TestImageIndexingInterface(unittest.TestCase):
 
 
     def test_3d(self):
-         """testing __getitem__ for extrating 2D slices from 3D image"""
+         """testing __getitem__ for 3D sub-region"""
 
          nda = np.linspace(0, 59, 60 ).reshape(3,4,5)
 
@@ -154,6 +154,82 @@ class TestImageIndexingInterface(unittest.TestCase):
          self.assertImageNDArrayEquals(img[::-1,::-1,::-1], nda[::-1,::-1,::-1])
          self.assertImageNDArrayEquals(img[:,::-2,::-1], nda[::-1,::-2,:])
          self.assertImageNDArrayEquals(img[-1:-4:-1,:,:], nda[:,:,-1:-4:-1])
+
+
+    def test_4d_extract(self):
+         """testing __getitem__ for extracting 3D slices from 4D image"""
+
+
+         # Check if we have 4D Image support
+         try:
+             sitk.Image([2,2,2,2], sitk.sitkFloat32)
+         except RuntimeError:
+             return # exit and don't run the test
+
+         nda = np.linspace(0, 119, 120 ).reshape(2,3,4,5)
+
+         img = sitk.GetImageFromArray( nda, isVector=False )
+
+         # check some exceptions
+         self.assertRaises(IndexError, lambda : img[0,3] )
+         self.assertRaises(IndexError, lambda : img[0,3,:,:] )
+         self.assertRaises(IndexError, lambda : img[0, 1, 2,:] )
+         self.assertRaises(IndexError, lambda : img[:,0,3] )
+         self.assertRaises(IndexError, lambda : img[:,0,3,:,:] )
+         self.assertRaises(IndexError, lambda : img[:,0,3,4,:] )
+         self.assertRaises(IndexError, lambda : img[2,0,3,4,:] )
+         self.assertRaises(IndexError, lambda : img[:,1:1,3,:] )
+         self.assertRaises(IndexError, lambda : img[:,:,1:0,3] )
+
+         self.assertImageNDArrayEquals(img[1], nda[:,:,:,1])
+         self.assertImageNDArrayEquals(img[-1], nda[:,:,:,-1])
+         self.assertImageNDArrayEquals(img[:,-2], nda[:,:,-2])
+         self.assertImageNDArrayEquals(img[:,:,2,:], nda[:,2])
+
+         self.assertImageNDArrayEquals(img[::-1,:,-2,:], nda[:,-2,:,::-1])
+         self.assertImageNDArrayEquals(img[::-1,0,:,0:-1], nda[0:-1,:,0,::-1])
+
+
+    def test_4d(self):
+         """testing __getitem__ for getting 4D sub-regions"""
+
+         # Check if we have 4D Image support
+         try:
+             sitk.Image([2,2,2,2], sitk.sitkFloat32)
+         except RuntimeError:
+             return # exit and don't run the test
+
+         nda = np.linspace(0, 119, 120 ).reshape(2,3,4,5)
+
+         img = sitk.GetImageFromArray( nda, isVector=False )
+
+         # check some exceptions
+         self.assertRaises(IndexError, lambda : img[0,1,0,0,0] )
+         self.assertRaises(IndexError, lambda : img[0,4,0,0] )
+         self.assertRaises(IndexError, lambda : img[0,0,0,2] )
+         self.assertRaises(IndexError, lambda : img[-6,0,0,0] )
+         self.assertRaises(IndexError, lambda : img[0,0,0,-3] )
+
+         # check basic indexing
+         self.assertEqual( img[0,0,0,0], 0.0 )
+         self.assertEqual( img[(1,0,0,0)], 1.0 )
+         self.assertEqual( img[[2,0,0,0]], 2.0 )
+         self.assertEqual( img[3,2,1,0], 33.0 )
+         self.assertEqual( img[-4,-3,-2,-1], 86.0 )
+         self.assertEqual( img[-4,-3,-2,-1], nda[-1,-2,-3,-4] )
+
+
+         self.assertImageNDArrayEquals(img[1:-1,1:-1,1:-1], nda[1:-1,1:-1,1:-1])
+         self.assertImageNDArrayEquals(img[1:-1,1:-1,1:-1], nda[1:-1,1:-1,1:-1,:])
+         self.assertImageNDArrayEquals(img[:,:,:,1:2],nda[1:2,:,:,:])
+         self.assertImageNDArrayEquals(img[3:6,1:5,2:4,0:2],nda[0:2,2:4,1:5,3:6])
+         self.assertImageNDArrayEquals(img[1:,2:,:2,:],nda[:,:2,2:,1:])
+
+         # some negative cases
+         self.assertImageNDArrayEquals(img[::-1,::-1,::-1,::-1], nda[::-1,::-1,::-1,::-1])
+         self.assertImageNDArrayEquals(img[:,::-2,::-1,::-3], nda[::-3,::-1,::-2,:])
+         self.assertImageNDArrayEquals(img[-1:-4:-1,:,:,:], nda[:,:,:,-1:-4:-1])
+
 
     def test_compare(self):
 

--- a/Wrapping/Python/Python.i
+++ b/Wrapping/Python/Python.i
@@ -762,7 +762,7 @@ def GetArrayFromImage(image):
 
 
 def GetImageFromArray( arr, isVector=None):
-    """Get a SimpleITK Image from a numpy array. If isVector is True, then the Image will have a Vector pixel type, and the last dimension of the array will be considered the component index. By default when isVector is None, 4D images are automatically considered 3D vector images."""
+    """Get a SimpleITK Image from a numpy array. If isVector is True, then the Image will have a Vector pixel type, and the last dimension of the array will be considered the component index. By default when isVector is None, 4D arrays are automatically considered 3D vector images, but 3D arrays are 3D images."""
 
     if not HAVE_NUMPY:
         raise ImportError('Numpy not available.')

--- a/Wrapping/Python/Python.i
+++ b/Wrapping/Python/Python.i
@@ -378,8 +378,8 @@
 
             # If we have a 3D image, we can extract 2D image if one index is an int and the reset are slices
             slice_dim = -1
-            if ( dim == 3 ):
-              # find only a single dimension with has an integer index
+            if ( dim > 2 ):
+              # find only a single dimension which has an integer index
               for i in range(len(idx)):
                 if type(idx[i]) is slice:
                   continue


### PR DESCRIPTION
Instatiate the SliceImageFilter in 4D. The Extract image filter is
alread instatiated in 4D.

Added support for detection of extract index to 4+ dimensions.

NOTE: Supported extract based indexing for 4D->2D is currently
implemented and the error is generated is rather generic.
closes #765