### PR TITLE
Use double-brace initialization of std::array

### DIFF
--- a/Testing/Unit/sitkImageFilterTestTemplate.cxx.in
+++ b/Testing/Unit/sitkImageFilterTestTemplate.cxx.in
@@ -35,11 +35,11 @@
 
 static bool isLabelType( const itk::simple::Image &img)
 {
-  static const std::array<itk::simple::PixelIDValueEnum, 4> labelIDs{
+  static const std::array<itk::simple::PixelIDValueEnum, 4> labelIDs{{
       itk::simple::sitkLabelUInt8,
       itk::simple::sitkLabelUInt16,
       itk::simple::sitkLabelUInt32,
-      itk::simple::sitkLabelUInt64};
+      itk::simple::sitkLabelUInt64}};
 
   return std::find(labelIDs.begin(), labelIDs.end(), img.GetPixelID()) != labelIDs.end();
 }


### PR DESCRIPTION
Double-braces required in C++11 prior to the CWG 1270 revision.

This addressed compilation warning with Visual Studio 2017: Testing/Unit/sitkComplexToModulusImageFilterTest.cxx:39:7: warning: suggest braces around initialization of subobject [-Wmissing-braces]