### PR TITLE
Remove ITK legacy code in Superbuild

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -78,8 +78,7 @@ endif()
 if( ITK_GIT_TAG STREQUAL _DEFAULT_ITK_GIT_TAG )
   # only remove legacy with the tested, and predefined version of ITK
   list( APPEND ep_itk_args
-    "-DITK_LEGACY_REMOVE:BOOL=OFF"
-    "-DITKV4_COMPATIBILITY:BOOL=ON"
+    "-DITK_LEGACY_REMOVE:BOOL=ON"
     )
 endif()
 


### PR DESCRIPTION
By default set ITK_LEGACY_REMOVE to ON, to aid in consistent behavior
with ITK.