### PR TITLE
Update data URLs in SourceTarball script

### DIFF
--- a/Utilities/Maintenance/SourceTarball.bash
+++ b/Utilities/Maintenance/SourceTarball.bash
@@ -105,13 +105,12 @@ validate () {
     fi
 }
 
-
 download_object() {
   algo="$1" ; hash="$2" ; path="$3"
   mkdir -p $(dirname "$path") &&
-  if curl "https://simpleitk.github.io/SimpleITKExternalData/$algo/$hash" --output "$path.tmp$$" 1>&2 ||
-     curl "https://www.itk.org/files/ExternalData/$algo/$hash" --output "$path.tmp$$" 1>&2 ||
-     curl "https://data.kitware.com/midas3/api/rest?method=midas.bitstream.download&checksum=${hash}&algorithm=${algo}" --output 1>&2; then
+  if curl -f "https://simpleitk.github.io/SimpleITKExternalData/$algo/$hash" --output 1>&2||
+     curl -f "https://s3.amazonaws.com/simpleitk/public/$algo/$hash" --output 1>&2 ||
+     curl -f "https://data.kitware.com:443/api/v1/file/hashsum/$algo/$hash/download" --output 1>&2; then
     mv "$path.tmp$$" "$path"
   else
     rm -f "$path.tmp$$"


### PR DESCRIPTION
Correct the data.kitware.com URL. Remove itk.org URL since the data
file will shortly not be available at the location. And add the
SimpleITK s3 bucket.