### PR TITLE
Enable keyword argument for Resample procedures

### DIFF
--- a/Testing/Unit/Python/CMakeLists.txt
+++ b/Testing/Unit/Python/CMakeLists.txt
@@ -5,6 +5,9 @@
 sitk_add_python_test( Test.ImageTests
   "${CMAKE_CURRENT_SOURCE_DIR}/sitkImageTests.py" )
 
+sitk_add_python_test( Test.BasicFiltersTests
+  "${CMAKE_CURRENT_SOURCE_DIR}/sitkBasicFilterTests.py")
+
 sitk_add_python_test( Test.TransformTests
   "${CMAKE_CURRENT_SOURCE_DIR}/sitkTransformTests.py" )
 

--- a/Testing/Unit/Python/sitkBasicFilterTests.py
+++ b/Testing/Unit/Python/sitkBasicFilterTests.py
@@ -1,0 +1,85 @@
+#==========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#==========================================================================*/
+
+from __future__ import print_function
+import unittest
+
+import SimpleITK as sitk
+import sys
+import tempfile
+import os.path
+import shutil
+
+
+
+class BasicFiltersTests(unittest.TestCase):
+    """Tests for the Python interface for the Image class"""
+
+    def setUp(self):
+        super(BasicFiltersTests, self).setUp()
+        self.test_dir = tempfile.mkdtemp()
+
+
+    def assertImageAlmostEqual(self, img1, img2, max_difference=1e-8, msg=None):
+        """ Compare with the maximum absolute difference between two images """
+
+        minMaxFilter = sitk.StatisticsImageFilter()
+        minMaxFilter.Execute(sitk.Abs(img1 - img2))
+
+        if (minMaxFilter.GetMaximum() > max_difference):
+            print("min: ", minMaxFilter.GetMinimum(), " max: ", minMaxFilter.GetMaximum(), " mean: ", minMaxFilter.GetMean())
+            self.fail(msg)
+
+
+    def test_procedure_resample(self):
+        """ Test the custom Resample procedure. """
+
+        img = sitk.GaborSource(sitk.sitkFloat32, [64, 64], frequency=.05)
+
+        tx = sitk.Euler2DTransform( [32,32], .1, [2,-3])
+
+        filter = sitk.ResampleImageFilter()
+        filter.SetTransform(tx)
+        filter.SetOutputPixelType(sitk.sitkFloat64)
+        filter.SetDefaultPixelValue(255)
+        filter.SetReferenceImage(img)
+
+        baseline_image = filter.Execute(img)
+
+        self.assertImageAlmostEqual( baseline_image,
+                                     sitk.Resample(img, tx, sitk.sitkLinear, 255.0, sitk.sitkFloat64, False) )
+        self.assertImageAlmostEqual( baseline_image,
+                                     sitk.Resample(img, img, tx, sitk.sitkLinear, 255.0, sitk.sitkFloat64, False) )
+        self.assertImageAlmostEqual( baseline_image,
+                                     sitk.Resample(img, (64, 64), tx, sitk.sitkLinear, (0.0, 0.0), (1.0, 1.0), (1.0, 0.0, 0.0, 1.0), 255.0, sitk.sitkFloat64, False) )
+
+        self.assertImageAlmostEqual( baseline_image,
+                                     sitk.Resample(img, transform=tx, defaultPixelValue=255.0, outputPixelType=sitk.sitkFloat64 ) )
+        self.assertImageAlmostEqual( baseline_image,
+                                     sitk.Resample(img, img, transform=tx, defaultPixelValue=255.0, outputPixelType=sitk.sitkFloat64) )
+        self.assertImageAlmostEqual( baseline_image,
+                                     sitk.Resample(img, [64, 64], transform=tx, defaultPixelValue=255.0, outputPixelType=sitk.sitkFloat64) )
+
+        self.assertImageAlmostEqual( baseline_image,
+                                     sitk.Resample(img, referenceImage=img, transform=tx, defaultPixelValue=255.0, outputPixelType=sitk.sitkFloat64) )
+        self.assertImageAlmostEqual( baseline_image,
+                                     sitk.Resample(img, size=(64, 64), transform=tx, defaultPixelValue=255.0, outputPixelType=sitk.sitkFloat64 ) )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Testing/Unit/Python/sitkImageTests.py
+++ b/Testing/Unit/Python/sitkImageTests.py
@@ -47,7 +47,7 @@ class ImageTests(unittest.TestCase):
         self.assertEqual(img1.GetMetaDataKeys(), img2.GetMetaDataKeys())
 
         for k in img1.GetMetaDataKeys():
-            aself.assertEqual(img1.GetMetaData(k), img2.GetMetaData(k))
+            self.assertEqual(img1.GetMetaData(k), img2.GetMetaData(k))
 
         self.assertEqual(sitk.Hash(img1), sitk.Hash(img2))
 

--- a/Wrapping/Python/Python.i
+++ b/Wrapping/Python/Python.i
@@ -31,6 +31,9 @@
 %ignore itk::simple::CastImageFilter::SetOutputPixelType( PixelIDValueType pixelID );
 %ignore itk::simple::GetPixelIDValueAsString( PixelIDValueType type );
 
+%ignore itk::simple::Resample;
+
+
 // Make __str__ transparent by renaming ToString to __str__
 %rename(__str__) ToString;
 
@@ -980,7 +983,76 @@ def GetImageFromArray( arr, isVector=None):
     return img
 %}
 
+%pythoncode %{
+  def Resample( image1, *args, **kwargs):
+    """
+     Resample ( Image image1, Transform transform = itk::simple::Transform(), InterpolatorEnum interpolator = itk::simple::sitkLinear, double defaultPixelValue = 0.0, PixelIDValueEnum outputPixelType = itk::simple::sitkUnknown, bool useNearestNeighborExtrapolator = false);
 
+     Resample ( Image image1, Image referenceImage, Transform transform = itk::simple::Transform(), InterpolatorEnum interpolator = itk::simple::sitkLinear, double defaultPixelValue = 0.0, PixelIDValueEnum outputPixelType = sitkUnknown, bool useNearestNeighborExtrapolator = false);
+
+     Resample ( const Image& image1, VectorUInt32 size, Transform transform = itk::simple::Transform(), InterpolatorEnum interpolator = itk::simple::sitkLinear, VectorDouble outputOrigin = std::vector<double>(3, 0.0), VectorDouble outputSpacing = std::vector<double>(3, 1.0), VectorDouble outputDirection = std::vector<double>(), double defaultPixelValue = 0.0, PixelIDValueEnum outputPixelType = sitkUnknown, bool useNearestNeighborExtrapolator = false);
+
+     itk::simple::ResampleImageFilter procedural interface.
+
+     This is a custom overloaded python method, which fully supports the 3 signatures with positional and keyword arguemnts. The second positional parameters without a default value are used to determine which overloaded procedure signature to envoke.
+
+    """
+    def _r_image( referenceImage,
+                  transform = Transform(),
+                  interpolator = sitkLinear,
+                  defaultPixelValue = 0.0,
+                  outputPixelType = sitkUnknown,
+                  useNearestNeighborExtrapolator = False):
+       filter = ResampleImageFilter()
+       filter.SetReferenceImage(referenceImage)
+       filter.SetTransform(transform)
+       filter.SetInterpolator(interpolator)
+       filter.SetDefaultPixelValue(defaultPixelValue)
+       filter.SetOutputPixelType(outputPixelType)
+       filter.SetUseNearestNeighborExtrapolator(useNearestNeighborExtrapolator)
+       return filter.Execute(image1)
+
+
+    def _r( size,
+            transform = Transform(),
+            interpolator = sitkLinear,
+            outputOrigin = (0.0, 0.0, 0.0),
+            outputSpacing = (1.0, 1.0, 1.0),
+            outputDirection = (),
+            defaultPixelValue = 0.0,
+            outputPixelType = sitkUnknown,
+            useNearestNeighborExtrapolator = False):
+        filter = ResampleImageFilter()
+        filter.SetSize(size)
+        filter.SetTransform(transform)
+        filter.SetInterpolator(interpolator)
+        filter.SetOutputOrigin(outputOrigin)
+        filter.SetOutputSpacing(outputSpacing)
+        filter.SetOutputDirection(outputDirection)
+        filter.SetDefaultPixelValue(defaultPixelValue)
+        filter.SetOutputPixelType(outputPixelType)
+        filter.SetUseNearestNeighborExtrapolator(useNearestNeighborExtrapolator)
+        filter.DebugOn()
+        return filter.Execute(image1)
+
+    if args:
+      if isinstance(args[0], Image):
+        return _r_image( *args, **kwargs)
+      if not isinstance(args[0], Transform):
+        try:
+          iter(args[0])
+          return _r( *args, **kwargs)
+        except TypeError as e:
+          pass
+
+    if "referenceImage" in kwargs:
+      return _r_image( *args, **kwargs)
+    if "size" in kwargs:
+      return _r( *args, **kwargs)
+
+    return _r_image( image1, *args, **kwargs)
+
+%}
 
 // Enable Python classes derived from Command Execute method to be
 // called from C++


### PR DESCRIPTION
SWIG does not support keyword argument for Python with C++ overloaded
functions. Therefore, the SWIG generate procedure is remove and
replaced with a manually written method that uses the positional
argument to determine the correct method signature.