### PR TITLE
Use SimpleITK fork of ITK

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -47,13 +47,17 @@ VariableListToArgs( ITK_VARS  ep_itk_args )
 
 set(proj ITK)  ## Use ITK convention of calling it ITK
 
+set(_DEFAULT_ITK_GIT_TAG "simpleitk-v1.2") # after 4.13.2 along release-4.13
+set(ITK_GIT_TAG "${_DEFAULT_ITK_GIT_TAG}" CACHE STRING "Tag in ITK git repo")
 
-set(ITK_GIT_REPOSITORY "${git_protocol}://github.com/InsightSoftwareConsortium/ITK.git" CACHE STRING "URL of ITK Git repository")
+if(ITK_GIT_TAG MATCHES "simpleitk-")
+  set(ITK_GIT_REPOSITORY "${git_protocol}://github.com/SimpleITK/ITK.git" CACHE STRING "URL of ITK Git repository")
+else()
+  set(ITK_GIT_REPOSITORY "${git_protocol}://github.com/InsightSoftwareConsortium/ITK.git" CACHE STRING "URL of ITK Git repository")
+endif()
 mark_as_advanced(ITK_GIT_REPOSITORY)
 sitk_legacy_naming(ITK_GIT_REPOSITORY ITK_REPOSITORY)
 
-set(_DEFAULT_ITK_GIT_TAG "3213404416666c17dbabc8fb0a07f1d27362f32c") # after 4.13.2 along release-4.13
-set(ITK_GIT_TAG "${_DEFAULT_ITK_GIT_TAG}" CACHE STRING "Tag in ITK git repo")
 mark_as_advanced(ITK_GIT_TAG)
 set(ITK_TAG_COMMAND GIT_TAG "${ITK_GIT_TAG}")
 


### PR DESCRIPTION
The back port patches to ITK fix Time overflow with N4 BiasFieldCorrection, updates GDCM and address buffer overflow issues in GDCM. It is for testing SimpleITK against SimpleITK/ITK before patches are merged into upstream ITK.
