### PR TITLE
Explicitly set SimpleITKFilter git hash

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -23,6 +23,7 @@ if(NOT DEFINED Module_SimpleITKFilters)
   set(Module_SimpleITKFilters ON)
 endif()
 
+set(Module_SimpleITKFilters_GIT_TAG c8c42430626f0123e7ec401c17c72c7d5ce82669 )
 
 get_cmake_property( _varNames VARIABLES )
 


### PR DESCRIPTION
The module update include a fix to the initialization to the
DICOMOrientImageFilter's array parameters.