### PR TITLE
Update SimpleITK along release-4.13.2

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -52,8 +52,8 @@ set(ITK_GIT_REPOSITORY "${git_protocol}://github.com/InsightSoftwareConsortium/I
 mark_as_advanced(ITK_GIT_REPOSITORY)
 sitk_legacy_naming(ITK_GIT_REPOSITORY ITK_REPOSITORY)
 
-set(ITK_GIT_TAG "v4.13.2" CACHE
-  STRING "Tag in ITK git repo") # release-4.13
+set(ITK_GIT_TAG "4a6e8c84198a741d18a2a39e616c26dda09b6686" CACHE
+  STRING "Tag in ITK git repo") # after 4.13.2 along release-4.13
 mark_as_advanced(ITK_GIT_TAG)
 set(ITK_TAG_COMMAND GIT_TAG "${ITK_GIT_TAG}")
 


### PR DESCRIPTION
git log --oneline  v4.13.2..upstream/release-4.13
432dd1b9dc ENH: back-porting #1165 to support Visual Studio 2019
90ad651db4 BUG: Patch missing const qualifier to GDCM dircos_comp comparison
a47c974f64 COMP: a fix for non-system double-conversion build
ac26e1c55f Merge pull request #969 from dzenanz/release-4.13
3ee6f1e5c9 ENH: use double-conversion's CMake targets
a0922944b4 Merge pull request #911 from thewtex/4.13-vxl-gcc-9
9825d546c4 COMP: Add VXL support for GCC 9
c2cfd2b6d1 COMP: VtkGlue module-Provide support for VTK new cmake targets
38c6ca0d76 COMP: Prevent duplicate wrapping ouput file specification