### PR TITLE
Add GetIndexes and GetRLEIndexes to LabelShapStatistics filter.

### DIFF
--- a/Code/BasicFilters/json/LabelShapeStatisticsImageFilter.json
+++ b/Code/BasicFilters/json/LabelShapeStatisticsImageFilter.json
@@ -10,7 +10,8 @@
   "no_procedure" : true,
   "no_return_image" : true,
   "include_files" : [
-    "itkShapeLabelObject.h"
+    "itkShapeLabelObject.h",
+    "sitkLabelFunctorUtils.hxx"
   ],
   "members" : [
     {
@@ -374,6 +375,36 @@
       ],
       "custom_cast" : "sitkVectorOfITKVectorToSTL<double>(value)",
       "label_map" : true
+    },
+    {
+      "name" : "Indexes",
+      "itk_get" : "f->GetOutput()->GetLabelObject(label)",
+      "type" : "std::vector<unsigned int>",
+      "no_print" : true,
+      "active" : true,
+      "parameters" : [
+        {
+          "name" : "label",
+          "type" : "int64_t"
+        }
+      ],
+      "custom_cast" : "GetIndexesFromLabelObject(*value)",
+      "detaileddescriptionGet" : "Get an array of indexes for pixels with the label value."
+    },
+    {
+      "name" : "RLEIndexes",
+      "itk_get" : "f->GetOutput()->GetLabelObject(label)",
+      "type" : "std::vector<unsigned int>",
+      "no_print" : true,
+      "active" : true,
+      "parameters" : [
+        {
+          "name" : "label",
+          "type" : "int64_t"
+        }
+      ],
+      "custom_cast" : "GetRLEIndexesFromLabelObject(*value)",
+      "detaileddescriptionGet" : "Get an array of run-length encoding (RLE) indexes for pixels with the label value. The array is the index of a starting line, followed by the length repeated. The length of the array is divisible by the image's dimension + 1. For example for a 2D image the array [ 2, 3, 2] would encode the two indexes [2,3] and [3,3]."
     }
   ],
   "tests" : [

--- a/Code/BasicFilters/src/sitkLabelFunctorUtils.hxx
+++ b/Code/BasicFilters/src/sitkLabelFunctorUtils.hxx
@@ -46,6 +46,53 @@ SetLabelFunctorFromColormap( TLabelFunctorType &functor, const std::vector<unsig
     }
 }
 
+/** \brief Convert an itk::LabelObject into a vector of indexes */
+template <typename TLabelObject>
+std::vector<unsigned int>
+GetIndexesFromLabelObject( const TLabelObject &lo )
+{
+  size_t sz = lo.Size();
+  std::vector<unsigned int> idxs(sz*TLabelObject::ImageDimension);
+  auto iter = idxs.begin();
+  for(itk::SizeValueType pixelId = 0; pixelId < lo.Size(); pixelId++)
+    {
+    const auto & idx = lo.GetIndex(pixelId);
+    for(unsigned int d = 0; d < TLabelObject::ImageDimension; ++d)
+      {
+      *(iter++) = idx[d];
+      }
+    }
+  return idxs;
+}
+
+
+/** \brief Convert an itk::LabelObject into a RLE encoded vector of indexes.
+ *
+ * The return array in the n-d index followed by a length. The 0
+ * dimension of the index is incremented for the length to generate
+ * the indexes represented.
+ */
+template <typename TLabelObject>
+std::vector<unsigned int>
+GetRLEIndexesFromLabelObject( const TLabelObject &lo )
+{
+  size_t sz = lo.GetNumberOfLines()*(TLabelObject::ImageDimension+1);
+  std::vector<unsigned int> rle(sz);
+
+  auto iter = rle.begin();
+  for(SizeValueType lineId = 0; lineId < lo.GetNumberOfLines(); ++lineId)
+    {
+    const auto & line = lo.GetLine(lineId);
+    const auto & idx = line.GetIndex();
+    for(unsigned int d = 0; d < TLabelObject::ImageDimension; ++d)
+      {
+      *(iter++) = idx[d];
+      }
+    *(iter++) = line.GetLength();
+    }
+  return rle;
+}
+
 }
 }
 

--- a/ExpandTemplateGenerator/Components/CustomCasts.cxx
+++ b/ExpandTemplateGenerator/Components/CustomCasts.cxx
@@ -3,7 +3,7 @@
 //
 namespace {
 $(when measurements $(foreach measurements
-$(if active and ( custom_cast or label_map ) then
+$(if itk_get or ( active and ( custom_cast or label_map ) ) then
 OUT=[[
 template<typename FilterType>
 struct ${name}CustomCast
@@ -29,7 +29,9 @@ OUT=OUT..[[ )
 if custom_cast then
   OUT=OUT..[[${name}CustomCast::Helper(]]
 end
-if label_map then
+if itk_get then
+   OUT=OUT..[[${itk_get}]]
+elseif label_map then
   OUT=OUT..[[f->GetOutput()->GetLabelObject(label)->Get${name}()]]
 else
   OUT=OUT..[[f->Get${name}(${parameters[1].name})]]


### PR DESCRIPTION
These method provide a convent way to the list of index for a label.