### PR TITLE
Update superbuild version of ITK

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -53,7 +53,7 @@ mark_as_advanced(ITK_GIT_REPOSITORY)
 sitk_legacy_naming(ITK_GIT_REPOSITORY ITK_REPOSITORY)
 
 # post v5.1rc01
-set(_DEFAULT_ITK_GIT_TAG "c342c6aedcebb2252e07a8e37892da965d6acff5")
+set(_DEFAULT_ITK_GIT_TAG "bcd762e7bd743341c2dce84852ced49d8292f293")
 set(ITK_GIT_TAG "${_DEFAULT_ITK_GIT_TAG}" CACHE STRING "Tag in ITK git repo")
 mark_as_advanced(ITK_GIT_TAG)
 set(ITK_TAG_COMMAND GIT_TAG "${ITK_GIT_TAG}")


### PR DESCRIPTION
closes #951.

This update contains a patch to fix the RelabelComponentImageFilter's
behavior with filter the size of labels.