### PR TITLE
AZP remove the cancel timeout

### DIFF
--- a/Testing/CI/Azure/azure-pipelines-batch.yml
+++ b/Testing/CI/Azure/azure-pipelines-batch.yml
@@ -8,7 +8,6 @@ pr: none
 jobs:
   - job: VisualStudio
     timeoutInMinutes: 0
-    cancelTimeoutInMinutes: 300
     strategy:
       maxParallel: 1
       matrix:
@@ -54,7 +53,6 @@ jobs:
 
   - job: macOS
     timeoutInMinutes: 0
-    cancelTimeoutInMinutes: 300
     strategy:
       maxParallel: 1
       matrix:

--- a/Testing/CI/Azure/azure-pipelines.yml
+++ b/Testing/CI/Azure/azure-pipelines.yml
@@ -10,7 +10,6 @@ variables:
 jobs:
   - job: Linux
     timeoutInMinutes: 0
-    cancelTimeoutInMinutes: 300
     pool:
       name: 'Default'
       demands:
@@ -63,7 +62,6 @@ jobs:
 
   - job: macOS
     timeoutInMinutes: 0
-    cancelTimeoutInMinutes: 300
     variables:
       imageName: 'macos-10.14'
       xcodeVersion: 10.2
@@ -120,7 +118,6 @@ jobs:
 
   - job: Windows
     timeoutInMinutes: 0
-    cancelTimeoutInMinutes: 300
     pool:
       vmImage: 'vs2017-win2016'
     steps:


### PR DESCRIPTION
Builds should just be killed when canceled.