### PR TITLE
Use the GTest top-level directory for GTEST_ROOT

### DIFF
--- a/CMake/sitkUseGTest.cmake
+++ b/CMake/sitkUseGTest.cmake
@@ -31,10 +31,6 @@ function(_sitk_gtest_use_gtest_source)
   set(CMAKE_CXX_VISIBILITY_PRESET)
   set(CMAKE_VISIBILITY_INLINES_HIDDEN)
 
-  set(CMAKE_CXX_STANDARD 11)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-
   set(BUILD_GTEST                 ON )
   set(BUILD_GMOCK                 OFF)
 

--- a/SuperBuild/External_GTest.cmake
+++ b/SuperBuild/External_GTest.cmake
@@ -29,4 +29,4 @@ ExternalProject_Add(${proj}
 
 sitkSourceDownloadDependency(${proj})
 
-set(GTEST_ROOT ${GTEST_source_dir}/googletest)
+set(GTEST_ROOT ${GTEST_source_dir})


### PR DESCRIPTION
The top-level project sets the required C++11 configuration and the
google test version. The addresses a CMake warning about an empty
VERSION argument to project.