### PR TITLE
Update manylinux docker

### DIFF
--- a/Utilities/Distribution/manylinux/Dockerfile-x86_64
+++ b/Utilities/Distribution/manylinux/Dockerfile-x86_64
@@ -2,7 +2,7 @@ FROM quay.io/pypa/manylinux1_x86_64
 MAINTAINER Insight Software Consortium <community@itk.org>
 
 ADD https://github.com/Kitware/CMake/releases/download/v3.11.4/cmake-3.11.4.tar.gz \
-    https://www.openssl.org/source/openssl-1.0.2q.tar.gz \
+    https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz \
     /tmp/
 
 WORKDIR /tmp/

--- a/Utilities/Distribution/manylinux/Dockerfile-x86_64
+++ b/Utilities/Distribution/manylinux/Dockerfile-x86_64
@@ -1,7 +1,7 @@
 FROM quay.io/pypa/manylinux1_x86_64
 MAINTAINER Insight Software Consortium <community@itk.org>
 
-ADD https://github.com/Kitware/CMake/releases/download/v3.11.4/cmake-3.11.4.tar.gz \
+ADD https://cmake.org/files/v3.13/cmake-3.13.5.tar.gz \
     https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz \
     /tmp/
 

--- a/Utilities/Distribution/manylinux/imagefiles/install.sh
+++ b/Utilities/Distribution/manylinux/imagefiles/install.sh
@@ -5,7 +5,7 @@ export MAKEFLAGS="-j ${NPROC}"
 OPENSSL_ROOT=openssl-1.0.2u
 # Hash from https://www.openssl.org/source/openssl-1.0.2u.tar.gz.sha256
 OPENSSL_HASH=ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16
-CMAKE_ROOT=cmake-3.11.4
+CMAKE_ROOT=cmake-3.13.5
 
 
 function check_var {

--- a/Utilities/Distribution/manylinux/imagefiles/install.sh
+++ b/Utilities/Distribution/manylinux/imagefiles/install.sh
@@ -2,9 +2,9 @@ NPROC=$(grep -c processor /proc/cpuinfo)
 
 export MAKEFLAGS="-j ${NPROC}"
 
-OPENSSL_ROOT=openssl-1.0.2q
-# Hash from https://www.openssl.org/source/openssl-1.0.2q.tar.gz.sha256
-OPENSSL_HASH=5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684
+OPENSSL_ROOT=openssl-1.0.2u
+# Hash from https://www.openssl.org/source/openssl-1.0.2u.tar.gz.sha256
+OPENSSL_HASH=ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16
 CMAKE_ROOT=cmake-3.11.4
 
 


### PR DESCRIPTION
Updating openssl and cmake versions to what compiles on the old Centos 5 manylinux1 image.

This addresses error due to change in the openssl path.