### PR TITLE
Remove Python 3.4 from manylinux packaging.

### DIFF
--- a/Testing/CI/Azure/templates/package-linux-job.yml
+++ b/Testing/CI/Azure/templates/package-linux-job.yml
@@ -1,6 +1,6 @@
 parameters:
   ARCH: x86_64
-  PYTHON_VERSIONS: "cp34-cp34m cp35-cp35m cp36-cp36m cp37-cp37m cp38-cp38"
+  PYTHON_VERSIONS: "cp35-cp35m cp36-cp36m cp37-cp37m cp38-cp38"
 
 jobs:
   - job: Linux

--- a/Utilities/Distribution/manylinux/Dockerfile-i686
+++ b/Utilities/Distribution/manylinux/Dockerfile-i686
@@ -1,8 +1,8 @@
 FROM quay.io/pypa/manylinux1_i686
 MAINTAINER Insight Software Consortium <community@itk.org>
 
-ADD https://github.com/Kitware/CMake/releases/download/v3.11.4/cmake-3.11.4.tar.gz \
-    https://www.openssl.org/source/openssl-1.0.2q.tar.gz \
+ADD https://cmake.org/files/v3.13/cmake-3.13.5.tar.gz \
+    https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz \
     /tmp/
 
 WORKDIR /tmp/

--- a/Utilities/Distribution/manylinux/imagefiles/cmd.sh
+++ b/Utilities/Distribution/manylinux/imagefiles/cmd.sh
@@ -51,7 +51,7 @@ function build_simpleitk_python {
     echo "PYTHON_INCLUDE_DIR:${PYTHON_INCLUDE_DIR}"
     echo "PYTHON_LIBRARY:${PYTHON_LIBRARY}"
 
-    ${PYTHON_EXECUTABLE} -m pip install --user numpy
+    ${PYTHON_EXECUTABLE} -m pip install --user numpy --progress-bar off
     rm -rf ${BLD_DIR}-${PYTHON} &&
     mkdir -p ${BLD_DIR}-${PYTHON} &&
     cd ${BLD_DIR}-${PYTHON} &&


### PR DESCRIPTION
Python 3.4 has reached EOL, so we not longer need to package for it.