### PR TITLE
Remove redundant void in function declarations

### DIFF
--- a/Code/BasicFilters/include/sitkCastImageFilter.h
+++ b/Code/BasicFilters/include/sitkCastImageFilter.h
@@ -46,7 +46,7 @@ public:
 
   /** Set/Get the output pixel type */
   SITK_RETURN_SELF_TYPE_HEADER SetOutputPixelType( PixelIDValueEnum pixelID );
-  PixelIDValueEnum GetOutputPixelType( void ) const;
+  PixelIDValueEnum GetOutputPixelType( ) const;
 
   virtual ~CastImageFilter();
 
@@ -103,7 +103,7 @@ private:
     typedef typename ::detail::FunctionTraits<TMemberFunctionPointer>::ClassType ObjectType;
 
     template< typename TImageType1, typename TImageType2 >
-    TMemberFunctionPointer operator() ( void ) const
+    TMemberFunctionPointer operator() ( ) const
     {
       return &ObjectType::template ExecuteInternalCast< TImageType1, TImageType2 >;
     }
@@ -118,7 +118,7 @@ private:
     typedef typename ::detail::FunctionTraits<TMemberFunctionPointer>::ClassType ObjectType;
 
     template< typename TImageType1, typename TImageType2 >
-    TMemberFunctionPointer operator() ( void ) const
+    TMemberFunctionPointer operator() ( ) const
     {
       return &ObjectType::template ExecuteInternalToVector< TImageType1, TImageType2 >;
     }
@@ -133,7 +133,7 @@ private:
     typedef typename ::detail::FunctionTraits<TMemberFunctionPointer>::ClassType ObjectType;
 
     template< typename TImageType1, typename TImageType2 >
-    TMemberFunctionPointer operator() ( void ) const
+    TMemberFunctionPointer operator() ( ) const
     {
       return &ObjectType::template ExecuteInternalToLabel< TImageType1, TImageType2 >;
     }
@@ -148,7 +148,7 @@ private:
     typedef typename ::detail::FunctionTraits<TMemberFunctionPointer>::ClassType ObjectType;
 
     template< typename TImageType1, typename TImageType2 >
-    TMemberFunctionPointer operator() ( void ) const
+    TMemberFunctionPointer operator() ( ) const
     {
       return &ObjectType::template ExecuteInternalLabelToImage< TImageType1, TImageType2 >;
     }

--- a/Code/BasicFilters/src/sitkCastImageFilter.cxx
+++ b/Code/BasicFilters/src/sitkCastImageFilter.cxx
@@ -72,7 +72,7 @@ CastImageFilter::Self& CastImageFilter::SetOutputPixelType( PixelIDValueEnum pix
   return *this;
 }
 
-PixelIDValueEnum CastImageFilter::GetOutputPixelType( void ) const
+PixelIDValueEnum CastImageFilter::GetOutputPixelType( ) const
 {
   return this->m_OutputPixelType;
 }

--- a/Code/Common/include/sitkAffineTransform.h
+++ b/Code/Common/include/sitkAffineTransform.h
@@ -91,7 +91,7 @@ private:
     itk::TransformBase *transform;
     AffineTransform *that;
     template< typename TransformType >
-    void operator() ( void ) const
+    void operator() ( ) const
       {
         TransformType *t = dynamic_cast<TransformType*>(transform);
         if (t && (typeid(*t) == typeid(TransformType)))

--- a/Code/Common/include/sitkBSplineTransform.h
+++ b/Code/Common/include/sitkBSplineTransform.h
@@ -101,7 +101,7 @@ private:
     itk::TransformBase *transform;
     BSplineTransform *that;
     template< typename TransformType >
-    void operator() ( void ) const
+    void operator() ( ) const
       {
         TransformType *t = dynamic_cast<TransformType*>(transform);
         if (t && (typeid(*t) == typeid(TransformType)))

--- a/Code/Common/include/sitkCommand.h
+++ b/Code/Common/include/sitkCommand.h
@@ -50,14 +50,14 @@ public:
   Command();
 
   /** Destructor. */
-  virtual ~Command(void);
+  virtual ~Command();
 
   /** Set/Get Command Name */
   virtual std::string GetName() const { return this->m_Name; }
   virtual void SetName(const std::string &name) { this->m_Name = name; }
 
   /** The method that defines action to be taken by the command */
-  virtual void Execute(void);
+  virtual void Execute();
 
 protected:
 

--- a/Code/Common/include/sitkDetail.h
+++ b/Code/Common/include/sitkDetail.h
@@ -34,7 +34,7 @@ struct MemberFunctionAddressor
   typedef typename ::detail::FunctionTraits<TMemberFunctionPointer>::ClassType ObjectType;
 
   template< typename TImageType >
-  TMemberFunctionPointer operator() ( void ) const
+  TMemberFunctionPointer operator() ( ) const
     {
       return &ObjectType::template ExecuteInternal< TImageType >;
     }
@@ -46,7 +46,7 @@ struct DualExecuteInternalAddressor
   typedef typename ::detail::FunctionTraits<TMemberFunctionPointer>::ClassType ObjectType;
 
   template< typename TImageType1, typename TImageType2 >
-  TMemberFunctionPointer operator() ( void ) const
+  TMemberFunctionPointer operator() ( ) const
     {
       return &ObjectType::template DualExecuteInternal< TImageType1, TImageType2 >;
     }
@@ -61,7 +61,7 @@ struct ExecuteInternalVectorImageAddressor
   typedef typename ::detail::FunctionTraits<TMemberFunctionPointer>::ClassType ObjectType;
 
   template< typename TImageType >
-  TMemberFunctionPointer operator() ( void ) const
+  TMemberFunctionPointer operator() ( ) const
   {
     return &ObjectType::template ExecuteInternalVectorImage< TImageType >;
   }
@@ -77,7 +77,7 @@ struct DualExecuteInternalVectorAddressor
   typedef typename ::detail::FunctionTraits<TMemberFunctionPointer>::ClassType ObjectType;
 
   template< typename TImageType1, typename TImageType2 >
-  TMemberFunctionPointer operator() ( void ) const
+  TMemberFunctionPointer operator() ( ) const
     {
       return &ObjectType::template DualExecuteInternalVector< TImageType1, TImageType2 >;
     }
@@ -92,7 +92,7 @@ struct ExecuteInternalLabelImageAddressor
   typedef typename ::detail::FunctionTraits<TMemberFunctionPointer>::ClassType ObjectType;
 
   template< typename TImageType >
-  TMemberFunctionPointer operator() ( void ) const
+  TMemberFunctionPointer operator() ( ) const
   {
     return &ObjectType::template ExecuteInternalLabelImage< TImageType >;
   }

--- a/Code/Common/include/sitkDisplacementFieldTransform.h
+++ b/Code/Common/include/sitkDisplacementFieldTransform.h
@@ -119,7 +119,7 @@ private:
     itk::TransformBase *transform;
     DisplacementFieldTransform *that;
     template< typename TransformType >
-    void operator() ( void ) const
+    void operator() ( ) const
       {
         TransformType *t = dynamic_cast<TransformType*>(transform);
         if (t && (typeid(*t) == typeid(TransformType)))

--- a/Code/Common/include/sitkDualMemberFunctionFactory.h
+++ b/Code/Common/include/sitkDualMemberFunctionFactory.h
@@ -126,11 +126,11 @@ public:
              typename TPixelIDTypeList2,
              unsigned int VImageDimension,
              typename TAddressor >
-  void RegisterMemberFunctions( void );
+  void RegisterMemberFunctions( );
   template < typename TPixelIDTypeList1,
              typename TPixelIDTypeList2,
              unsigned int VImageDimension >
-  void RegisterMemberFunctions( void )
+  void RegisterMemberFunctions( )
   {
     typedef detail::DualExecuteInternalAddressor<MemberFunctionType> AddressorType;
     this->RegisterMemberFunctions< TPixelIDTypeList1, TPixelIDTypeList2, VImageDimension, AddressorType>();

--- a/Code/Common/include/sitkDualMemberFunctionFactory.hxx
+++ b/Code/Common/include/sitkDualMemberFunctionFactory.hxx
@@ -130,7 +130,7 @@ template <typename TMemberFunctionPointer>
 template < typename TPixelIDTypeList1, typename TPixelIDTypeList2, unsigned int VImageDimension, typename TAddressor >
 void
 DualMemberFunctionFactory< TMemberFunctionPointer >
-::RegisterMemberFunctions( void )
+::RegisterMemberFunctions( )
 {
   typedef DualMemberFunctionInstantiater< Self, VImageDimension, TAddressor > InstantiaterType;
 

--- a/Code/Common/include/sitkFunctionCommand.h
+++ b/Code/Common/include/sitkFunctionCommand.h
@@ -42,7 +42,7 @@ public:
 
   FunctionCommand();
 
-  virtual void Execute(void);
+  virtual void Execute();
 
   /** Generic method to set a class's member function to be called in
    *  the Execute method.

--- a/Code/Common/include/sitkImage.h
+++ b/Code/Common/include/sitkImage.h
@@ -80,7 +80,7 @@ namespace simple
     virtual ~Image( );
 
     /** \brief Default constructor, creates an image of size 0 */
-    Image( void );
+    Image( );
 
     // copy constructor
     Image( const Image &img );
@@ -168,8 +168,8 @@ namespace simple
      *
      * @{
      */
-    itk::DataObject* GetITKBase( void );
-    const itk::DataObject* GetITKBase( void ) const;
+    itk::DataObject* GetITKBase( );
+    const itk::DataObject* GetITKBase( ) const;
     /**@}*/
 
     /** Get the pixel type
@@ -178,11 +178,11 @@ namespace simple
      * manually changed, unless by assignment. The value may be -1 or
      * "Unknown".
      */
-    PixelIDValueEnum GetPixelID( void ) const;
-    PixelIDValueType GetPixelIDValue( void ) const;
+    PixelIDValueEnum GetPixelID( ) const;
+    PixelIDValueType GetPixelIDValue( ) const;
 
     /** Return the pixel type as a human readable string value. */
-    std::string GetPixelIDTypeAsString( void ) const;
+    std::string GetPixelIDTypeAsString( ) const;
 
     /** Get the number of physical dimensions.
      *
@@ -191,14 +191,14 @@ namespace simple
      * applicable to. This does not include the pixels' vector index
      * as a dimension.
      */
-    unsigned int GetDimension( void ) const;
+    unsigned int GetDimension( ) const;
 
     /** \brief Get the number of components for each pixel
      *
      * For scalar images this methods returns 1. For vector images the
      * number of components for each pixel is returned.
      */
-    unsigned int GetNumberOfComponentsPerPixel( void ) const;
+    unsigned int GetNumberOfComponentsPerPixel( ) const;
 
     /** \brief Get the number of pixels in the image
      *
@@ -208,12 +208,12 @@ namespace simple
      * component images.
      *
      */
-    uint64_t GetNumberOfPixels( void ) const;
+    uint64_t GetNumberOfPixels( ) const;
 
     /** Get/Set the Origin in physical space
      * @{
      */
-    std::vector< double > GetOrigin( void ) const;
+    std::vector< double > GetOrigin( ) const;
     void SetOrigin( const std::vector< double > &origin );
     /** @} */
 
@@ -223,7 +223,7 @@ namespace simple
      * length of the vector is equal to the dimension of the Image.
      * @{
      */
-    std::vector< double > GetSpacing( void ) const;
+    std::vector< double > GetSpacing( ) const;
     void SetSpacing( const std::vector< double > &spacing );
     /** @} */
 
@@ -253,17 +253,17 @@ namespace simple
     /** Get the number of pixels the Image is in each dimension as a
       * std::vector. The size of the vector is equal to the number of dimensions
       * for the image. */
-    std::vector< unsigned int > GetSize( void ) const;
+    std::vector< unsigned int > GetSize( ) const;
 
     /** Get the number of pixels the Image is in the first dimension */
-    unsigned int GetWidth( void ) const;
+    unsigned int GetWidth( ) const;
 
     /** Get the number of pixels the Image is in the second dimension */
-    unsigned int GetHeight( void ) const;
+    unsigned int GetHeight( ) const;
 
     /** Get the number of pixels the Image is in the third dimension
       * or 0 if the Image is only 2D */
-    unsigned int GetDepth( void ) const;
+    unsigned int GetDepth( ) const;
 
 
     /** \brief Copy common meta-data from an image to this one.
@@ -284,7 +284,7 @@ namespace simple
      * image's meta-data dictionary. Iterate through with these keys
      * to get the values.
      */
-    std::vector<std::string> GetMetaDataKeys( void ) const;
+    std::vector<std::string> GetMetaDataKeys( ) const;
 
     /** \brief Query the meta-data dictionary for the existence of a key.
      */
@@ -313,7 +313,7 @@ namespace simple
      */
     bool EraseMetaData( const std::string &key );
 
-    std::string ToString( void ) const;
+    std::string ToString( ) const;
 
     /** \brief Get the value of a pixel
      *
@@ -534,7 +534,7 @@ namespace simple
       typedef typename ::detail::FunctionTraits<TMemberFunctionPointer>::ClassType ObjectType;
 
       template< typename TImageType >
-      TMemberFunctionPointer operator() ( void ) const
+      TMemberFunctionPointer operator() ( ) const
       {
         return &ObjectType::template AllocateInternal< TImageType >;
       }

--- a/Code/Common/include/sitkMemberFunctionFactory.h
+++ b/Code/Common/include/sitkMemberFunctionFactory.h
@@ -115,9 +115,9 @@ public:
   template < typename TPixelIDTypeList,
              unsigned int VImageDimension,
              typename TAddressor >
-  void RegisterMemberFunctions( void );
+  void RegisterMemberFunctions( );
   template < typename TPixelIDTypeList, unsigned int VImageDimension >
-  void RegisterMemberFunctions( void )
+  void RegisterMemberFunctions( )
   {
     typedef detail::MemberFunctionAddressor< TMemberFunctionPointer > AddressorType;
     this->RegisterMemberFunctions< TPixelIDTypeList, VImageDimension, AddressorType >();

--- a/Code/Common/include/sitkMemberFunctionFactory.hxx
+++ b/Code/Common/include/sitkMemberFunctionFactory.hxx
@@ -117,7 +117,7 @@ template <typename TPixelIDTypeList,
           unsigned int VImageDimension,
           typename TAddressor>
 void MemberFunctionFactory<TMemberFunctionPointer>
-::RegisterMemberFunctions( void )
+::RegisterMemberFunctions( )
 {
   typedef MemberFunctionInstantiater< MemberFunctionFactory, VImageDimension,TAddressor > InstantiaterType;
 

--- a/Code/Common/include/sitkMemberFunctionFactoryBase.h
+++ b/Code/Common/include/sitkMemberFunctionFactoryBase.h
@@ -74,7 +74,7 @@ protected:
   typedef typename ::detail::FunctionTraits<MemberFunctionType>::ResultType    MemberFunctionResultType;
 
 
-  MemberFunctionFactoryBase( void )
+  MemberFunctionFactoryBase( )
     :  m_PFunction4( typelist::Length<InstantiatedPixelIDTypeList>::Result ),
        m_PFunction3( typelist::Length<InstantiatedPixelIDTypeList>::Result ),
        m_PFunction2( typelist::Length<InstantiatedPixelIDTypeList>::Result )
@@ -131,7 +131,7 @@ protected:
   typedef typename ::detail::FunctionTraits<MemberFunctionType>::Argument0Type MemberFunctionArgumentType;
 
 
-  MemberFunctionFactoryBase( void )
+  MemberFunctionFactoryBase( )
     :  m_PFunction4( typelist::Length<InstantiatedPixelIDTypeList>::Result ),
        m_PFunction3( typelist::Length<InstantiatedPixelIDTypeList>::Result ),
        m_PFunction2( typelist::Length<InstantiatedPixelIDTypeList>::Result )
@@ -185,7 +185,7 @@ protected:
   typedef typename ::detail::FunctionTraits<MemberFunctionType>::ClassType     ObjectType;
 
 
-  MemberFunctionFactoryBase( void )
+  MemberFunctionFactoryBase( )
     :  m_PFunction4( typelist::Length<InstantiatedPixelIDTypeList>::Result ),
        m_PFunction3( typelist::Length<InstantiatedPixelIDTypeList>::Result ),
        m_PFunction2( typelist::Length<InstantiatedPixelIDTypeList>::Result )
@@ -241,7 +241,7 @@ protected:
   typedef typename ::detail::FunctionTraits<MemberFunctionType>::ClassType     ObjectType;
 
 
-  MemberFunctionFactoryBase( void )
+  MemberFunctionFactoryBase( )
     :  m_PFunction4( typelist::Length<InstantiatedPixelIDTypeList>::Result ),
        m_PFunction3( typelist::Length<InstantiatedPixelIDTypeList>::Result ),
        m_PFunction2( typelist::Length<InstantiatedPixelIDTypeList>::Result )
@@ -297,7 +297,7 @@ protected:
   typedef typename ::detail::FunctionTraits<MemberFunctionType>::ClassType     ObjectType;
 
 
-  MemberFunctionFactoryBase( void )
+  MemberFunctionFactoryBase( )
     :  m_PFunction4( typelist::Length<InstantiatedPixelIDTypeList>::Result ),
        m_PFunction3( typelist::Length<InstantiatedPixelIDTypeList>::Result ),
        m_PFunction2( typelist::Length<InstantiatedPixelIDTypeList>::Result )
@@ -353,7 +353,7 @@ protected:
   typedef typename ::detail::FunctionTraits<MemberFunctionType>::ClassType     ObjectType;
 
 
-  MemberFunctionFactoryBase( void )
+  MemberFunctionFactoryBase( )
     :  m_PFunction4( typelist::Length<InstantiatedPixelIDTypeList>::Result ),
        m_PFunction3( typelist::Length<InstantiatedPixelIDTypeList>::Result ),
        m_PFunction2( typelist::Length<InstantiatedPixelIDTypeList>::Result )

--- a/Code/Common/include/sitkScaleTransform.h
+++ b/Code/Common/include/sitkScaleTransform.h
@@ -77,7 +77,7 @@ private:
     itk::TransformBase *transform;
     ScaleTransform *that;
     template< typename TransformType >
-    void operator() ( void ) const
+    void operator() ( ) const
       {
         TransformType *t = dynamic_cast<TransformType*>(transform);
         if (t && (typeid(*t) == typeid(TransformType)))

--- a/Code/Common/include/sitkTransform.h
+++ b/Code/Common/include/sitkTransform.h
@@ -88,7 +88,7 @@ public:
 
   /** \brief By default a 3-d identity transform is constructed
    */
-  Transform( void );
+  Transform( );
 
   /** \brief Construct a SimpleITK Transform from a pointer to an ITK
    * composite transform.
@@ -128,7 +128,7 @@ public:
    */
   Transform( Image &displacement, TransformEnum type = sitkDisplacementField );
 
-  virtual ~Transform( void );
+  virtual ~Transform( );
 
   /** \brief Copy constructor and assignment operator
    *
@@ -151,13 +151,13 @@ public:
    *
    * @{
    */
-  itk::TransformBase* GetITKBase( void );
-  const itk::TransformBase* GetITKBase( void ) const;
+  itk::TransformBase* GetITKBase( );
+  const itk::TransformBase* GetITKBase( ) const;
   /**@}*/
 
   /** Return the dimension of the Transform ( 2D or 3D )
    */
-  unsigned int GetDimension( void ) const;
+  unsigned int GetDimension( ) const;
 
   // todo get transform type
 
@@ -165,21 +165,21 @@ public:
    * @{
    */
   void SetParameters ( const std::vector<double>& parameters );
-  std::vector<double> GetParameters( void ) const;
+  std::vector<double> GetParameters( ) const;
   /**@}*/
 
   /** Return the number of optimizable parameters */
-  unsigned int GetNumberOfParameters( void ) const;
+  unsigned int GetNumberOfParameters( ) const;
 
   /** Set/Get Fixed Transform Parameter
    * @{
    */
   void SetFixedParameters ( const std::vector<double>& parameters );
-  std::vector<double> GetFixedParameters( void ) const;
+  std::vector<double> GetFixedParameters( ) const;
   /**@}*/
 
   /** Get the number of fixed parameters */
-  unsigned int GetNumberOfFixedParameters( void ) const;
+  unsigned int GetNumberOfFixedParameters( ) const;
 
   // Make composition
   SITK_RETURN_SELF_TYPE_HEADER AddTransform( Transform t );
@@ -243,7 +243,7 @@ public:
    */
   Transform GetInverse() const;
 
-  std::string ToString( void ) const;
+  std::string ToString( ) const;
 
 
   /** return user readable name for the SimpleITK transform */
@@ -256,7 +256,7 @@ public:
    * to the itk::Transform pointed to is only pointed to by this
    * object.
    */
-  void MakeUnique( void );
+  void MakeUnique( );
 
 protected:
 
@@ -278,7 +278,7 @@ private:
     itk::TransformBase *transform;
     Transform *that;
     template< typename TransformType >
-    void operator() ( void ) const
+    void operator() ( ) const
       {
         TransformType *t = dynamic_cast<TransformType*>(transform);
         if (t)
@@ -306,7 +306,7 @@ private:
     typedef typename ::detail::FunctionTraits<TMemberFunctionPointer>::ClassType ObjectType;
 
     template< typename TImageType >
-    TMemberFunctionPointer operator() ( void ) const
+    TMemberFunctionPointer operator() ( ) const
       {
         return &ObjectType::template InternalDisplacementInitialization< TImageType >;
       }

--- a/Code/Common/include/sitkTranslationTransform.h
+++ b/Code/Common/include/sitkTranslationTransform.h
@@ -66,7 +66,7 @@ struct MyVisitor
   itk::TransformBase *transform;
   TranslationTransform *that;
   template< typename TransformType >
-  void operator() ( void ) const
+  void operator() ( ) const
     {
       TransformType *t = dynamic_cast<TransformType*>(transform);
       if (t && (typeid(*t) == typeid(TransformType)))

--- a/Code/Common/src/sitkBSplineTransform.cxx
+++ b/Code/Common/src/sitkBSplineTransform.cxx
@@ -42,7 +42,7 @@ std::vector<Image> sitkImageArrayConvert(const TImageArrayType &a)
 
 
 template<typename TBSplineTransform>
-unsigned int sitkGetOrder(void)
+unsigned int sitkGetOrder()
 {
   return TBSplineTransform::SplineOrder;
 }

--- a/Code/Common/src/sitkCommand.cxx
+++ b/Code/Common/src/sitkCommand.cxx
@@ -41,7 +41,7 @@ Command::~Command( )
 }
 
 
-void Command::Execute(void)
+void Command::Execute()
 {
 }
 

--- a/Code/Common/src/sitkFunctionCommand.cxx
+++ b/Code/Common/src/sitkFunctionCommand.cxx
@@ -32,7 +32,7 @@ FunctionCommand::FunctionCommand( )
   Command::SetName("FunctionCommand");
 }
 
-void FunctionCommand::Execute(void)
+void FunctionCommand::Execute()
 {
   if (bool(this->m_Function))
     {

--- a/Code/Common/src/sitkImage.cxx
+++ b/Code/Common/src/sitkImage.cxx
@@ -100,7 +100,7 @@ namespace itk
         }
     }
 
-    itk::DataObject* Image::GetITKBase( void )
+    itk::DataObject* Image::GetITKBase( )
     {
       if ( m_PimpleImage )
         {
@@ -113,7 +113,7 @@ namespace itk
         }
     }
 
-    const itk::DataObject* Image::GetITKBase( void ) const
+    const itk::DataObject* Image::GetITKBase( ) const
     {
       if ( m_PimpleImage )
         {
@@ -125,72 +125,72 @@ namespace itk
         }
     }
 
-    PixelIDValueType Image::GetPixelIDValue( void ) const
+    PixelIDValueType Image::GetPixelIDValue( ) const
     {
       return this->GetPixelID();
     }
 
-    PixelIDValueEnum Image::GetPixelID( void ) const
+    PixelIDValueEnum Image::GetPixelID( ) const
     {
       assert( m_PimpleImage );
       return this->m_PimpleImage->GetPixelID();
     }
 
-    unsigned int Image::GetDimension( void ) const
+    unsigned int Image::GetDimension( ) const
     {
       assert( m_PimpleImage );
       return this->m_PimpleImage->GetDimension();
     }
 
-    unsigned int Image::GetNumberOfComponentsPerPixel( void ) const
+    unsigned int Image::GetNumberOfComponentsPerPixel( ) const
     {
       assert( m_PimpleImage );
       return this->m_PimpleImage->GetNumberOfComponentsPerPixel();
     }
 
-    uint64_t Image::GetNumberOfPixels( void ) const
+    uint64_t Image::GetNumberOfPixels( ) const
     {
       assert( m_PimpleImage );
       return this->m_PimpleImage->GetNumberOfPixels();
     }
 
-    std::string Image::GetPixelIDTypeAsString( void ) const
+    std::string Image::GetPixelIDTypeAsString( ) const
     {
       return std::string( GetPixelIDValueAsString( this->GetPixelIDValue() ) );
     }
 
-    std::string Image::ToString( void ) const
+    std::string Image::ToString( ) const
     {
       assert( m_PimpleImage );
       return this->m_PimpleImage->ToString();
     }
 
-    std::vector< unsigned int > Image::GetSize( void ) const
+    std::vector< unsigned int > Image::GetSize( ) const
     {
       assert( m_PimpleImage );
       return this->m_PimpleImage->GetSize();
     }
 
-    unsigned int Image::GetWidth( void ) const
+    unsigned int Image::GetWidth( ) const
     {
       assert( m_PimpleImage );
       return this->m_PimpleImage->GetWidth();
     }
 
-    unsigned int Image::GetHeight( void ) const
+    unsigned int Image::GetHeight( ) const
     {
       assert( m_PimpleImage );
       return this->m_PimpleImage->GetHeight();
     }
 
-    unsigned int Image::GetDepth( void ) const
+    unsigned int Image::GetDepth( ) const
     {
       assert( m_PimpleImage );
       return this->m_PimpleImage->GetDepth();
     }
 
     // Get Origin
-    std::vector< double > Image::GetOrigin( void ) const
+    std::vector< double > Image::GetOrigin( ) const
     {
        assert( m_PimpleImage );
       return this->m_PimpleImage->GetOrigin();
@@ -205,7 +205,7 @@ namespace itk
     }
 
     // Get Spacing
-    std::vector< double > Image::GetSpacing( void ) const
+    std::vector< double > Image::GetSpacing( ) const
     {
        assert( m_PimpleImage );
       return this->m_PimpleImage->GetSpacing();
@@ -220,7 +220,7 @@ namespace itk
     }
 
     // Get Direction
-    std::vector< double > Image::GetDirection( void ) const
+    std::vector< double > Image::GetDirection( ) const
     {
       assert( m_PimpleImage );
       return this->m_PimpleImage->GetDirection();
@@ -255,7 +255,7 @@ namespace itk
       this->SetDirection( srcImage.GetDirection() );
     }
 
-    std::vector<std::string> Image::GetMetaDataKeys( void ) const
+    std::vector<std::string> Image::GetMetaDataKeys( ) const
     {
       assert( m_PimpleImage );
       const itk::MetaDataDictionary &mdd = this->m_PimpleImage->GetDataBase()->GetMetaDataDictionary();

--- a/Code/Common/src/sitkPimpleImageBase.h
+++ b/Code/Common/src/sitkPimpleImageBase.h
@@ -40,32 +40,32 @@ namespace itk
   class SITKCommon_HIDDEN PimpleImageBase
   {
   public:
-    virtual ~PimpleImageBase( void ) { };
+    virtual ~PimpleImageBase( ) { };
 
-    virtual PixelIDValueEnum GetPixelID(void) const = 0;
-    virtual unsigned int GetDimension( void ) const  = 0;
-    virtual uint64_t GetNumberOfPixels( void ) const = 0;
-    virtual unsigned int GetNumberOfComponentsPerPixel( void ) const = 0;
+    virtual PixelIDValueEnum GetPixelID() const = 0;
+    virtual unsigned int GetDimension( ) const  = 0;
+    virtual uint64_t GetNumberOfPixels( ) const = 0;
+    virtual unsigned int GetNumberOfComponentsPerPixel( ) const = 0;
 
-    virtual PimpleImageBase *ShallowCopy(void) const = 0;
-    virtual PimpleImageBase *DeepCopy(void) const = 0;
-    virtual itk::DataObject* GetDataBase( void ) = 0;
-    virtual const itk::DataObject* GetDataBase( void ) const = 0;
+    virtual PimpleImageBase *ShallowCopy() const = 0;
+    virtual PimpleImageBase *DeepCopy() const = 0;
+    virtual itk::DataObject* GetDataBase( ) = 0;
+    virtual const itk::DataObject* GetDataBase( ) const = 0;
 
-    virtual unsigned int GetWidth( void ) const { return this->GetSize( 0 ); }
-    virtual unsigned int GetHeight( void ) const { return this->GetSize( 1 ); }
-    virtual unsigned int GetDepth( void ) const { return this->GetSize( 2 ); }
+    virtual unsigned int GetWidth( ) const { return this->GetSize( 0 ); }
+    virtual unsigned int GetHeight( ) const { return this->GetSize( 1 ); }
+    virtual unsigned int GetDepth( ) const { return this->GetSize( 2 ); }
 
-    virtual std::vector< unsigned int > GetSize( void ) const = 0;
+    virtual std::vector< unsigned int > GetSize( ) const = 0;
     virtual unsigned int GetSize( unsigned int dimension ) const = 0;
 
 
-    virtual std::vector<double> GetOrigin( void ) const = 0;
+    virtual std::vector<double> GetOrigin( ) const = 0;
     virtual void SetOrigin( const std::vector<double> &orgn ) = 0;
-    virtual std::vector<double> GetSpacing( void ) const = 0;
+    virtual std::vector<double> GetSpacing( ) const = 0;
     virtual void SetSpacing( const std::vector<double> &spc ) = 0;
 
-    virtual std::vector< double > GetDirection( void ) const = 0;
+    virtual std::vector< double > GetDirection( ) const = 0;
     virtual void SetDirection( const std::vector< double > &direction ) = 0;
 
     virtual std::vector<int64_t> TransformPhysicalPointToIndex( const std::vector<double> &pt) const = 0;

--- a/Code/Common/src/sitkPimpleImageBase.hxx
+++ b/Code/Common/src/sitkPimpleImageBase.hxx
@@ -91,8 +91,8 @@ namespace itk
           }
       }
 
-    virtual PimpleImageBase *ShallowCopy( void ) const { return new Self(this->m_Image.GetPointer()); }
-    virtual PimpleImageBase *DeepCopy( void ) const { return this->DeepCopy<TImageType>(); }
+    virtual PimpleImageBase *ShallowCopy( ) const { return new Self(this->m_Image.GetPointer()); }
+    virtual PimpleImageBase *DeepCopy( ) const { return this->DeepCopy<TImageType>(); }
 
     template <typename UImageType>
     typename std::enable_if<!IsLabel<UImageType>::Value, PimpleImageBase*>::type
@@ -120,24 +120,24 @@ namespace itk
         return new Self( output.GetPointer() );
       }
 
-    virtual itk::DataObject* GetDataBase( void ) { return this->m_Image.GetPointer(); }
-    virtual const itk::DataObject* GetDataBase( void ) const { return this->m_Image.GetPointer(); }
+    virtual itk::DataObject* GetDataBase( ) { return this->m_Image.GetPointer(); }
+    virtual const itk::DataObject* GetDataBase( ) const { return this->m_Image.GetPointer(); }
 
 
-    PixelIDValueEnum GetPixelID(void) const noexcept
+    PixelIDValueEnum GetPixelID() const noexcept
       {
         // The constructor ensures that we have a valid image
         // this maps the Image's pixel type to the array index
         return static_cast<PixelIDValueEnum>(ImageTypeToPixelIDValue<ImageType>::Result);
       }
 
-    virtual unsigned int GetDimension( void ) const
+    virtual unsigned int GetDimension( ) const
       {
         return ImageType::ImageDimension;
       }
 
 
-    virtual unsigned int GetNumberOfComponentsPerPixel( void ) const { return this->GetNumberOfComponentsPerPixel<TImageType>(); }
+    virtual unsigned int GetNumberOfComponentsPerPixel( ) const { return this->GetNumberOfComponentsPerPixel<TImageType>(); }
 
     template <typename UImageType>
     typename std::enable_if<!IsVector<UImageType>::Value, unsigned int>::type
@@ -156,7 +156,7 @@ namespace itk
 
 
     // Get Origin
-    virtual std::vector<double> GetOrigin( void ) const
+    virtual std::vector<double> GetOrigin( ) const
       {
         return sitkITKVectorToSTL<double>( this->m_Image->GetOrigin() );
       }
@@ -168,7 +168,7 @@ namespace itk
       }
 
     // Get Spacing
-    virtual std::vector<double> GetSpacing( void ) const
+    virtual std::vector<double> GetSpacing( ) const
       {
         return sitkITKVectorToSTL<double>( this->m_Image->GetSpacing() );
       }
@@ -181,7 +181,7 @@ namespace itk
 
 
     // Get Direction
-    virtual std::vector< double > GetDirection( void ) const
+    virtual std::vector< double > GetDirection( ) const
       {
       return sitkITKDirectionToSTL( this->m_Image->GetDirection() );
       }
@@ -275,7 +275,7 @@ namespace itk
         return largestRegion.GetSize(dimension);
       }
 
-    virtual std::vector<unsigned int> GetSize( void ) const
+    virtual std::vector<unsigned int> GetSize( ) const
       {
         typename ImageType::RegionType largestRegion = this->m_Image->GetLargestPossibleRegion();
         std::vector<unsigned int> size( ImageType::ImageDimension );
@@ -283,12 +283,12 @@ namespace itk
         return sitkITKVectorToSTL<unsigned int>( largestRegion.GetSize() );
       }
 
-    virtual uint64_t GetNumberOfPixels( void ) const
+    virtual uint64_t GetNumberOfPixels( ) const
       {
         return this->m_Image->GetLargestPossibleRegion().GetNumberOfPixels();
       }
 
-    std::string ToString( void ) const
+    std::string ToString( ) const
       {
         std::ostringstream out;
         this->m_Image->Print ( out );

--- a/Code/Common/src/sitkPimpleTransform.hxx
+++ b/Code/Common/src/sitkPimpleTransform.hxx
@@ -58,15 +58,15 @@ namespace simple
 class SITKCommon_HIDDEN PimpleTransformBase
 {
 public:
-  virtual ~PimpleTransformBase( void ) {};
+  virtual ~PimpleTransformBase( ) {};
 
   // Get Access to the internal ITK transform class
-  virtual TransformBase * GetTransformBase( void ) = 0;
-  virtual const TransformBase * GetTransformBase( void ) const = 0;
+  virtual TransformBase * GetTransformBase( ) = 0;
+  virtual const TransformBase * GetTransformBase( ) const = 0;
 
   // general methods to get information about the internal class
-  virtual unsigned int GetInputDimension( void ) const = 0;
-  virtual unsigned int GetOutputDimension( void ) const = 0;
+  virtual unsigned int GetInputDimension( ) const = 0;
+  virtual unsigned int GetOutputDimension( ) const = 0;
 
   // Set the fixed parameter for the transform, converting from the
   // simpleITK std::vector to the ITK's array.
@@ -90,18 +90,18 @@ public:
     }
 
   // Get the fixed parameters form the transform
-  std::vector< double >  GetFixedParameters( void ) const
+  std::vector< double >  GetFixedParameters( ) const
     {
       const itk::TransformBase::ParametersType &p = this->GetTransformBase()->GetFixedParameters();
       return std::vector< double >( p.begin(), p.end() );
     }
 
-  unsigned int GetNumberOfFixedParameters( void ) const
+  unsigned int GetNumberOfFixedParameters( ) const
   {
     return this->GetTransformBase()->GetFixedParameters().GetSize();
   }
 
-  unsigned int GetNumberOfParameters( void ) const
+  unsigned int GetNumberOfParameters( ) const
   {
     return this->GetTransformBase()->GetNumberOfParameters();
   }
@@ -125,15 +125,15 @@ public:
       p.SetData( const_cast<double*>(&inParams[0]), numberOfParameters, false );
       this->GetTransformBase()->SetParameters( p );
     }
-  std::vector< double > GetParameters( void ) const
+  std::vector< double > GetParameters( ) const
     {
       const itk::TransformBase::ParametersType &p = this->GetTransformBase()->GetParameters();
       return std::vector< double >( p.begin(), p.end() );
     }
 
 
-  virtual PimpleTransformBase *ShallowCopy( void ) const = 0;
-  virtual PimpleTransformBase *DeepCopy( void ) const = 0;
+  virtual PimpleTransformBase *ShallowCopy( ) const = 0;
+  virtual PimpleTransformBase *DeepCopy( ) const = 0;
 
   virtual int GetReferenceCount( ) const = 0;
 
@@ -154,7 +154,7 @@ public:
     }
 
 
-  std::string ToString( void ) const
+  std::string ToString( ) const
     {
       std::ostringstream out;
       this->GetTransformBase()->Print ( out, 1 );
@@ -216,19 +216,19 @@ public:
       m_Transform = s.m_Transform;
     }
 
-  virtual TransformBase * GetTransformBase( void ) { return this->m_Transform.GetPointer(); }
-  virtual const TransformBase * GetTransformBase( void ) const { return this->m_Transform.GetPointer(); }
+  virtual TransformBase * GetTransformBase( ) { return this->m_Transform.GetPointer(); }
+  virtual const TransformBase * GetTransformBase( ) const { return this->m_Transform.GetPointer(); }
 
-  virtual unsigned int GetInputDimension( void ) const { return InputDimension; }
-  virtual unsigned int GetOutputDimension( void ) const { return OutputDimension; }
+  virtual unsigned int GetInputDimension( ) const { return InputDimension; }
+  virtual unsigned int GetOutputDimension( ) const { return OutputDimension; }
 
 
-  virtual PimpleTransformBase *ShallowCopy( void ) const
+  virtual PimpleTransformBase *ShallowCopy( ) const
     {
       return new Self( this->m_Transform.GetPointer() );
     }
 
-  virtual PimpleTransformBase *DeepCopy( void ) const
+  virtual PimpleTransformBase *DeepCopy( ) const
     {
       PimpleTransformBase *copy( new Self( this->m_Transform->Clone() ) );
       return copy;

--- a/Code/Common/src/sitkTransform.cxx
+++ b/Code/Common/src/sitkTransform.cxx
@@ -90,7 +90,7 @@ public:
 };
 
 template<unsigned int Dimension>
-bool RegisterMoreTransforms(void)
+bool RegisterMoreTransforms()
 {
   typedef itk::MatrixOffsetTransformBase<double, Dimension, Dimension> MatrixOffsetTransformType;
   itk::TransformFactory<MatrixOffsetTransformType>::RegisterTransform();
@@ -282,7 +282,7 @@ void Transform::InternalBSplineInitialization( Image & inImage )
     Self::SetPimpleTransform( new PimpleTransform< DisplacementTransformType >(itkDisplacement.GetPointer()) );
   }
 
-void Transform::MakeUnique( void )
+void Transform::MakeUnique( )
 {
   if ( this->m_PimpleTransform->GetReferenceCount() > 1 )
     {
@@ -420,19 +420,19 @@ void Transform::SetPimpleTransform( PimpleTransformBase *pimpleTransform )
   template void SITKCommon_EXPORT Transform::InternalInitialization<2>( TransformEnum, itk::TransformBase * );
   template void SITKCommon_EXPORT Transform::InternalInitialization<3>( TransformEnum, itk::TransformBase * );
 
-  itk::TransformBase* Transform::GetITKBase ( void )
+  itk::TransformBase* Transform::GetITKBase ( )
   {
     assert( m_PimpleTransform );
     return this->m_PimpleTransform->GetTransformBase();
   }
 
-  const itk::TransformBase* Transform::GetITKBase ( void ) const
+  const itk::TransformBase* Transform::GetITKBase ( ) const
   {
     assert( m_PimpleTransform );
     return this->m_PimpleTransform->GetTransformBase();
   }
 
-  unsigned int  Transform::GetDimension( void ) const
+  unsigned int  Transform::GetDimension( ) const
   {
     assert( m_PimpleTransform );
     return this->m_PimpleTransform->GetInputDimension();
@@ -445,13 +445,13 @@ void Transform::SetPimpleTransform( PimpleTransformBase *pimpleTransform )
     this->m_PimpleTransform->SetParameters( parameters );
   }
 
-  std::vector<double> Transform::GetParameters( void ) const
+  std::vector<double> Transform::GetParameters( ) const
   {
     assert( m_PimpleTransform );
     return this->m_PimpleTransform->GetParameters();
   }
 
-  unsigned int Transform::GetNumberOfParameters( void ) const
+  unsigned int Transform::GetNumberOfParameters( ) const
   {
     assert( m_PimpleTransform );
     return this->m_PimpleTransform->GetNumberOfParameters();
@@ -464,13 +464,13 @@ void Transform::SetPimpleTransform( PimpleTransformBase *pimpleTransform )
     this->m_PimpleTransform->SetFixedParameters( parameters );
   }
 
-  std::vector<double> Transform::GetFixedParameters( void ) const
+  std::vector<double> Transform::GetFixedParameters( ) const
   {
     assert( m_PimpleTransform );
     return this->m_PimpleTransform->GetFixedParameters();
   }
 
-  unsigned int Transform::GetNumberOfFixedParameters( void ) const
+  unsigned int Transform::GetNumberOfFixedParameters( ) const
   {
     assert( m_PimpleTransform );
     return this->m_PimpleTransform->GetNumberOfFixedParameters();
@@ -555,7 +555,7 @@ std::vector< double > Transform::TransformVector( const std::vector< double > &v
   }
 
 
-  std::string Transform::ToString( void ) const
+  std::string Transform::ToString( ) const
   {
     assert( m_PimpleTransform );
 
@@ -565,7 +565,7 @@ std::vector< double > Transform::TransformVector( const std::vector< double > &v
     return std::string("itk::simple::")+this->GetName() + '\n'+this->m_PimpleTransform->ToString();
   }
 
-  std::string Transform::GetName( void ) const
+  std::string Transform::GetName( ) const
   {
     return "Transform";
   }

--- a/Code/IO/include/sitkImageFileReader.h
+++ b/Code/IO/include/sitkImageFileReader.h
@@ -90,7 +90,7 @@ namespace itk {
        * certain dimension or type, the meta-information can still be
        * read.
        */
-      void ReadImageInformation(void);
+      void ReadImageInformation();
 
       /** \brief Image information methods updated via ReadImageInformation
        *
@@ -106,14 +106,14 @@ namespace itk {
        * as a SimpleITK Image.
        * @{
        */
-      PixelIDValueEnum GetPixelID( void ) const;
-      PixelIDValueType GetPixelIDValue( void ) const;
-      unsigned int GetDimension( void ) const;
-      unsigned int GetNumberOfComponents( void ) const;
-      const std::vector<double> &GetOrigin( void ) const;
-      const std::vector<double> &GetSpacing( void ) const;
+      PixelIDValueEnum GetPixelID( ) const;
+      PixelIDValueType GetPixelIDValue( ) const;
+      unsigned int GetDimension( ) const;
+      unsigned int GetNumberOfComponents( ) const;
+      const std::vector<double> &GetOrigin( ) const;
+      const std::vector<double> &GetSpacing( ) const;
       const std::vector<double> &GetDirection() const;
-      const std::vector<uint64_t> &GetSize( void ) const;
+      const std::vector<uint64_t> &GetSize( ) const;
       /* @} */
 
       /** \brief Get the meta-data dictionary keys
@@ -125,7 +125,7 @@ namespace itk {
        * file's meta-data dictionary. Iterate through with these keys
        * to get the values.
        **/
-      std::vector<std::string> GetMetaDataKeys( void ) const;
+      std::vector<std::string> GetMetaDataKeys( ) const;
 
       /** \brief Query a meta-data dictionary for the existence of a key.
        **/

--- a/Code/IO/include/sitkImageFileWriter.h
+++ b/Code/IO/include/sitkImageFileWriter.h
@@ -76,10 +76,10 @@ class SmartPointer;
        * only a request as not all file formats support compression.
        * @{ */
       SITK_RETURN_SELF_TYPE_HEADER SetUseCompression( bool UseCompression );
-      bool GetUseCompression( void ) const;
+      bool GetUseCompression( ) const;
 
-      SITK_RETURN_SELF_TYPE_HEADER UseCompressionOn( void ) { return this->SetUseCompression(true); }
-      SITK_RETURN_SELF_TYPE_HEADER UseCompressionOff( void ) { return this->SetUseCompression(false); }
+      SITK_RETURN_SELF_TYPE_HEADER UseCompressionOn( ) { return this->SetUseCompression(true); }
+      SITK_RETURN_SELF_TYPE_HEADER UseCompressionOff( ) { return this->SetUseCompression(false); }
       /** @} */
 
 
@@ -90,7 +90,7 @@ class SmartPointer;
        *  for lossless zip or LZW like compression algorithms.  Please see the specific itk::ImageIO for details.
        * @{ */
       SITK_RETURN_SELF_TYPE_HEADER SetCompressionLevel(int);
-      int GetCompressionLevel(void) const;
+      int GetCompressionLevel() const;
       /** @} */
 
       /** \brief A compression algorithm hint
@@ -100,7 +100,7 @@ class SmartPointer;
        * itk::ImageIO for details.
        * @{ */
       SITK_RETURN_SELF_TYPE_HEADER SetCompressor(const std::string &);
-      std::string GetCompressor(void);
+      std::string GetCompressor();
       /** @} */
 
       /** \brief Set/Get name of ImageIO to use
@@ -116,7 +116,7 @@ class SmartPointer;
        * @{
        */
       virtual SITK_RETURN_SELF_TYPE_HEADER SetImageIO(const std::string &imageio);
-      virtual std::string GetImageIO( void ) const;
+      virtual std::string GetImageIO( ) const;
       /* @} */
 
 
@@ -129,10 +129,10 @@ class SmartPointer;
        * to create new study/series/frame of reference values.
        * @{ */
       SITK_RETURN_SELF_TYPE_HEADER SetKeepOriginalImageUID( bool KeepOriginalImageUID );
-      bool GetKeepOriginalImageUID( void ) const;
+      bool GetKeepOriginalImageUID( ) const;
 
-      SITK_RETURN_SELF_TYPE_HEADER KeepOriginalImageUIDOn( void ) { return this->SetKeepOriginalImageUID(true); }
-      SITK_RETURN_SELF_TYPE_HEADER KeepOriginalImageUIDOff( void ) { return this->SetKeepOriginalImageUID(false); }
+      SITK_RETURN_SELF_TYPE_HEADER KeepOriginalImageUIDOn( ) { return this->SetKeepOriginalImageUID(true); }
+      SITK_RETURN_SELF_TYPE_HEADER KeepOriginalImageUIDOff( ) { return this->SetKeepOriginalImageUID(false); }
       /** @} */
 
       SITK_RETURN_SELF_TYPE_HEADER SetFileName ( const std::string &fileName );

--- a/Code/IO/include/sitkImageReaderBase.h
+++ b/Code/IO/include/sitkImageReaderBase.h
@@ -56,7 +56,7 @@ class SmartPointer;
        * @{
        */
       SITK_RETURN_SELF_TYPE_HEADER SetOutputPixelType( PixelIDValueEnum pixelID );
-      PixelIDValueEnum GetOutputPixelType( void ) const;
+      PixelIDValueEnum GetOutputPixelType( ) const;
       /* @} */
 
       virtual Image Execute() = 0;
@@ -93,7 +93,7 @@ class SmartPointer;
        * @{
        */
       virtual SITK_RETURN_SELF_TYPE_HEADER SetImageIO(const std::string &imageio);
-      virtual std::string GetImageIO( void ) const;
+      virtual std::string GetImageIO( ) const;
       /* @} */
 
 

--- a/Code/IO/include/sitkImageSeriesWriter.h
+++ b/Code/IO/include/sitkImageSeriesWriter.h
@@ -76,7 +76,7 @@ class ImageIOBase;
        * @{
        */
       virtual SITK_RETURN_SELF_TYPE_HEADER SetImageIO(const std::string &imageio);
-      virtual std::string GetImageIO( void ) const;
+      virtual std::string GetImageIO( ) const;
       /* @} */
 
       /** return user readable name of the filter */
@@ -89,10 +89,10 @@ class ImageIOBase;
        * only a request as not all file formatts support compression.
        * @{ */
       SITK_RETURN_SELF_TYPE_HEADER SetUseCompression( bool UseCompression );
-      bool GetUseCompression( void ) const;
+      bool GetUseCompression( ) const;
 
-      SITK_RETURN_SELF_TYPE_HEADER UseCompressionOn( void ) { return this->SetUseCompression(true); }
-      SITK_RETURN_SELF_TYPE_HEADER UseCompressionOff( void ) { return this->SetUseCompression(false); }
+      SITK_RETURN_SELF_TYPE_HEADER UseCompressionOn( ) { return this->SetUseCompression(true); }
+      SITK_RETURN_SELF_TYPE_HEADER UseCompressionOff( ) { return this->SetUseCompression(false); }
       /** @} */
 
       /** \brief A hint for the amount of compression to be applied during writing.
@@ -102,7 +102,7 @@ class ImageIOBase;
        *  for lossless zip or LZW like compression algorithms.  Please see the specific itk::ImageIO for details.
        * @{ */
       SITK_RETURN_SELF_TYPE_HEADER SetCompressionLevel(int);
-      int GetCompressionLevel(void) const;
+      int GetCompressionLevel() const;
       /** @} */
 
       /** \brief A compression algorithm hint
@@ -112,7 +112,7 @@ class ImageIOBase;
        * itk::ImageIO for details.
        * @{ */
       SITK_RETURN_SELF_TYPE_HEADER SetCompressor(const std::string &);
-      std::string GetCompressor(void);
+      std::string GetCompressor();
       /** @} */
 
       /** The filenames to where the image slices are written.

--- a/Code/IO/include/sitkImportImageFilter.h
+++ b/Code/IO/include/sitkImportImageFilter.h
@@ -87,7 +87,7 @@ namespace itk {
     protected:
 
       // Internal method called by the template dispatch system
-      template <class TImageType> Image ExecuteInternal ( void );
+      template <class TImageType> Image ExecuteInternal ( );
 
       // If the output image type is a VectorImage then the number of
       // components per pixel needs to be set, otherwise the method
@@ -102,7 +102,7 @@ namespace itk {
     private:
 
       // function pointer type
-      typedef Image (Self::*MemberFunctionType)( void );
+      typedef Image (Self::*MemberFunctionType)( );
 
       // friend to get access to executeInternal member
       friend struct detail::MemberFunctionAddressor<MemberFunctionType>;

--- a/Code/IO/src/sitkImageFileReader.cxx
+++ b/Code/IO/src/sitkImageFileReader.cxx
@@ -178,42 +178,42 @@ namespace itk {
 
     PixelIDValueEnum
     ImageFileReader
-    ::GetPixelID( void ) const
+    ::GetPixelID( ) const
     {
       return this->m_PixelType;
     }
 
     PixelIDValueType
     ImageFileReader
-    ::GetPixelIDValue( void ) const
+    ::GetPixelIDValue( ) const
     {
       return this->m_PixelType;
     }
 
     unsigned int
     ImageFileReader
-    ::GetDimension( void ) const
+    ::GetDimension( ) const
     {
       return this->m_Dimension;
     }
 
     unsigned int
     ImageFileReader
-    ::GetNumberOfComponents( void ) const
+    ::GetNumberOfComponents( ) const
     {
       return this->m_NumberOfComponents;
     }
 
     const std::vector<double> &
     ImageFileReader
-    ::GetOrigin( void ) const
+    ::GetOrigin( ) const
     {
       return this->m_Origin;
     }
 
     const std::vector<double> &
     ImageFileReader
-    ::GetSpacing( void ) const
+    ::GetSpacing( ) const
     {
       return this->m_Spacing;
     }
@@ -227,14 +227,14 @@ namespace itk {
 
     const std::vector<uint64_t> &
     ImageFileReader
-    ::GetSize( void ) const
+    ::GetSize( ) const
     {
       return this->m_Size;
     }
 
     void
     ImageFileReader
-    ::ReadImageInformation( void )
+    ::ReadImageInformation( )
     {
       itk::ImageIOBase::Pointer imageio = this->GetImageIOBase( this->m_FileName );
       this->UpdateImageInformationFromImageIO(imageio);
@@ -244,7 +244,7 @@ namespace itk {
 
     std::vector<std::string>
     ImageFileReader
-    ::GetMetaDataKeys( void ) const
+    ::GetMetaDataKeys( ) const
     {
       return this->m_pfGetMetaDataKeys();
     }

--- a/Code/IO/src/sitkImageFileWriter.cxx
+++ b/Code/IO/src/sitkImageFileWriter.cxx
@@ -102,7 +102,7 @@ ImageFileWriter::SetUseCompression( bool UseCompression )
   return *this;
 }
 
-bool ImageFileWriter::GetUseCompression( void ) const
+bool ImageFileWriter::GetUseCompression( ) const
 {
   return this->m_UseCompression;
 }
@@ -115,7 +115,7 @@ ImageFileWriter::SetCompressionLevel(int CompressionLevel)
 }
 
 int
-ImageFileWriter::GetCompressionLevel(void) const
+ImageFileWriter::GetCompressionLevel() const
 {
   return m_CompressionLevel;
 }
@@ -128,7 +128,7 @@ ImageFileWriter::SetCompressor(const std::string &Compressor)
 }
 
 std::string
-ImageFileWriter::GetCompressor(void)
+ImageFileWriter::GetCompressor()
 {
   return m_Compressor;
 }
@@ -141,7 +141,7 @@ ImageFileWriter::SetKeepOriginalImageUID( bool KeepOriginalImageUID )
   return *this;
 }
 
-bool ImageFileWriter::GetKeepOriginalImageUID( void ) const
+bool ImageFileWriter::GetKeepOriginalImageUID( ) const
 {
   return this->m_KeepOriginalImageUID;
 }
@@ -185,7 +185,7 @@ ImageFileWriter
 
 std::string
 ImageFileWriter
-::GetImageIO(void) const
+::GetImageIO() const
 {
   return this->m_ImageIOName;
 }

--- a/Code/IO/src/sitkImageReaderBase.cxx
+++ b/Code/IO/src/sitkImageReaderBase.cxx
@@ -132,7 +132,7 @@ ImageReaderBase
 
 PixelIDValueEnum
 ImageReaderBase
-::GetOutputPixelType( void ) const
+::GetOutputPixelType( ) const
 {
   return this->m_OutputPixelType;
 }
@@ -178,7 +178,7 @@ ImageReaderBase
 
 std::string
 ImageReaderBase
-::GetImageIO(void) const
+::GetImageIO() const
 {
   return this->m_ImageIOName;
 }

--- a/Code/IO/src/sitkImageSeriesWriter.cxx
+++ b/Code/IO/src/sitkImageSeriesWriter.cxx
@@ -111,7 +111,7 @@ namespace itk {
 
   std::string
   ImageSeriesWriter
-  ::GetImageIO(void) const
+  ::GetImageIO() const
   {
     return this->m_ImageIOName;
   }
@@ -146,7 +146,7 @@ namespace itk {
     return *this;
   }
 
-  bool ImageSeriesWriter::GetUseCompression( void ) const
+  bool ImageSeriesWriter::GetUseCompression( ) const
   {
     return this->m_UseCompression;
   }
@@ -159,7 +159,7 @@ namespace itk {
   }
 
   int
-  ImageSeriesWriter::GetCompressionLevel(void) const
+  ImageSeriesWriter::GetCompressionLevel() const
   {
     return m_CompressionLevel;
   }
@@ -172,7 +172,7 @@ namespace itk {
   }
 
   std::string
-  ImageSeriesWriter::GetCompressor(void)
+  ImageSeriesWriter::GetCompressor()
   {
     return m_Compressor;
   }

--- a/Code/Registration/include/sitkImageRegistrationMethod.h
+++ b/Code/Registration/include/sitkImageRegistrationMethod.h
@@ -689,7 +689,7 @@ namespace simple
       typedef typename ::detail::FunctionTraits<TMemberFunctionPointer>::ClassType ObjectType;
 
       template< typename TImageType >
-      TMemberFunctionPointer operator() ( void ) const
+      TMemberFunctionPointer operator() ( ) const
         {
           return &ObjectType::template EvaluateInternal< TImageType >;
         }

--- a/Testing/Unit/sitkCommonTests.cxx
+++ b/Testing/Unit/sitkCommonTests.cxx
@@ -622,7 +622,7 @@ struct MemberFunctionCommandTest
 };
 
 int gValue = 0;
-void functionCommand(void)
+void functionCommand()
 {
   gValue = 98;
 }

--- a/Testing/Unit/sitkExceptionsTests.cxx
+++ b/Testing/Unit/sitkExceptionsTests.cxx
@@ -26,7 +26,7 @@ class sitkExceptionsTest
 {
 public:
 
-  void ThrowsitkException( void )
+  void ThrowsitkException( )
   {
     sitkExceptionMacro( << DESCRIPTION );
   }

--- a/Testing/Unit/sitkTypeListsTests.cxx
+++ b/Testing/Unit/sitkTypeListsTests.cxx
@@ -25,28 +25,28 @@ public:
   TypeListTest() {};
   struct CountPredicate
   {
-    CountPredicate( void ) : count(0) {}
+    CountPredicate( ) : count(0) {}
 
     template<class TType>
-    void operator()( void )
+    void operator()( )
       {
         ++count;
       }
 
     template<class TType1, class TType2>
-    void operator()( void )
+    void operator()( )
       {
         ++count;
       }
 
     template<class TType>
-    void operator()( void ) const
+    void operator()( ) const
       {
         ++count;
       }
 
     template<class TType1, class TType2>
-    void operator()( void ) const
+    void operator()( ) const
       {
         ++count;
         std::cout << typeid(TType1).name() << " " << typeid( TType2 ).name() << std::endl;


### PR DESCRIPTION
The following command was run to generate this change:

run-clang-tidy -p /scratch/blowekamp/SimpleITK-ITK
  -extra-arg=-D__clang__ -checks=-*,modernize-redundant-void-arg
  -header-filter=.* -fix