### PR TITLE
Use lambda over using nested std::bind

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ referenced:
     run:
       name: Dependencies
       command: |
-        sudo apt-get install -y rsync lua5.3 ccache kwstyle
+        sudo apt-get install -y rsync lua5.3 ccache
         sudo python -m pip install --upgrade pip
         sudo python -m pip install scikit-ci-addons # Provides "ctest_junit_formatter" add-on
         sudo python -m pip install cmake==3.13.3

--- a/Code/Common/src/sitkBSplineTransform.cxx
+++ b/Code/Common/src/sitkBSplineTransform.cxx
@@ -258,13 +258,12 @@ void BSplineTransform::InternalInitialization(itk::TransformBase *transform)
 template<class TransformType>
 void BSplineTransform::InternalInitialization(TransformType *t)
 {
-  { // TransformDomainDirection
-  typename TransformType::DirectionType (*pfSTLToITKDirection)(const std::vector<double> &) = &sitkSTLToITKDirection<typename TransformType::DirectionType>;
-  this->m_pfSetTransformDomainDirection = std::bind(&TransformType::SetTransformDomainDirection,t,std::bind(pfSTLToITKDirection,std::placeholders::_1));
-
-  std::vector<double> (*pfITKDirectionToSTL)( const typename TransformType::DirectionType &) = &sitkITKDirectionToSTL<typename TransformType::DirectionType>;
-  this->m_pfGetTransformDomainDirection = std::bind(pfITKDirectionToSTL,std::bind(&TransformType::GetTransformDomainDirection,t));
-  }
+  this->m_pfSetTransformDomainDirection = [t](const std::vector<double> &v) {
+    t->SetTransformDomainDirection(sitkSTLToITKDirection< typename TransformType::DirectionType>(v));
+  };
+  this->m_pfGetTransformDomainDirection = [t]() {
+    return sitkITKDirectionToSTL(t->GetTransformDomainDirection());
+  };
 
    // TransformDomainMeshSize
   SITK_TRANSFORM_SET_MPF( TransformDomainMeshSize, typename TransformType::MeshSizeType, unsigned int );
@@ -273,9 +272,9 @@ void BSplineTransform::InternalInitialization(TransformType *t)
   // TransformDomainPhysicalDimensions
   SITK_TRANSFORM_SET_MPF( TransformDomainPhysicalDimensions, typename TransformType::PhysicalDimensionsType, double );
 
-
-  std::vector<Image> (*pfImageArrayConvert)(const typename TransformType::CoefficientImageArray &) = &sitkImageArrayConvert<typename TransformType::CoefficientImageArray>;
-  this->m_pfGetCoefficientImages = std::bind(pfImageArrayConvert, std::bind(&TransformType::GetCoefficientImages,t) );
+  this->m_pfGetCoefficientImages = [t] () {
+    return sitkImageArrayConvert(t->GetCoefficientImages());
+  };
   this->m_pfSetCoefficientImages = std::bind(SetCoefficientImages<TransformType>, t, std::placeholders::_1);
 
   this->m_pfGetOrder =  &sitkGetOrder<TransformType>;

--- a/Code/Common/src/sitkScaleSkewVersor3DTransform.cxx
+++ b/Code/Common/src/sitkScaleSkewVersor3DTransform.cxx
@@ -214,19 +214,22 @@ void ScaleSkewVersor3DTransform::InternalInitialization(TransformType *t)
   SITK_TRANSFORM_SET_MPF(Skew, typename TransformType::SkewVectorType, double);
   SITK_TRANSFORM_SET_MPF_GetMatrix();
 
-  void  (TransformType::*pfSetRotation1) (const typename TransformType::VersorType &) = &TransformType::SetRotation;
-  this->m_pfSetRotation1 = std::bind(pfSetRotation1,t,std::bind(&sitkSTLVectorToITKVersor<double, double>,
-                                                                    std::placeholders::_1));
+  this->m_pfSetRotation1 = [t](const std::vector<double> &v) {
+    t->SetRotation(sitkSTLVectorToITKVersor<double>(v));
+  };
 
-  typename TransformType::OutputVectorType (*pfSTLVectorToITK)(const std::vector<double> &) = &sitkSTLVectorToITK<typename TransformType::OutputVectorType, double>;
-  void  (TransformType::*pfSetRotation2) (const typename TransformType::AxisType &, double) = &TransformType::SetRotation;
-  this->m_pfSetRotation2 = std::bind(pfSetRotation2,t,std::bind(pfSTLVectorToITK,std::placeholders::_1),std::placeholders::_2);
+  this->m_pfSetRotation2 = [t](const std::vector<double> &v, double d) {
+    t->SetRotation(sitkSTLVectorToITK<typename TransformType::AxisType>(v),d);
+  };
 
-  this->m_pfGetVersor  = std::bind(&sitkITKVersorToSTL<double, double>,std::bind(&TransformType::GetVersor,t));
-
+  this->m_pfGetVersor = [t] () {
+    return sitkITKVersorToSTL<double>(t->GetVersor());
+  };
 
   // pre argument has no effect
-  this->m_pfTranslate = std::bind(&TransformType::Translate,t,std::bind(pfSTLVectorToITK,std::placeholders::_1), false);
+  this->m_pfTranslate = [t] (const std::vector<double> &v) {
+    t->Translate( sitkSTLVectorToITK<typename TransformType::OutputVectorType>(v), false );
+  };
 }
 
 }

--- a/Code/Common/src/sitkScaleVersor3DTransform.cxx
+++ b/Code/Common/src/sitkScaleVersor3DTransform.cxx
@@ -197,18 +197,22 @@ void ScaleVersor3DTransform::InternalInitialization(TransformType *t)
   SITK_TRANSFORM_SET_MPF(Scale, typename TransformType::ScaleVectorType, double);
   SITK_TRANSFORM_SET_MPF_GetMatrix();
 
-  void  (TransformType::*pfSetRotation1) (const typename TransformType::VersorType &) = &TransformType::SetRotation;
-  this->m_pfSetRotation1 = std::bind(pfSetRotation1,t,std::bind(&sitkSTLVectorToITKVersor<double, double>,std::placeholders::_1));
+  this->m_pfSetRotation1 = [t](const std::vector<double> &v) {
+    t->SetRotation(sitkSTLVectorToITKVersor<double>(v));
+  };
 
-  typename TransformType::OutputVectorType (*pfSTLVectorToITK)(const std::vector<double> &) = &sitkSTLVectorToITK<typename TransformType::OutputVectorType, double>;
-  void  (TransformType::*pfSetRotation2) (const typename TransformType::AxisType &, double) = &TransformType::SetRotation;
-  this->m_pfSetRotation2 = std::bind(pfSetRotation2,t,std::bind(pfSTLVectorToITK,std::placeholders::_1),std::placeholders::_2);
+  this->m_pfSetRotation2 = [t](const std::vector<double> &v, double d) {
+    t->SetRotation(sitkSTLVectorToITK<typename TransformType::AxisType>(v),d);
+  };
 
-  this->m_pfGetVersor  = std::bind(&sitkITKVersorToSTL<double, double>,std::bind(&TransformType::GetVersor,t));
-
+  this->m_pfGetVersor = [t] () {
+    return sitkITKVersorToSTL<double>(t->GetVersor());
+  };
 
   // pre argument has no effect
-  this->m_pfTranslate = std::bind(&TransformType::Translate,t,std::bind(pfSTLVectorToITK,std::placeholders::_1), false);
+  this->m_pfTranslate = [t] (const std::vector<double> &v) {
+    t->Translate( sitkSTLVectorToITK<typename TransformType::OutputVectorType>(v), false );
+  };
 }
 
 }

--- a/Code/Common/src/sitkSimilarity3DTransform.cxx
+++ b/Code/Common/src/sitkSimilarity3DTransform.cxx
@@ -205,21 +205,26 @@ void Similarity3DTransform::InternalInitialization(TransformType *t)
   SITK_TRANSFORM_SET_MPF_GetMatrix();
   SITK_TRANSFORM_SET_MPF_SetMatrix();
 
-  void  (TransformType::*pfSetRotation1) (const typename TransformType::VersorType &) = &TransformType::SetRotation;
-  this->m_pfSetRotation1 = std::bind(pfSetRotation1,t,std::bind(&sitkSTLVectorToITKVersor<double, double>,std::placeholders::_1));
+  this->m_pfSetRotation1 = [t](const std::vector<double> &v) {
+    t->SetRotation(sitkSTLVectorToITKVersor<double>(v));
+  };
 
-  typename TransformType::OutputVectorType (*pfSTLVectorToITK)(const std::vector<double> &) = &sitkSTLVectorToITK<typename TransformType::OutputVectorType, double>;
-  void  (TransformType::*pfSetRotation2) (const typename TransformType::AxisType &, double) = &TransformType::SetRotation;
-  this->m_pfSetRotation2 = std::bind(pfSetRotation2,t,std::bind(pfSTLVectorToITK,std::placeholders::_1),std::placeholders::_2);
+  this->m_pfSetRotation2 = [t](const std::vector<double> &v, double d) {
+    t->SetRotation(sitkSTLVectorToITK<typename TransformType::AxisType>(v),d);
+  };
 
-  this->m_pfGetVersor  = std::bind(&sitkITKVersorToSTL<double, double>,std::bind(&TransformType::GetVersor,t));
+  this->m_pfGetVersor = [t] () {
+    return sitkITKVersorToSTL<double>(t->GetVersor());
+  };
 
   this->m_pfSetScale = std::bind(&TransformType::SetScale,t,std::placeholders::_1);
   this->m_pfGetScale = std::bind(&TransformType::GetScale,t);
 
   // pre argument has no effect
-  this->m_pfTranslate = std::bind(&TransformType::Translate,t,std::bind(pfSTLVectorToITK,std::placeholders::_1), false);
-
+  // pre argument has no effect
+  this->m_pfTranslate = [t] (const std::vector<double> &v) {
+    t->Translate( sitkSTLVectorToITK<typename TransformType::OutputVectorType>(v), false );
+  };
 }
 
 }

--- a/Code/Common/src/sitkTransformHelper.hxx
+++ b/Code/Common/src/sitkTransformHelper.hxx
@@ -19,27 +19,20 @@
 #define sitkTransformHelper_hxx
 
 
-#define SITK_TRANSFORM_SET_MPF(NAME,ITK_TYPENAME, COMPONENT)                      \
+#define SITK_TRANSFORM_SET_MPF(NAME, ITK_TYPENAME, COMPONENT)                      \
   {                                                                     \
-  typedef ITK_TYPENAME itkType;                                         \
-  itkType (*pfSTLToITK)(const std::vector<COMPONENT> &) = &sitkSTLVectorToITK<itkType, COMPONENT>; \
-  this->m_pfSet##NAME = std::bind(&TransformType::Set##NAME,t,std::bind(pfSTLToITK,std::placeholders::_1)); \
-                                                                        \
-  std::vector<COMPONENT> (*pfITKToSTL)( const itkType &) = &sitkITKVectorToSTL<COMPONENT,itkType>; \
-  this->m_pfGet##NAME = std::bind(pfITKToSTL,std::bind(&TransformType::Get##NAME,t)); \
+  this->m_pfSet##NAME = [t](const std::vector<COMPONENT> &arg){ t->Set##NAME(sitkSTLVectorToITK<ITK_TYPENAME>(arg));};\
+  this->m_pfGet##NAME = [t](){ return sitkITKVectorToSTL<COMPONENT>(t->Get##NAME());}; \
   }
 
 #define SITK_TRANSFORM_SET_MPF_GetMatrix()                              \
   {                                                                     \
-  std::vector<double>  (*pfITKDirectionToSTL)(const typename TransformType::MatrixType &) = &sitkITKDirectionToSTL<typename TransformType::MatrixType>; \
-  this->m_pfGetMatrix = std::bind(pfITKDirectionToSTL,std::bind(&TransformType::GetMatrix,t)); \
+  this->m_pfGetMatrix =[t](){ return sitkITKDirectionToSTL<typename TransformType::MatrixType>(t->GetMatrix());}; \
   }
 
 #define SITK_TRANSFORM_SET_MPF_SetMatrix()                              \
   {                                                                     \
-  void (TransformType::*pfSetMatrix) (const typename TransformType::MatrixType &, double) = &TransformType::SetMatrix; \
-  typename TransformType::MatrixType (*pfSTLToITKDirection)(const std::vector<double> &) = &sitkSTLToITKDirection<typename TransformType::MatrixType>; \
-  this->m_pfSetMatrix = std::bind(pfSetMatrix, t, std::bind(pfSTLToITKDirection, std::placeholders::_1), std::placeholders::_2); \
+    this->m_pfSetMatrix = [t](const std::vector<double> &arg, double tolerance){t->SetMatrix(sitkSTLToITKDirection<typename TransformType::MatrixType>(arg), tolerance);}; \
   }
 
 

--- a/Code/Common/src/sitkVersorRigid3DTransform.cxx
+++ b/Code/Common/src/sitkVersorRigid3DTransform.cxx
@@ -188,17 +188,22 @@ void VersorRigid3DTransform::InternalInitialization(TransformType *t)
   SITK_TRANSFORM_SET_MPF_GetMatrix();
   SITK_TRANSFORM_SET_MPF_SetMatrix();
 
-  void  (TransformType::*pfSetRotation1) (const typename TransformType::VersorType &) = &TransformType::SetRotation;
-  this->m_pfSetRotation1 = std::bind(pfSetRotation1,t,std::bind(&sitkSTLVectorToITKVersor<double, double>,std::placeholders::_1));
+  this->m_pfSetRotation1 = [t](const std::vector<double> &v) {
+    t->SetRotation(sitkSTLVectorToITKVersor<double>(v));
+  };
 
-  typename TransformType::OutputVectorType (*pfSTLVectorToITK)(const std::vector<double> &) = &sitkSTLVectorToITK<typename TransformType::OutputVectorType, double>;
-  void  (TransformType::*pfSetRotation2) (const typename TransformType::AxisType &, double) = &TransformType::SetRotation;
-  this->m_pfSetRotation2 = std::bind(pfSetRotation2,t,std::bind(pfSTLVectorToITK,std::placeholders::_1),std::placeholders::_2);
+  this->m_pfSetRotation2 = [t](const std::vector<double> &v, double d) {
+    t->SetRotation(sitkSTLVectorToITK<typename TransformType::AxisType>(v),d);
+  };
 
-  this->m_pfGetVersor  = std::bind(&sitkITKVersorToSTL<double, double>,std::bind(&TransformType::GetVersor,t));
+  this->m_pfGetVersor = [t] () {
+    return sitkITKVersorToSTL<double>(t->GetVersor());
+  };
 
   // pre argument has no effect
-  this->m_pfTranslate = std::bind(&TransformType::Translate,t,std::bind(pfSTLVectorToITK,std::placeholders::_1), false);
+  this->m_pfTranslate = [t] (const std::vector<double> &v) {
+    t->Translate( sitkSTLVectorToITK<typename TransformType::OutputVectorType>(v), false );
+  };
 }
 
 }

--- a/Code/Common/src/sitkVersorTransform.cxx
+++ b/Code/Common/src/sitkVersorTransform.cxx
@@ -161,16 +161,17 @@ void VersorTransform::InternalInitialization(TransformType *t)
   SITK_TRANSFORM_SET_MPF_GetMatrix();
   SITK_TRANSFORM_SET_MPF_SetMatrix();
 
-  typename TransformType::OutputVectorType (*pfSTLVectorToITK)(const std::vector<double> &) = &sitkSTLVectorToITK<typename TransformType::OutputVectorType, double>;
+  this->m_pfSetRotation1 = [t](const std::vector<double> &v) {
+    t->SetRotation(sitkSTLVectorToITKVersor<double>(v));
+  };
 
-  void  (TransformType::*pfSetRotation1) (const typename TransformType::VersorType &) = &TransformType::SetRotation;
-  this->m_pfSetRotation1 = std::bind(pfSetRotation1,t,std::bind(&sitkSTLVectorToITKVersor<double, double>,std::placeholders::_1));
+  this->m_pfSetRotation2 = [t](const std::vector<double> &v, double d) {
+    t->SetRotation(sitkSTLVectorToITK<typename TransformType::AxisType>(v),d);
+  };
 
-  void  (TransformType::*pfSetRotation2) (const typename TransformType::AxisType &, double) = &TransformType::SetRotation;
-  this->m_pfSetRotation2 = std::bind(pfSetRotation2,t,std::bind(pfSTLVectorToITK,std::placeholders::_1),std::placeholders::_2);
-
-  this->m_pfGetVersor  = std::bind(&sitkITKVersorToSTL<double, double>,std::bind(&TransformType::GetVersor,t));
-
+  this->m_pfGetVersor = [t] () {
+    return sitkITKVersorToSTL<double>(t->GetVersor());
+  };
 }
 
 }

--- a/Code/Registration/src/sitkImageRegistrationMethod_CreateOptimizer.cxx
+++ b/Code/Registration/src/sitkImageRegistrationMethod_CreateOptimizer.cxx
@@ -106,7 +106,10 @@ namespace simple
       this->m_pfGetOptimizerPosition = std::bind(&PositionOptimizerCustomCast::CustomCast,optimizer.GetPointer());
       this->m_pfGetOptimizerLearningRate = std::bind(&_OptimizerType::GetLearningRate,optimizer.GetPointer());
       this->m_pfGetOptimizerConvergenceValue = std::bind(&_OptimizerType::GetConvergenceValue,optimizer.GetPointer());
-      this->m_pfGetOptimizerScales = std::bind(&PositionOptimizerCustomCast::Helper<_OptimizerType::ScalesType>, std::bind(&_OptimizerType::GetScales, optimizer.GetPointer()));
+      auto x = optimizer.GetPointer();
+      this->m_pfGetOptimizerScales = [x]() {
+        return PositionOptimizerCustomCast::Helper(x->GetScales());
+      };
 
       optimizer->Register();
       return optimizer.GetPointer();
@@ -128,7 +131,10 @@ namespace simple
       this->m_pfGetOptimizerPosition = std::bind(&PositionOptimizerCustomCast::CustomCast,optimizer.GetPointer());
       this->m_pfGetOptimizerLearningRate = std::bind(&_OptimizerType::GetLearningRate,optimizer.GetPointer());
       this->m_pfGetOptimizerConvergenceValue = std::bind(&_OptimizerType::GetConvergenceValue,optimizer.GetPointer());
-      this->m_pfGetOptimizerScales = std::bind(&PositionOptimizerCustomCast::Helper<_OptimizerType::ScalesType>, std::bind(&_OptimizerType::GetScales, optimizer.GetPointer()));
+      auto x = optimizer.GetPointer();
+      this->m_pfGetOptimizerScales = [x]() {
+        return PositionOptimizerCustomCast::Helper(x->GetScales());
+      };
 
       optimizer->Register();
       return optimizer.GetPointer();
@@ -154,7 +160,11 @@ namespace simple
       this->m_pfGetOptimizerPosition = std::bind(&PositionOptimizerCustomCast::CustomCast,optimizer.GetPointer());
       this->m_pfGetOptimizerLearningRate = std::bind(&_OptimizerType::GetLearningRate,optimizer.GetPointer());
       this->m_pfGetOptimizerConvergenceValue = std::bind(&_OptimizerType::GetConvergenceValue,optimizer.GetPointer());
-      this->m_pfGetOptimizerScales = std::bind(&PositionOptimizerCustomCast::Helper<_OptimizerType::ScalesType>, std::bind(&_OptimizerType::GetScales, optimizer.GetPointer()));
+      auto x = optimizer.GetPointer();
+      this->m_pfGetOptimizerScales = [x]() {
+        return PositionOptimizerCustomCast::Helper(x->GetScales());
+      };
+
 
       optimizer->Register();
       return optimizer.GetPointer();
@@ -179,7 +189,11 @@ namespace simple
       this->m_pfGetOptimizerPosition = std::bind(&PositionOptimizerCustomCast::CustomCast,optimizer.GetPointer());
       this->m_pfGetOptimizerLearningRate = std::bind(&_OptimizerType::GetLearningRate,optimizer.GetPointer());
       this->m_pfGetOptimizerConvergenceValue = std::bind(&_OptimizerType::GetConvergenceValue,optimizer.GetPointer());
-      this->m_pfGetOptimizerScales = std::bind(&PositionOptimizerCustomCast::Helper<_OptimizerType::ScalesType>, std::bind(&_OptimizerType::GetScales, optimizer.GetPointer()));
+      auto x = optimizer.GetPointer();
+      this->m_pfGetOptimizerScales = [x]() {
+        return PositionOptimizerCustomCast::Helper(x->GetScales());
+      };
+
 
       return optimizer.GetPointer();
       }
@@ -227,7 +241,11 @@ namespace simple
       this->m_pfGetMetricValue = std::bind(&_OptimizerType::GetValue,optimizer.GetPointer());
       this->m_pfGetOptimizerIteration = std::bind(&CurrentIterationCustomCast::CustomCast,optimizer.GetPointer());
       this->m_pfGetOptimizerPosition = std::bind(&PositionOptimizerCustomCast::CustomCast,optimizer.GetPointer());
-      this->m_pfGetOptimizerScales = std::bind(&PositionOptimizerCustomCast::Helper<_OptimizerType::ScalesType>, std::bind(&_OptimizerType::GetScales, optimizer.GetPointer()));
+      auto x = optimizer.GetPointer();
+      this->m_pfGetOptimizerScales = [x]() {
+        return PositionOptimizerCustomCast::Helper(x->GetScales());
+      };
+
 
       return optimizer.GetPointer();
       }
@@ -250,7 +268,11 @@ namespace simple
       this->m_pfGetMetricValue = std::bind(&_OptimizerType::GetValue,optimizer.GetPointer());
       this->m_pfGetOptimizerIteration = std::bind(&CurrentIterationCustomCast::CustomCast,optimizer.GetPointer());
       this->m_pfGetOptimizerPosition = std::bind(&PositionOptimizerCustomCast::CustomCast,optimizer.GetPointer());
-      this->m_pfGetOptimizerScales = std::bind(&PositionOptimizerCustomCast::Helper<_OptimizerType::ScalesType>, std::bind(&_OptimizerType::GetScales, optimizer.GetPointer()));
+      auto x = optimizer.GetPointer();
+      this->m_pfGetOptimizerScales = [x]() {
+        return PositionOptimizerCustomCast::Helper(x->GetScales());
+      };
+
 
       return optimizer.GetPointer();
       }
@@ -265,8 +287,11 @@ namespace simple
       this->m_pfGetMetricValue = std::bind(&_OptimizerType::GetCurrentValue,optimizer);
       this->m_pfGetOptimizerIteration = std::bind(&CurrentIterationCustomCast::CustomCast,optimizer.GetPointer());
       this->m_pfGetOptimizerPosition = std::bind(&PositionOptimizerCustomCast::CustomCast,optimizer);
+      auto x = optimizer.GetPointer();
+      this->m_pfGetOptimizerScales = [x]() {
+        return PositionOptimizerCustomCast::Helper(x->GetScales());
+      };
 
-      this->m_pfGetOptimizerScales = std::bind(&PositionOptimizerCustomCast::Helper<_OptimizerType::ScalesType>, std::bind(&_OptimizerType::GetScales, optimizer.GetPointer()));
 
       this->m_pfUpdateWithBestValue = std::bind(&UpdateWithBestValueExhaustive<double>,
                                                   optimizer,
@@ -295,7 +320,11 @@ namespace simple
       this->m_pfGetMetricValue = std::bind(&_OptimizerType::GetValue,optimizer);
       this->m_pfGetOptimizerIteration = std::bind(&CurrentIterationCustomCast::CustomCast,optimizer.GetPointer());
       this->m_pfGetOptimizerPosition = std::bind(&PositionOptimizerCustomCast::CustomCast,optimizer);
-      this->m_pfGetOptimizerScales = std::bind(&PositionOptimizerCustomCast::Helper<_OptimizerType::ScalesType>, std::bind(&_OptimizerType::GetScales, optimizer.GetPointer()));
+      auto x = optimizer.GetPointer();
+      this->m_pfGetOptimizerScales = [x]() {
+        return PositionOptimizerCustomCast::Helper(x->GetScales());
+      };
+
 
       optimizer->Register();
       return optimizer.GetPointer();
@@ -314,7 +343,11 @@ namespace simple
       this->m_pfGetMetricValue = std::bind(&_OptimizerType::GetValue,optimizer.GetPointer());
       this->m_pfGetOptimizerIteration = std::bind(&CurrentIterationCustomCast::CustomCast,optimizer.GetPointer());
       this->m_pfGetOptimizerPosition = std::bind(&PositionOptimizerCustomCast::CustomCast,optimizer.GetPointer());
-      this->m_pfGetOptimizerScales = std::bind(&PositionOptimizerCustomCast::Helper<_OptimizerType::ScalesType>, std::bind(&_OptimizerType::GetScales, optimizer.GetPointer()));
+      auto x = optimizer.GetPointer();
+      this->m_pfGetOptimizerScales = [x]() {
+        return PositionOptimizerCustomCast::Helper(x->GetScales());
+      };
+
 
       optimizer->Register();
       return optimizer.GetPointer();
@@ -349,7 +382,11 @@ namespace simple
       this->m_pfGetOptimizerIteration = std::bind(&CurrentIterationCustomCast::CustomCast,optimizer.GetPointer());
       this->m_pfGetOptimizerPosition = std::bind(&PositionOptimizerCustomCast::CustomCast,optimizer.GetPointer());
       this->m_pfGetOptimizerConvergenceValue = std::bind(&_OptimizerType::GetFrobeniusNorm,optimizer.GetPointer());
-      this->m_pfGetOptimizerScales = std::bind(&PositionOptimizerCustomCast::Helper<_OptimizerType::ScalesType>, std::bind(&_OptimizerType::GetScales, optimizer.GetPointer()));
+      auto x = optimizer.GetPointer();
+      this->m_pfGetOptimizerScales = [x]() {
+        return PositionOptimizerCustomCast::Helper(x->GetScales());
+      };
+
 
       optimizer->Register();
       return optimizer.GetPointer();


### PR DESCRIPTION
The lambda wrapping is clearer and reduces the number of typedefs and
variables required.

The std::bind is still preferred when multiple arguments are pass, as
the std::placeholders work concisely, or when a simple binding of an
argument (this) is needed.