### PR TITLE
Updating ITK Superbuild along release-4.13 branch

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -52,7 +52,7 @@ set(ITK_GIT_REPOSITORY "${git_protocol}://github.com/InsightSoftwareConsortium/I
 mark_as_advanced(ITK_GIT_REPOSITORY)
 sitk_legacy_naming(ITK_GIT_REPOSITORY ITK_REPOSITORY)
 
-set(_DEFAULT_ITK_GIT_TAG "3213404416666c17dbabc8fb0a07f1d27362f32c") # after 4.13.2 along release-4.13
+set(_DEFAULT_ITK_GIT_TAG "28fd1cb66a77441e0a7999128c16e97e1b7291ff") # after 4.13.2 along release-4.13
 set(ITK_GIT_TAG "${_DEFAULT_ITK_GIT_TAG}" CACHE STRING "Tag in ITK git repo")
 mark_as_advanced(ITK_GIT_TAG)
 set(ITK_TAG_COMMAND GIT_TAG "${ITK_GIT_TAG}")


### PR DESCRIPTION
$ git log 3213404416666c17dbabc8fb0a07f1d27362f32c..upstream/release-4.13 --format="%C(auto) %h %s"
 f64fdf66b1 Merge pull request #1392 from blowekamp/FixN4MTimeForRelease4.13
 63d148715e BUG: Don't use InsertElement which modifies MTime
 ebaca30f07 Merge pull request #1389 from blowekamp/UpdateGDCMForRelease4.13
 08dc0116fe BUG: update CircleCI configuration with selections from master
 90e6da1ff6 ENH: Update GDCM to latest on the release-2.8 branch
 20f10c2e20 Merge branch 'upstream-GDCM' into UpdateGDCMForRelease4.13
 0353bb40ed GDCM 2019-11-04 (7e3be76f)