### PR TITLE
Check for aliasing of image's pixel container

### DIFF
--- a/Code/Common/src/sitkPimpleImageBase.hxx
+++ b/Code/Common/src/sitkPimpleImageBase.hxx
@@ -78,6 +78,8 @@ namespace itk
                               << "SimpleITK does not support streaming or unbuffered regions!" );
           }
 
+        InternalCheckBuffer(image);
+
         const IndexType & idx = image->GetBufferedRegion().GetIndex();
         for ( unsigned int i = 0; i < ImageType::ImageDimension; ++i )
           {
@@ -720,6 +722,38 @@ namespace itk
                             << " but the GetPixel access method requires type: "
                             << GetPixelIDValueAsString(  PixelIDToPixelIDValue<TPixelIDType>::Result )
                             << "!" );
+      }
+
+    template< typename TPixelType, unsigned int NDimension >
+    bool
+    InternalCheckBuffer(const itk::Image<TPixelType, NDimension> *image)
+      {
+        auto container = image->GetPixelContainer();
+        if (container->GetReferenceCount() != 1)
+          {
+          sitkExceptionMacro( << "The image pixel container is shared by other resources and presents aliasing issue.");
+          }
+        return true;
+      }
+
+    template< typename TPixelType, unsigned int NDimension >
+    bool
+    InternalCheckBuffer(const itk::VectorImage<TPixelType, NDimension> *image)
+      {
+        auto container = image->GetPixelContainer();
+        if (container->GetReferenceCount() != 1)
+          {
+          sitkExceptionMacro( << "The vector image pixel container is shared by other resources and presents aliasing issues.");
+          }
+        return true;
+      }
+
+
+    template< typename TLabelObject >
+    bool
+    InternalCheckBuffer(const itk::LabelMap<TLabelObject> *)
+      {
+        return true;
       }
 
     template < typename TPixelIDType >

--- a/ExpandTemplateGenerator/Components/ExecuteInternalUpdateAndReturn.cxx.in
+++ b/ExpandTemplateGenerator/Components/ExecuteInternalUpdateAndReturn.cxx.in
@@ -71,8 +71,9 @@ OUT=[[
 ]]
 else
 OUT=[[
-  typename FilterType::OutputImageType *itkOutImage = filter->GetOutput();
-  this->FixNonZeroIndex( itkOutImage );
-  return Image( this->CastITKToImage(itkOutImage) );
+  typename FilterType::OutputImageType::Pointer itkOutImage{ filter->GetOutput()};
+  filter = nullptr;
+  this->FixNonZeroIndex( itkOutImage.GetPointer() );
+  return Image{ this->CastITKToImage( itkOutImage.GetPointer() ) };
 ]]
 end)


### PR DESCRIPTION
To add additional safety with image buffer aliasing, the pixel
container of the itk::Image is now checked to verify that is only has
one reference. In filter's execute method the filter needs to be
deleted before the check to ensure the filter has no internal
references to the buffer.