### PR TITLE
Use value parameter and move for Set methods of std::vectors

### DIFF
--- a/Code/BasicFilters/templates/sitkRegionGrowingImageFilterTemplate.h.in
+++ b/Code/BasicFilters/templates/sitkRegionGrowingImageFilterTemplate.h.in
@@ -32,9 +32,9 @@ $(include ClassDeclaration.h.in)
 $(include PublicDeclarations.h.in)
 $(include MemberGetSetDeclarations.h.in)
       /** Set SeedList */
-      SITK_RETURN_SELF_TYPE_HEADER SetSeedList ( const std::vector< std::vector<unsigned int> > &t )
+      SITK_RETURN_SELF_TYPE_HEADER SetSeedList ( std::vector< std::vector<unsigned int> > t )
         {
-        this->m_SeedList = t; return *this;
+          this->m_SeedList = std::move(t); return *this;
         }
 
       /** Get SeedList */
@@ -51,17 +51,17 @@ $(include MemberGetSetDeclarations.h.in)
         }
 
       /** SetSeed - Set list to a single seed */
-      SITK_RETURN_SELF_TYPE_HEADER SetSeed( const std::vector<unsigned int> &idx )
+      SITK_RETURN_SELF_TYPE_HEADER SetSeed( std::vector<unsigned int> idx )
         {
         this->m_SeedList.clear();
-        this->m_SeedList.push_back(idx);
+        this->m_SeedList.push_back(std::move(idx));
         return *this;
         }
 
       /** AddSeed - Add a seed to the end of the list */
-      SITK_RETURN_SELF_TYPE_HEADER AddSeed( const std::vector<unsigned int> &idx )
+      SITK_RETURN_SELF_TYPE_HEADER AddSeed( std::vector<unsigned int> idx )
         {
-        this->m_SeedList.push_back(idx);
+          this->m_SeedList.push_back(std::move(idx));
         return *this;
         }
 

--- a/ExpandTemplateGenerator/Components/InputParameters.in
+++ b/ExpandTemplateGenerator/Components/InputParameters.in
@@ -9,9 +9,9 @@ for i = 1,#inputs do
     if not inputs[i].type and inputs[i].enum then
       OUT = OUT .. name .. '::' .. inputs[i].name .. 'Type'
     elseif inputs[i].dim_vec and (inputs[i].dim_vec == 1) then
-      OUT = OUT..'const std::vector<'..inputs[i].type..'> &'
+      OUT = OUT..'std::vector<'..inputs[i].type..'>'
     elseif inputs[i].point_vec and (inputs[i].point_vec == 1) then
-      OUT = OUT..'const std::vector< std::vector<'..inputs[i].type..'> > &'
+      OUT = OUT..'std::vector< std::vector<'..inputs[i].type..'> >'
     else
       OUT = OUT .. 'const ' .. inputs[i].type .. ' &'
     end

--- a/ExpandTemplateGenerator/Components/MemberGetSetDeclarations.h.in
+++ b/ExpandTemplateGenerator/Components/MemberGetSetDeclarations.h.in
@@ -32,13 +32,19 @@ end)$(if (not no_set_method) or (no_set_method == 0) then
       if not type and enum then
         OUT=OUT..' ${name}Type'
       elseif dim_vec and (dim_vec == 1) then
-        OUT=OUT..' const std::vector<${type}> &'
+        OUT=OUT..' std::vector<${type}>'
       elseif point_vec and (point_vec == 1) then
-        OUT=OUT..' const std::vector< std::vector<${type}> >&'
+        OUT=OUT..' std::vector< std::vector<${type}> >'
       else
         OUT=OUT..' ${type}'
       end
-      OUT=OUT..' ${name} ) { this->m_${name} = ${name}; return *this; }'
+      OUT=OUT..' ${name} ) '
+      if (dim_vec and (dim_vec == 1)) or
+         (point_vec and (point_vec == 1)) then
+        OUT = OUT..'{ this->m_${name} = std::move(${name}); return *this; }'
+      else
+        OUT=OUT..'{ this->m_${name} = ${name}; return *this; }'
+      end
   if dim_vec and ( set_as_scalar == 1 ) then
     OUT = OUT .. '\
 \

--- a/ExpandTemplateGenerator/Components/MemberParameters.in
+++ b/ExpandTemplateGenerator/Components/MemberParameters.in
@@ -9,9 +9,9 @@ $(for i = 1,#members do
   if not members[i].type and members[i].enum then
     OUT = OUT .. name .. '::' .. members[i].name .. 'Type'
   elseif members[i].dim_vec and (members[i].dim_vec == 1) then
-    OUT = OUT..'const std::vector<'..members[i].type..'> &'
+    OUT = OUT..'std::vector<'..members[i].type..'>'
   elseif members[i].point_vec and (members[i].point_vec == 1) then
-    OUT = OUT..'const std::vector< std::vector<'..members[i].type..'> > &'
+    OUT = OUT..'std::vector< std::vector<'..members[i].type..'> >'
   else
     OUT = OUT .. members[i].type
   end

--- a/ExpandTemplateGenerator/Components/MemberParametersWithDefaults.in
+++ b/ExpandTemplateGenerator/Components/MemberParametersWithDefaults.in
@@ -13,9 +13,9 @@ $(for i = 1,#members do
   if not type and members[i].enum then
     OUT = OUT .. name .. '::' .. members[i].name .. 'Type'
   elseif members[i].dim_vec and (members[i].dim_vec == 1) then
-    OUT = OUT..'const std::vector<'..members[i].type..'> &'
+    OUT = OUT..'std::vector<'..members[i].type..'>'
   elseif members[i].point_vec and (members[i].point_vec == 1) then
-    OUT = OUT..'const std::vector< std::vector<'..members[i].type..'> > &'
+    OUT = OUT..'std::vector< std::vector<'..members[i].type..'> >'
   else
     OUT = OUT .. members[i].type
   end

--- a/ExpandTemplateGenerator/Components/ProceduralAPIRValueReference.cxx.in
+++ b/ExpandTemplateGenerator/Components/ProceduralAPIRValueReference.cxx.in
@@ -5,7 +5,15 @@ Image ${name:gsub("ImageFilter$", ""):gsub("Filter$", "")} ( $(include ImageRVal
 {
   ${name} filter;
 $(for i = 1,#members do
-  OUT=OUT .. [[  filter.Set]] ..members[i].name..[[( ]] .. members[i].name:sub(1,1):lower() .. members[i].name:sub(2,-1) .. [[ );]]
+  OUT=OUT .. [[  filter.Set]] ..members[i].name..[[( ]]
+  member_name = members[i].name:sub(1,1):lower() .. members[i].name:sub(2,-1)
+  if (members[i].dim_vec and (members[i].dim_vec == 1)) or
+     (members[i].point_vec and (members[i].point_vec == 1)) then
+    OUT = OUT..'std::move('..member_name..')'
+  else
+    OUT = OUT..member_name
+  end
+  OUT=OUT.. [[ );]]
 end)
   return filter.Execute ( $(for inum=1,number_of_inputs do
                               if inum==1 then


### PR DESCRIPTION
Improves performance by removing an std::vector copy, when the
argument is initialized with an rvalue reference, and then the
parameter is moved into the member variable. Otherwise the argument
will be initialized with a copy, then a move operation performed.