### PR TITLE
Use python 3 executable

### DIFF
--- a/Utilities/JSON/JSONBeautify.py
+++ b/Utilities/JSON/JSONBeautify.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import json
 import sys
 try:


### PR DESCRIPTION
The JSONBeautify script required python 3. Specifying python3 eases
the use of the correct python version in a multi-versions system
environment.