### PR TITLE
Remove EXPORT specification for static member function declaration

### DIFF
--- a/Code/BasicFilters/json/DICOMOrientImageFilter.json
+++ b/Code/BasicFilters/json/DICOMOrientImageFilter.json
@@ -5,7 +5,7 @@
   "number_of_inputs" : 1,
   "pixel_types" : "typelist::Append<BasicPixelIDTypeList, VectorPixelIDTypeList>::Type",
   "custom_register" : "this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 3 > ();\n",
-  "public_declarations" : "static SITKBasicFilters_EXPORT std::string GetOrientationFromDirectionCosines( const std::vector<double> &direction );\n   static SITKBasicFilters_EXPORT std::vector<double> GetDirectionCosinesFromOrientation( const std::string &str );",
+  "public_declarations" : "static std::string GetOrientationFromDirectionCosines( const std::vector<double> &direction );\n   static std::vector<double> GetDirectionCosinesFromOrientation( const std::string &str );",
   "filter_type" : "itk::DICOMOrientImageFilter<InputImageType>",
   "members" : [
     {


### PR DESCRIPTION
The declaration was causing the following error:

error C2487: member of dll interface class may not be declared with dll interface