### PR TITLE
Add missing implementation of DeepCopy for LabelMaps

### DIFF
--- a/Code/Common/src/sitkPimpleImageBase.hxx
+++ b/Code/Common/src/sitkPimpleImageBase.hxx
@@ -26,6 +26,7 @@
 #include "itkVectorImage.h"
 #include "itkLabelMap.h"
 #include "itkImageDuplicator.h"
+#include "itkConvertLabelMapFilter.h"
 
 
 #include <type_traits>
@@ -108,8 +109,13 @@ namespace itk
     typename std::enable_if<IsLabel<UImageType>::Value, PimpleImageBase*>::type
     DeepCopy( void ) const
       {
-        sitkExceptionMacro( "This method is not implemented yet" );
-        return new Self( this->m_Image.GetPointer() );
+        typedef itk::ConvertLabelMapFilter<UImageType, UImageType> FilterType;
+        typename FilterType::Pointer filter = FilterType::New();
+        filter->SetInput ( this->m_Image );
+        filter->UpdateLargestPossibleRegion();
+        ImagePointer output = filter->GetOutput();
+
+        return new Self( output.GetPointer() );
       }
 
     virtual itk::DataObject* GetDataBase( void ) { return this->m_Image.GetPointer(); }

--- a/Testing/Unit/sitkImageTests.cxx
+++ b/Testing/Unit/sitkImageTests.cxx
@@ -511,6 +511,17 @@ TEST_F(Image, CopyOnWrite)
     << " Reference Count for shared after set spacing";
   EXPECT_FALSE(img0.IsUnique());
   EXPECT_EQ( sitk::Hash( imgCopy ), sitk::Hash( img0 ) ) << "Hash for shared and copy after set spacing";
+
+  sitk::Image labelImage1(10, 10, sitk::sitkLabelUInt8);
+  EXPECT_TRUE(labelImage1.IsUnique());
+  sitk::Image labelImage2(labelImage1);
+  EXPECT_FALSE(labelImage1.IsUnique());
+  EXPECT_FALSE(labelImage2.IsUnique());
+
+  // copy on write
+  labelImage2.SetSpacing( std::vector<double>( {1.2, 3.4} ));
+  EXPECT_TRUE(labelImage1.IsUnique());
+  EXPECT_TRUE(labelImage2.IsUnique());
 }
 
 TEST_F(Image,Operators)


### PR DESCRIPTION
The itk::ConvertLabelMap filter is used to copy the LabelMap data
structure.