### PR TITLE
Fix pixel container management in convert

### DIFF
--- a/Code/Common/include/sitkImageConvert.h
+++ b/Code/Common/include/sitkImageConvert.h
@@ -48,19 +48,25 @@ GetImageFromVectorImage( itk::VectorImage< TPixelType, ImageDimension > *img, bo
   size_t numberOfElements = img->GetBufferedRegion().GetNumberOfPixels();
   typename ImageType::PixelType* buffer = reinterpret_cast<typename ImageType::PixelType*>( img->GetPixelContainer()->GetBufferPointer() );
 
-  if (!img->GetPixelContainer()->GetContainerManageMemory())
-    {
-    transferOwnership=false;
-    }
 
   typename ImageType::Pointer out = ImageType::New();
 
+  if (!img->GetPixelContainer()->GetContainerManageMemory())
+    {
+    // Set the image's pixel container to import the pointer provided.
+    out->GetPixelContainer()->SetImportPointer(buffer, numberOfElements, false );
+    }
+  else
+    {
+    out->GetPixelContainer()->SetImportPointer(buffer, numberOfElements, transferOwnership );
+    if (transferOwnership)
+      {
+      img->GetPixelContainer()->ContainerManageMemoryOff();
+      }
+    }
+
   out->CopyInformation( img );
   out->SetRegions( img->GetBufferedRegion() );
-
-  // Set the image's pixel container to import the pointer provided.
-  out->GetPixelContainer()->SetImportPointer(buffer, numberOfElements, transferOwnership );
-  img->GetPixelContainer()->SetContainerManageMemory(!transferOwnership);
 
   return out;
 
@@ -83,17 +89,22 @@ GetVectorImageFromImage( itk::Image< itk::Vector< TPixelType, NLength >, NImageD
   numberOfElements *= NImageDimension;
 
 
-  if (!img->GetPixelContainer()->GetContainerManageMemory())
-    {
-    transferOwnership=false;
-    }
-
-
   typename VectorImageType::Pointer out = VectorImageType::New();
 
-  // Set the image's pixel container to import the pointer provided.
-  out->GetPixelContainer()->SetImportPointer(buffer, numberOfElements, transferOwnership );
-  img->GetPixelContainer()->SetContainerManageMemory(!transferOwnership);
+  if (!img->GetPixelContainer()->GetContainerManageMemory())
+    {
+    // Set the image's pixel container to import the pointer provided.
+    out->GetPixelContainer()->SetImportPointer(buffer, numberOfElements, false );
+    }
+  else
+    {
+    out->GetPixelContainer()->SetImportPointer(buffer, numberOfElements, transferOwnership );
+    if (transferOwnership)
+      {
+      img->GetPixelContainer()->ContainerManageMemoryOff();
+      }
+    }
+
   out->CopyInformation( img );
   out->SetRegions( img->GetBufferedRegion() );
 

--- a/Testing/Unit/sitkTransformTests.cxx
+++ b/Testing/Unit/sitkTransformTests.cxx
@@ -36,10 +36,12 @@
 #include "sitkResampleImageFilter.h"
 #include "sitkHashImageFilter.h"
 
+#include "sitkInvertDisplacementFieldImageFilter.h"
 #include "sitkBSplineTransformInitializerFilter.h"
 
 
 #include "itkMath.h"
+#include "itkVectorImage.h"
 
 namespace sitk = itk::simple;
 namespace nsstd = itk::simple::nsstd;
@@ -1113,6 +1115,33 @@ TEST(TransformTest,DisplacementFieldTransform_Points)
   EXPECT_VECTOR_DOUBLE_NEAR( tx.TransformPoint( v2(0.5, 0.5) ), v2(0.5,0.5), 1e-15 );
 
 }
+
+TEST(BasicFilters, DisplacementField_GetDisplacementField)
+  {
+    // A test case where a double free was occurring, due to change in
+    // the pixel containers ownership.
+    namespace sitk = itk::simple;
+
+    sitk::Image sourceImage( std::vector<unsigned int>(2, 64), sitk::sitkVectorFloat64, 2);
+
+      sitk::DisplacementFieldTransform displacementField(sourceImage);
+
+    sitk::Image displacementImage = displacementField.GetDisplacementField();
+
+    typedef itk::VectorImage<double, 2> ImageBaseType;
+    ImageBaseType *imageBase = dynamic_cast<ImageBaseType*>(displacementImage.GetITKBase());
+    ASSERT_TRUE(imageBase != SITK_NULLPTR);
+    EXPECT_FALSE(imageBase->GetPixelContainer()->GetContainerManageMemory());
+
+    sitk::Image result = sitk::InvertDisplacementField(displacementImage);
+
+    EXPECT_FALSE(imageBase->GetPixelContainer()->GetContainerManageMemory());
+
+    imageBase = dynamic_cast<ImageBaseType*>(result.GetITKBase());
+    ASSERT_TRUE(imageBase != SITK_NULLPTR);
+    EXPECT_TRUE(imageBase->GetPixelContainer()->GetContainerManageMemory());
+  }
+
 
 TEST(TransformTest,Euler2DTransform)
 {


### PR DESCRIPTION
Fix memory issue related to using the `DisplacementFieldTransform::GetDisplacementField`output.

closes #947 