### PR TITLE
Changed the github links from directly pointing to the latest release.

### DIFF
--- a/Documentation/docs/source/installation.rst
+++ b/Documentation/docs/source/installation.rst
@@ -89,7 +89,7 @@ C# binary files
 
 **Binaries for select C# platforms** can be found on SimpleITK's
 `GitHub releases
-<https://github.com/SimpleITK/SimpleITK/releases/tag/latest>`__
+<https://github.com/SimpleITK/SimpleITK/releases>`__
 under the appropriate version. Installing the library should only
 involve importing the unzipped files into you C# environment. The
 files have the following naming convention:
@@ -109,7 +109,7 @@ Java binary files
 
 **Binaries for select Java platforms** can be found on SimpleITK's
 `GitHub releases page
-<https://github.com/SimpleITK/SimpleITK/releases/tag/latest>`__
+<https://github.com/SimpleITK/SimpleITK/releases>`__
 under the appropriate version. Installation instructions are available
 at :ref:`setup SimpleITK with Java <setup-java>`.
 


### PR DESCRIPTION
The previous link led to a page which only contained information with
respect to the latest version/release. It is better to point to the
page where all releases appear and the user can search that
page. Otherwise they won't know where to go if by latest release, they
actually wanted the release and not latest development version.