### PR TITLE
Add URL_HASH to external projects

### DIFF
--- a/SuperBuild/External_Lua.cmake
+++ b/SuperBuild/External_Lua.cmake
@@ -25,6 +25,7 @@ set(lua_PATCH_COMMAND ${CMAKE_COMMAND} -E copy_if_different
 
 ExternalProject_Add(Lua
   URL "${lua_URL}"
+  URL_HASH "${lua_URL_HASH}"
   PATCH_COMMAND ${lua_PATCH_COMMAND}
   CMAKE_GENERATOR ${gen}
   CMAKE_ARGS

--- a/SuperBuild/External_PCRE.cmake
+++ b/SuperBuild/External_PCRE.cmake
@@ -42,6 +42,7 @@ if(NOT PCRE_DIR)
 
   ExternalProject_add(PCRE
     URL "${PCRE_URL}"
+    URL_HASH "${PCRE_URL_HASH}"
     CONFIGURE_COMMAND ${pcre_CONFIGURE_COMMAND}
     DEPENDS "${PCRE_DEPENDENCIES}"
     ${External_Project_USES_TERMINAL}

--- a/SuperBuild/External_Swig.cmake
+++ b/SuperBuild/External_Swig.cmake
@@ -39,6 +39,7 @@ if(NOT SWIG_DIR)
     # swig.exe available as pre-built binary on Windows:
     ExternalProject_Add(Swig
       URL "${SWIGWIN_URL}"
+      URL_HASH "${SWIGWIN_URL_HASH}"
       SOURCE_DIR ${swig_source_dir}
       CONFIGURE_COMMAND ""
       BUILD_COMMAND ""
@@ -102,6 +103,7 @@ if(NOT SWIG_DIR)
       sitkSourceDownload(SWIG_URL "swig-${SWIG_TARGET_VERSION}.tar.gz")
       set(SWIG_DOWNLOAD_STEP
         URL "${SWIG_URL}"
+        URL_HASH "${SWIG_URL_HASH}"
         )
     endif()
 

--- a/SuperBuild/External_virtualenv.cmake
+++ b/SuperBuild/External_virtualenv.cmake
@@ -19,6 +19,7 @@ sitkSourceDownload(${proj}_URL "virtualenv-${${proj}_TARGET_VERSION}.tar.gz")
 
 ExternalProject_Add(${proj}
   URL "${${proj}_URL}"
+  URL_HASH "${${proj}_URL_HASH}"
   SOURCE_DIR ${${proj}_source_dir}
   BINARY_DIR ${${proj}_binary_dir}
   INSTALL_DIR ${${proj}_install_dir}

--- a/SuperBuild/SuperBuild.cmake
+++ b/SuperBuild/SuperBuild.cmake
@@ -61,21 +61,24 @@ add_custom_target( SuperBuildSimpleITKSource )
 # the build tree, and can be locally cache with other ExternalData
 # controlled environment variables.
 #
+# <output variable> is set to the downloaded file.
+# <output variable>_HASH is set to a hash of the file of the form ALGO=HASH_VALUE
+#
 # The "SuperBuildSimpleITKSource" target needs to be manually added as
 # a dependencies to the ExternalProject.
 #
 #   add_dependencies( PROJ "SuperBuildSimpleITKSource" )
 #
-# Note: Hash files are created under the SOURCE directory in the
-# .ExternalSource sub-directory during configuration.
-#
 function(sitkSourceDownload outVar filename)
 
   set(link_file "${CMAKE_CURRENT_SOURCE_DIR}/ExternalSource/${filename}")
   if( NOT EXISTS "${link_file}.md5")
-    set(link_file "${CMAKE_CURRENT_SOURCE_DIR}/.ExternalSource/${filename}")
-    file(WRITE  "${link_file}.md5" ${hash} )
+    message(FATALERROR "The source download file: \"${link_file}.md5\" does not exists.")
   endif()
+
+  file(READ "${link_file}.md5" _HASH)
+  string(STRIP "${_HASH}" _HASH)
+  set(${outVar}_HASH "MD5=${_HASH}" PARENT_SCOPE)
 
   ExternalData_Expand_arguments(
     SuperBuildSimpleITKSourceReal


### PR DESCRIPTION
Update the function used to download source code via CMake's
ExternalData to also produce a hash variable, then used it in the
external project calls. This addresses warning produce by CMake that
the URL_HASH is missing.