### PR TITLE
Updating the Read-The-Docs configuration.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinx-tabs
 cmake
 sphinx_rtd_theme
+sphinx==3.0.0


### PR DESCRIPTION
RTD recommends pinning the sphinx version via the requirements.txt
file
(https://docs.readthedocs.io/en/stable/builds.html#understanding-what-s-going-on).
We weren't doing this before.