### PR TITLE
Moderize to use = default for constructors and destructors

### DIFF
--- a/Code/BasicFilters/src/sitkBSplineTransformInitializerFilter.cxx
+++ b/Code/BasicFilters/src/sitkBSplineTransformInitializerFilter.cxx
@@ -58,10 +58,7 @@ BSplineTransformInitializerFilter::BSplineTransformInitializerFilter ()
 //
 // Destructor
 //
-BSplineTransformInitializerFilter::~BSplineTransformInitializerFilter ()
-{
-
-}
+BSplineTransformInitializerFilter::~BSplineTransformInitializerFilter () = default;
 
 
 //

--- a/Code/BasicFilters/src/sitkCastImageFilter.cxx
+++ b/Code/BasicFilters/src/sitkCastImageFilter.cxx
@@ -27,9 +27,7 @@ namespace simple
 //----------------------------------------------------------------------------
 
 
-CastImageFilter::~CastImageFilter()
-{
-}
+CastImageFilter::~CastImageFilter() = default;
 
 //
 // Default constructor that initializes parameters

--- a/Code/BasicFilters/src/sitkCenteredTransformInitializerFilter.cxx
+++ b/Code/BasicFilters/src/sitkCenteredTransformInitializerFilter.cxx
@@ -55,10 +55,7 @@ CenteredTransformInitializerFilter::CenteredTransformInitializerFilter ()
 //
 // Destructor
 //
-CenteredTransformInitializerFilter::~CenteredTransformInitializerFilter ()
-{
-
-}
+CenteredTransformInitializerFilter::~CenteredTransformInitializerFilter () = default;
 
 //
 // ToString

--- a/Code/BasicFilters/src/sitkCenteredVersorTransformInitializerFilter.cxx
+++ b/Code/BasicFilters/src/sitkCenteredVersorTransformInitializerFilter.cxx
@@ -55,10 +55,7 @@ CenteredVersorTransformInitializerFilter::CenteredVersorTransformInitializerFilt
 //
 // Destructor
 //
-CenteredVersorTransformInitializerFilter::~CenteredVersorTransformInitializerFilter ()
-{
-
-}
+CenteredVersorTransformInitializerFilter::~CenteredVersorTransformInitializerFilter () = default;
 
 
 //

--- a/Code/BasicFilters/src/sitkHashImageFilter.cxx
+++ b/Code/BasicFilters/src/sitkHashImageFilter.cxx
@@ -30,8 +30,7 @@ namespace itk {
   namespace simple {
 
     HashImageFilter::~HashImageFilter ()
-    {
-    }
+    = default;
 
     HashImageFilter::HashImageFilter () {
       this->m_HashFunction = SHA1;

--- a/Code/BasicFilters/src/sitkLandmarkBasedTransformInitializerFilter.cxx
+++ b/Code/BasicFilters/src/sitkLandmarkBasedTransformInitializerFilter.cxx
@@ -59,10 +59,7 @@ LandmarkBasedTransformInitializerFilter::LandmarkBasedTransformInitializerFilter
 //
 // Destructor
 //
-LandmarkBasedTransformInitializerFilter::~LandmarkBasedTransformInitializerFilter ()
-{
-
-}
+LandmarkBasedTransformInitializerFilter::~LandmarkBasedTransformInitializerFilter () = default;
 
 
 //

--- a/Code/Common/src/sitkAffineTransform.cxx
+++ b/Code/Common/src/sitkAffineTransform.cxx
@@ -25,9 +25,7 @@ namespace itk
 namespace simple
 {
 
-AffineTransform::~AffineTransform()
-{
-}
+AffineTransform::~AffineTransform() = default;
 
 // construct identity
 AffineTransform::AffineTransform(unsigned int dimensions)

--- a/Code/Common/src/sitkBSplineTransform.cxx
+++ b/Code/Common/src/sitkBSplineTransform.cxx
@@ -101,9 +101,7 @@ void SetCoefficientImages(TBSplineTransform* bspline, const std::vector<Image> &
 }
 
 
-BSplineTransform::~BSplineTransform()
-{
-}
+BSplineTransform::~BSplineTransform() = default;
 
 // construct identity
 BSplineTransform::BSplineTransform(unsigned int dimensions, unsigned int order)

--- a/Code/Common/src/sitkDisplacementFieldTransform.cxx
+++ b/Code/Common/src/sitkDisplacementFieldTransform.cxx
@@ -134,9 +134,7 @@ void InternalSetInterpolator( TDisplacementFieldTransform *itkDisplacementTx, In
 
 }
 
-DisplacementFieldTransform::~DisplacementFieldTransform()
-{
-}
+DisplacementFieldTransform::~DisplacementFieldTransform() = default;
 
 // construct identity
 DisplacementFieldTransform::DisplacementFieldTransform(unsigned int dimensions)

--- a/Code/Common/src/sitkEuler2DTransform.cxx
+++ b/Code/Common/src/sitkEuler2DTransform.cxx
@@ -25,9 +25,7 @@ namespace itk
 namespace simple
 {
 
-Euler2DTransform::~Euler2DTransform()
-{
-}
+Euler2DTransform::~Euler2DTransform() = default;
 
 // construct identity
 Euler2DTransform::Euler2DTransform()

--- a/Code/Common/src/sitkEuler3DTransform.cxx
+++ b/Code/Common/src/sitkEuler3DTransform.cxx
@@ -25,9 +25,7 @@ namespace itk
 namespace simple
 {
 
-Euler3DTransform::~Euler3DTransform()
-{
-}
+Euler3DTransform::~Euler3DTransform() = default;
 
 // construct identity
 Euler3DTransform::Euler3DTransform()

--- a/Code/Common/src/sitkFunctionCommand.cxx
+++ b/Code/Common/src/sitkFunctionCommand.cxx
@@ -23,9 +23,7 @@ namespace itk
 namespace simple
 {
 
-FunctionCommand::~FunctionCommand( )
-{
-}
+FunctionCommand::~FunctionCommand( ) = default;
 
 FunctionCommand::FunctionCommand( )
 {

--- a/Code/Common/src/sitkPimpleImageBase.h
+++ b/Code/Common/src/sitkPimpleImageBase.h
@@ -40,7 +40,8 @@ namespace itk
   class SITKCommon_HIDDEN PimpleImageBase
   {
   public:
-    virtual ~PimpleImageBase( ) { };
+
+    virtual ~PimpleImageBase( ) = default;
 
     virtual PixelIDValueEnum GetPixelID() const = 0;
     virtual unsigned int GetDimension( ) const  = 0;

--- a/Code/Common/src/sitkPimpleTransform.hxx
+++ b/Code/Common/src/sitkPimpleTransform.hxx
@@ -58,7 +58,8 @@ namespace simple
 class SITKCommon_HIDDEN PimpleTransformBase
 {
 public:
-  virtual ~PimpleTransformBase( ) {};
+
+  virtual ~PimpleTransformBase( ) = default;;
 
   // Get Access to the internal ITK transform class
   virtual TransformBase * GetTransformBase( ) = 0;

--- a/Code/Common/src/sitkProcessObject.cxx
+++ b/Code/Common/src/sitkProcessObject.cxx
@@ -91,7 +91,7 @@ public:
 protected:
   itk::simple::Command *                    m_That;
   SimpleAdaptorCommand():m_That(0) {}
-  virtual ~SimpleAdaptorCommand() {}
+  virtual ~SimpleAdaptorCommand() = default;
 };
 
 } // end anonymous namespace

--- a/Code/Common/src/sitkScaleSkewVersor3DTransform.cxx
+++ b/Code/Common/src/sitkScaleSkewVersor3DTransform.cxx
@@ -25,9 +25,7 @@ namespace itk
 namespace simple
 {
 
-ScaleSkewVersor3DTransform::~ScaleSkewVersor3DTransform()
-{
-}
+ScaleSkewVersor3DTransform::~ScaleSkewVersor3DTransform() = default;
 
 // construct identity
 ScaleSkewVersor3DTransform::ScaleSkewVersor3DTransform()

--- a/Code/Common/src/sitkScaleTransform.cxx
+++ b/Code/Common/src/sitkScaleTransform.cxx
@@ -24,9 +24,7 @@ namespace itk
 namespace simple
 {
 
-ScaleTransform::~ScaleTransform()
-{
-}
+ScaleTransform::~ScaleTransform() = default;
 
 ScaleTransform::ScaleTransform(unsigned int dimensions,
                                            const std::vector<double> &scale)

--- a/Code/Common/src/sitkScaleVersor3DTransform.cxx
+++ b/Code/Common/src/sitkScaleVersor3DTransform.cxx
@@ -26,9 +26,7 @@ namespace itk
 namespace simple
 {
 
-ScaleVersor3DTransform::~ScaleVersor3DTransform()
-{
-}
+ScaleVersor3DTransform::~ScaleVersor3DTransform() = default;
 
 // construct identity
 ScaleVersor3DTransform::ScaleVersor3DTransform()

--- a/Code/Common/src/sitkSimilarity2DTransform.cxx
+++ b/Code/Common/src/sitkSimilarity2DTransform.cxx
@@ -25,9 +25,7 @@ namespace itk
 namespace simple
 {
 
-Similarity2DTransform::~Similarity2DTransform()
-{
-}
+Similarity2DTransform::~Similarity2DTransform() = default;
 
 // construct identity
 Similarity2DTransform::Similarity2DTransform()

--- a/Code/Common/src/sitkSimilarity3DTransform.cxx
+++ b/Code/Common/src/sitkSimilarity3DTransform.cxx
@@ -25,9 +25,7 @@ namespace itk
 namespace simple
 {
 
-Similarity3DTransform::~Similarity3DTransform()
-{
-}
+Similarity3DTransform::~Similarity3DTransform() = default;
 
 // construct identity
 Similarity3DTransform::Similarity3DTransform()

--- a/Code/Common/src/sitkTranslationTransform.cxx
+++ b/Code/Common/src/sitkTranslationTransform.cxx
@@ -25,9 +25,7 @@ namespace itk
 namespace simple
 {
 
-TranslationTransform::~TranslationTransform()
-{
-}
+TranslationTransform::~TranslationTransform() = default;
 
 TranslationTransform::TranslationTransform(unsigned int dimensions,
                                            const std::vector<double> &offset)

--- a/Code/Common/src/sitkVersorRigid3DTransform.cxx
+++ b/Code/Common/src/sitkVersorRigid3DTransform.cxx
@@ -25,9 +25,7 @@ namespace itk
 namespace simple
 {
 
-VersorRigid3DTransform::~VersorRigid3DTransform()
-{
-}
+VersorRigid3DTransform::~VersorRigid3DTransform() = default;
 
 // construct identity
 VersorRigid3DTransform::VersorRigid3DTransform()

--- a/Code/Common/src/sitkVersorTransform.cxx
+++ b/Code/Common/src/sitkVersorTransform.cxx
@@ -25,9 +25,7 @@ namespace itk
 namespace simple
 {
 
-VersorTransform::~VersorTransform()
-{
-}
+VersorTransform::~VersorTransform() = default;
 
 // construct identity
 VersorTransform::VersorTransform()

--- a/Code/IO/src/sitkImageFileReader.cxx
+++ b/Code/IO/src/sitkImageFileReader.cxx
@@ -75,8 +75,7 @@ namespace itk {
 
 
   ImageFileReader::~ImageFileReader()
-  {
-  }
+  = default;
 
   ImageFileReader::ImageFileReader() :
     m_PixelType(sitkUnknown),

--- a/Code/IO/src/sitkImageFileWriter.cxx
+++ b/Code/IO/src/sitkImageFileWriter.cxx
@@ -34,9 +34,7 @@ void WriteImage ( const Image& image, const std::string &inFileName, bool useCom
 }
 
 
-ImageFileWriter::~ImageFileWriter()
-{
-}
+ImageFileWriter::~ImageFileWriter() = default;
 
 ImageFileWriter::ImageFileWriter()
 {

--- a/Code/IO/src/sitkImageReaderBase.cxx
+++ b/Code/IO/src/sitkImageReaderBase.cxx
@@ -40,9 +40,7 @@ namespace itk {
 namespace simple {
 
 ImageReaderBase
-::~ImageReaderBase()
-{
-}
+::~ImageReaderBase() = default;
 
 ImageReaderBase
 ::ImageReaderBase()

--- a/Code/IO/src/sitkImageSeriesWriter.cxx
+++ b/Code/IO/src/sitkImageSeriesWriter.cxx
@@ -39,8 +39,7 @@ namespace itk {
   }
 
   ImageSeriesWriter::~ImageSeriesWriter()
-  {
-  }
+  = default;
 
   ImageSeriesWriter::ImageSeriesWriter()
   {

--- a/Code/IO/src/sitkImportImageFilter.cxx
+++ b/Code/IO/src/sitkImportImageFilter.cxx
@@ -207,9 +207,7 @@ Image ImportAsDouble(
     return import.Execute();
 }
 
-ImportImageFilter::~ImportImageFilter()
-{
-}
+ImportImageFilter::~ImportImageFilter() = default;
 
 ImportImageFilter::ImportImageFilter()
 {

--- a/Code/Registration/src/sitkImageRegistrationMethod.cxx
+++ b/Code/Registration/src/sitkImageRegistrationMethod.cxx
@@ -96,9 +96,7 @@ ImageRegistrationMethod::ImageRegistrationMethod()
 }
 
 
-ImageRegistrationMethod::~ImageRegistrationMethod()
-{
-}
+ImageRegistrationMethod::~ImageRegistrationMethod() = default;
 
 std::string  ImageRegistrationMethod::ToString() const
 {

--- a/Testing/Unit/sitkTypeListsTests.cxx
+++ b/Testing/Unit/sitkTypeListsTests.cxx
@@ -22,7 +22,7 @@ class TypeListTest
   : public ::testing::Test
 {
 public:
-  TypeListTest() {};
+  TypeListTest() = default;;
   struct CountPredicate
   {
     CountPredicate( ) : count(0) {}


### PR DESCRIPTION
The change was generated by:

run-clang-tidy -p /scratch/blowekamp/SimpleITK-ITK
  -extra-arg=-D__clang__  -header-filter=.* -fix
  -checks=-*,modernize-use-equals-default