### PR TITLE
Add missing InitialDisplacementField input

### DIFF
--- a/Code/BasicFilters/json/LevelSetMotionRegistrationFilter.json
+++ b/Code/BasicFilters/json/LevelSetMotionRegistrationFilter.json
@@ -15,6 +15,12 @@
     {
       "name" : "MovingImage",
       "type" : "Image"
+    },
+    {
+      "name" : "InitialDisplacementField",
+      "type" : "Image",
+      "optional" : true,
+      "custom_itk_cast" : "  typedef itk::VectorImage<double, FilterType::DisplacementFieldType::ImageDimension> VectorImageType;\n      filter->SetInitialDisplacementField( GetImageFromVectorImage(const_cast<VectorImageType*>(CastImageToITK<VectorImageType>(*inInitialDisplacementField).GetPointer()) ) );"
     }
   ],
   "members" : [


### PR DESCRIPTION
The LevelSetMotionRegistrationImageFilter in ITK is derived from the
PDEDeformableRegistrationImageFilter, simular to the Deamons
filters. These allow the initial displacement field to optionally be
set.