### PR TITLE
Add wrapping for DICOMOrientImageFilter

### DIFF
--- a/Code/BasicFilters/json/DICOMOrientImageFilter.json
+++ b/Code/BasicFilters/json/DICOMOrientImageFilter.json
@@ -1,0 +1,151 @@
+{
+  "name" : "DICOMOrientImageFilter",
+  "template_code_filename" : "ImageFilter",
+  "template_test_filename" : "ImageFilter",
+  "number_of_inputs" : 1,
+  "pixel_types" : "typelist::Append<BasicPixelIDTypeList, VectorPixelIDTypeList>::Type",
+  "custom_register" : "this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 3 > ();\n",
+  "public_declarations" : "static SITKBasicFilters_EXPORT std::string GetOrientationFromDirectionCosines( const std::vector<double> &direction );\n   static SITKBasicFilters_EXPORT std::vector<double> GetDirectionCosinesFromOrientation( const std::string &str );",
+  "filter_type" : "itk::DICOMOrientImageFilter<InputImageType>",
+  "members" : [
+    {
+      "name" : "DesiredCoordinateOrientation",
+      "type" : "std::string",
+      "default" : "std::string(\"LPS\")",
+      "briefdescriptionSet" : "",
+      "detaileddescriptionSet" : "Set/Get the desired coordinate orientation for the output image",
+      "custom_itk_cast" : "filter->SetDesiredCoordinateOrientation( this->m_DesiredCoordinateOrientation );",
+      "briefdescriptionGet" : "",
+      "detaileddescriptionGet" : "Set/Get the desired coordinate orientation for the output image"
+    }
+  ],
+  "measurements" : [
+    {
+      "name" : "FlipAxes",
+      "type" : "std::vector<bool>",
+      "default" : "std::vector<bool>()",
+      "custom_itk_cast" : "this->m_FlipAxes = sitkITKVectorToSTL<bool>(filter->GetFlipAxes());",
+      "briefdescriptionGet" : "",
+      "detaileddescriptionGet" : "Get flip axes.\n\nThis value is computed during Update."
+    },
+    {
+      "name" : "PermuteOrder",
+      "type" : "std::vector<unsigned int>",
+      "default" : "std::vector<unsigned int>()",
+      "custom_itk_cast" : "this->m_PermuteOrder = sitkITKVectorToSTL<unsigned int>(filter->GetPermuteOrder());",
+      "briefdescriptionGet" : "",
+      "detaileddescriptionGet" : "Get axes permute order.\n\nThis value is computed during Update."
+    }
+  ],
+  "tests" : [
+    {
+      "tag" : "default",
+      "description" : "default",
+      "md5hash" : "a963bd6a755b853103a2d195e01a50d3",
+      "settings" : [],
+      "inputs" : [
+        "Input/RA-Short.nrrd"
+      ],
+      "measurements_results" : [
+        {
+          "name" : "FlipAxes",
+          "dim_vec" : 1,
+          "value" : [
+            0,
+            0,
+            0
+          ],
+          "tolerance" : 1e-23
+        },
+        {
+          "name" : "PermuteOrder",
+          "dim_vec" : 1,
+          "value" : [
+            0,
+            1,
+            2
+          ],
+          "tolerance" : 1e-23
+        }
+      ]
+    },
+    {
+      "tag" : "RIP",
+      "description" : "default",
+      "md5hash" : "8aa3dce315a62d31f59c084a07f02448",
+      "settings" : [
+        {
+          "parameter" : "DesiredCoordinateOrientation",
+          "type" : "std::string",
+          "value" : "\"RIP\""
+        }
+      ],
+      "inputs" : [
+        "Input/RA-Short.nrrd"
+      ],
+      "measurements_results" : [
+        {
+          "name" : "FlipAxes",
+          "dim_vec" : 1,
+          "value" : [
+            1,
+            1,
+            0
+          ],
+          "tolerance" : 1e-23
+        },
+        {
+          "name" : "PermuteOrder",
+          "dim_vec" : 1,
+          "value" : [
+            0,
+            2,
+            1
+          ],
+          "tolerance" : 1e-23
+        }
+      ]
+    },
+    {
+      "tag" : "RAS",
+      "description" : "default",
+      "md5hash" : "33eec76230a501095ab4e6509f76e7de",
+      "settings" : [
+        {
+          "parameter" : "DesiredCoordinateOrientation",
+          "type" : "std::string",
+          "value" : "\"RAS\""
+        }
+      ],
+      "inputs" : [
+        "Input/RA-Short.nrrd"
+      ],
+      "measurements_results" : [
+        {
+          "name" : "FlipAxes",
+          "dim_vec" : 1,
+          "value" : [
+            1,
+            1,
+            0
+          ],
+          "tolerance" : 1e-23
+        },
+        {
+          "name" : "PermuteOrder",
+          "dim_vec" : 1,
+          "value" : [
+            0,
+            1,
+            2
+          ],
+          "tolerance" : 1e-23
+        }
+      ]
+    }
+  ],
+  "itk_module" : "SimpleITKFilters",
+  "itk_group" : "SimpleITKFilters",
+  "detaileddescription" : "The physical location of all pixels in the image remains the same, but the meta-data and the ordering of the stored pixels may change.\n\nDICOMOrientImageFilter depends on a set of constants that describe all possible labels. Directions are labeled in terms of following pairs:\n\n\\li Left and Right (Subject's left and right)\n\n\\li Anterior and Posterior (Subject's front and back)\n\n\\li Inferior and Superior (Subject's bottom and top, i.e. feet and head)\n\n\n\n\nThe initials of these directions are used in a 3 letter code in the enumerated type OrientationEnum. The initials are given fastest moving index first, second fastest second, third fastest third, where the label's direction indicates increasing values.\n\nAn ITK image with an identity direction cosine matrix is in LPS (Left, Posterior, Superior) orientation as defined by the DICOM standard.\n\n \\f[ LPS = \\begin{Bmatrix} from\\ right\\ to\\ \\textbf{L}eft \\\\ from\\ anterior\\ towards\\ \\textbf{P}osterior \\\\ from\\ inferior\\ towards\\ \\textbf{S}uperior \\end{Bmatrix} \\f] \n\nThe output orientation is specified with SetDesiredCoordinateOrientation. The input coordinate orientation is computed from the input image's direction cosine matrix.",
+  "briefdescription" : "Permute axes and flip images as needed to obtain an approximation to the desired orientation."
+}

--- a/Code/BasicFilters/src/CMakeLists.txt
+++ b/Code/BasicFilters/src/CMakeLists.txt
@@ -108,6 +108,10 @@ list(APPEND SimpleITKBasicFiltersGeneratedSource_ITKTransform
   sitkBSplineTransformInitializerFilter.cxx )
 set(SimpleITKBasicFiltersGeneratedSource_ITKTransform ${SimpleITKBasicFiltersGeneratedSource_ITKTransform} CACHE INTERNAL "")
 
+list(APPEND SimpleITKBasicFiltersGeneratedSource_SimpleITKFilters
+  sitkDICOMOrientImageFilter_Support.cxx )
+set(SimpleITKBasicFiltersGeneratedSource_SimpleITKFilters ${SimpleITKBasicFiltersGeneratedSource_SimpleITKFilters} CACHE INTERNAL "")
+
 list(APPEND SimpleITKBasicFiltersGeneratedSource_ITKRegistrationCommon
   sitkCenteredTransformInitializerFilter.cxx
   sitkCenteredVersorTransformInitializerFilter.cxx

--- a/Code/BasicFilters/src/sitkDICOMOrientImageFilter_Support.cxx
+++ b/Code/BasicFilters/src/sitkDICOMOrientImageFilter_Support.cxx
@@ -1,0 +1,50 @@
+/*=========================================================================
+*
+*  Copyright NumFOCUS
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*         http://www.apache.org/licenses/LICENSE-2.0.txt
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*=========================================================================*/
+
+#include "sitkDICOMOrientImageFilter.h"
+#include "itkDICOMOrientation.h"
+
+// This file is intended to contain the definition of static
+// member variables needed by JSON Expand templated image filters.
+// It may also contain other member declarations, or other useful
+// items that could be specified here, as opposed to the JSON.
+
+namespace itk {
+  namespace simple {
+
+  std::string DICOMOrientImageFilter::GetOrientationFromDirectionCosines( const std::vector<double> &direction )
+  {
+    typedef typename itk::ImageBase<3>::DirectionType DirectionType;
+    const DirectionType itkDirection = sitkSTLToITKDirection<DirectionType>(direction);
+
+    const DICOMOrientation orientation(itkDirection);
+    return orientation.GetAsString();
+  }
+
+  std::vector<double> DICOMOrientImageFilter::GetDirectionCosinesFromOrientation( const std::string &str )
+  {
+    const DICOMOrientation orientation(str);
+
+    const auto itkDirection = orientation.GetAsDirection();
+
+    return sitkITKDirectionToSTL(itkDirection);
+
+  }
+
+  }
+}

--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -53,7 +53,7 @@ set(ITK_GIT_REPOSITORY "${git_protocol}://github.com/InsightSoftwareConsortium/I
 mark_as_advanced(ITK_GIT_REPOSITORY)
 sitk_legacy_naming(ITK_GIT_REPOSITORY ITK_REPOSITORY)
 
-set(_DEFAULT_ITK_GIT_TAG "v5.1rc02")
+set(_DEFAULT_ITK_GIT_TAG "8f64ced3639d5dfd200ff46e99f3fed9f9f1aab6")
 set(ITK_GIT_TAG "${_DEFAULT_ITK_GIT_TAG}" CACHE STRING "Tag in ITK git repo")
 mark_as_advanced(ITK_GIT_TAG)
 set(ITK_TAG_COMMAND GIT_TAG "${ITK_GIT_TAG}")

--- a/Testing/Unit/sitkBasicFiltersTests.cxx
+++ b/Testing/Unit/sitkBasicFiltersTests.cxx
@@ -53,6 +53,7 @@
 #include <sitkCommand.h>
 #include <sitkResampleImageFilter.h>
 #include <sitkSignedMaurerDistanceMapImageFilter.h>
+#include <sitkDICOMOrientImageFilter.h>
 
 #include "itkVectorImage.h"
 #include "itkVector.h"
@@ -933,4 +934,25 @@ TEST(BasicFilters,OtsuThreshold_CheckNamesInputCompatibility)
   // is thrown.
   EXPECT_THROW( sitk::OtsuThreshold(input, mask1), sitk::GenericException );
   EXPECT_THROW( sitk::OtsuThreshold(input, mask2), sitk::GenericException );
+}
+
+TEST(BasicFilters, DICOMOrientImageFilter_Direction)
+{
+  namespace sitk= itk::simple;
+
+  auto directionLPS= v9(1.0,0.0,0.0,
+                        0.0,1.0,
+                        0.0,0.0,0.0,1.0);
+  auto directionRAS= v9(-1.0,0.0,0.0,
+                        0.0,-1.0,0.0,
+                        0.0,0.0,1.0);
+
+  EXPECT_EQ(directionLPS,
+            sitk::DICOMOrientImageFilter::GetDirectionCosinesFromOrientation("LPS"));
+  EXPECT_EQ("LPS",  sitk::DICOMOrientImageFilter::GetOrientationFromDirectionCosines(directionLPS));
+
+  EXPECT_EQ(v9(-1.0,0.0,0.0, 0.0,-1.0,0.0, 0.0,0.0,1.0),
+            sitk::DICOMOrientImageFilter::GetDirectionCosinesFromOrientation("RAS"));
+  EXPECT_EQ("RAS",sitk::DICOMOrientImageFilter::GetOrientationFromDirectionCosines(directionRAS));
+
 }


### PR DESCRIPTION
Adding testing, and access to convert between orientation strings to
direction cosine matrix.

Closes #644.
