### PR TITLE
AZP Remove nightly package schedule from yaml

### DIFF
--- a/Testing/CI/Azure/azure-pipelines-package.yml
+++ b/Testing/CI/Azure/azure-pipelines-package.yml
@@ -7,13 +7,8 @@ trigger:
      exclude:
        - '*'
 pr: none
-schedules:
-- cron: "0 3 * * *" # 10 pm EST->UTC
-  displayName: Daily build
-  branches:
-    include:
-    - master
-  always: false
+
+# Scheduled builds on master to build the "latest" are configure through the AZP GUI.
 
 variables:
   ExternalDataVersion: 1.2.0


### PR DESCRIPTION
The nightly schedule is now done in the GUI.

The yams based schedule stopped working, so we are switching to the AZP GUI based configuration for this option.