### PR TITLE
Removes breadcrumbs template

### DIFF
--- a/docs/_templates/breadcrumbs.html
+++ b/docs/_templates/breadcrumbs.html
@@ -1,6 +1,0 @@
-{%- extends "sphinx_rtd_theme/breadcrumbs.html" %}
-
-{% block breadcrumbs_aside %}
-{% endblock %}
-{% block breadcrumbs %}
-{% endblock %}


### PR DESCRIPTION
Note, if you would like this file back and make breadcrumbs work: 
add {{ super() }} in the block.