### PR TITLE
Write testing output image files with compression

### DIFF
--- a/Testing/Unit/CSharpImageFilterTestTemplate.cs.in
+++ b/Testing/Unit/CSharpImageFilterTestTemplate.cs.in
@@ -181,6 +181,7 @@ OUT=[[
 
                 // Write output
                 ImageFileWriter writer = new ImageFileWriter();
+                writer.UseCompressionOn()
                 writer.SetFileName( args[args.Length-1] );
                 writer.Execute( output );
 ]]

--- a/Testing/Unit/JavaImageFilterTestTemplate.java.in
+++ b/Testing/Unit/JavaImageFilterTestTemplate.java.in
@@ -225,6 +225,7 @@ OUT=[[
         }
 
       // Write output
+      writer.useCompressionOn();
       writer.setFileName( argv[argv.length - 1] );
       writer.execute( output );
 ]]

--- a/Testing/Unit/LuaImageFilterTestTemplate.lua.in
+++ b/Testing/Unit/LuaImageFilterTestTemplate.lua.in
@@ -148,6 +148,7 @@ OUT=[[
         end
     end
 
+    writer:UseCompressionOn ()
     writer:SetFileName ( arg[#arg] )
     writer:Execute ( output )
 ]]

--- a/Testing/Unit/PythonImageFilterTestTemplate.py.in
+++ b/Testing/Unit/PythonImageFilterTestTemplate.py.in
@@ -110,6 +110,7 @@ OUT=[[
     if output.GetPixelIDValue() in labelIDs:
        output = SimpleITK.LabelMapToLabel(output)
 
+    writer.UseCompressionOn()
     writer.SetFileName ( sys.argv[-1] )
     writer.Execute ( output )
 ]]

--- a/Testing/Unit/RImageFilterTestTemplate.R.in
+++ b/Testing/Unit/RImageFilterTestTemplate.R.in
@@ -115,6 +115,7 @@ OUT=[[
   output <- LabelMapToLabel(output)
   }
 
+  writer$$UseCompressionOn()
   writer$$SetFileName( lastargument )
   writer$$Execute( output )
 ]]

--- a/Testing/Unit/RubyImageFilterTestTemplate.rb.in
+++ b/Testing/Unit/RubyImageFilterTestTemplate.rb.in
@@ -143,6 +143,7 @@ OUT=[[
     caster = Simpleitk::LabelMapToLabelImageFilter.new
     output = caster.execute( output )
   end
+  writer.use_compression_on()
   writer.set_file_name( ARGV[ARGV.length-1] )
   writer.execute( output )
 ]]

--- a/Testing/Unit/TclImageFilterTestTemplate.tcl.in
+++ b/Testing/Unit/TclImageFilterTestTemplate.tcl.in
@@ -105,7 +105,7 @@ OUT=[[
   if { [lsearch $labelIDs [$$output GetPixelIDValue] ] >= 0 } {
       set output [ LabelMapToLabel $$output ]
   }
-
+  writer UseCompressionOn
   writer SetFileName [lindex $$argv end]
   writer Execute $$output
 ]]


### PR DESCRIPTION
This reduces the space used during testing.