### PR TITLE
Increase the GTest discover timeout to ensure generation

### DIFF
--- a/Testing/Unit/CMakeLists.txt
+++ b/Testing/Unit/CMakeLists.txt
@@ -265,7 +265,7 @@ target_compile_options( sitkSystemInformationTest
 
  # CMake 3.10 added this method, to avoid configure time introspection
 if(NOT CMAKE_CROSSCOMPILING)
-   gtest_discover_tests( SimpleITKUnitTestDriver0 DISCOVERY_TIMEOUT 60 )
+   gtest_discover_tests( SimpleITKUnitTestDriver0 DISCOVERY_TIMEOUT 180 )
  else()
    gtest_add_tests(SimpleITKUnitTestDriver0 "" ${SimpleITKUnitTestSource})
 endif()


### PR DESCRIPTION
the 60 second timeout was encountered, so it's increased.