### PR TITLE
Remove ImageFilter's uint template parameter

### DIFF
--- a/Code/BasicFilters/include/sitkCastImageFilter.h
+++ b/Code/BasicFilters/include/sitkCastImageFilter.h
@@ -39,7 +39,7 @@ namespace simple
  * \sa itk::simple::Cast for the procedural interface
  */
 class SITKBasicFilters_EXPORT CastImageFilter
-  : public ImageFilter<1>
+  : public ImageFilter
 {
 public:
   typedef CastImageFilter      Self;

--- a/Code/BasicFilters/include/sitkImageFilter.h
+++ b/Code/BasicFilters/include/sitkImageFilter.h
@@ -33,7 +33,6 @@ namespace itk {
    * All SimpleITK filters which take one input image should inherit from this
    * class
    */
-  template < unsigned int N>
   class SITKBasicFilters0_EXPORT ImageFilter:
       public ProcessObject
   {

--- a/Code/BasicFilters/include/sitkLandmarkBasedTransformInitializerFilter.h
+++ b/Code/BasicFilters/include/sitkLandmarkBasedTransformInitializerFilter.h
@@ -72,7 +72,7 @@ in ITK" by Kim E.Y., Johnson H., Williams N. available at http://midasjournal.co
 \sa itk::simple::LandmarkBasedTransformInitializerFilter for the procedural interface
 \sa itk::LandmarkBasedTransformInitializer for the Doxygen on the original ITK class.
      */
-    class SITKBasicFilters_EXPORT LandmarkBasedTransformInitializerFilter : public ImageFilter<0> {
+    class SITKBasicFilters_EXPORT LandmarkBasedTransformInitializerFilter : public ImageFilter {
     public:
       typedef LandmarkBasedTransformInitializerFilter Self;
 

--- a/Code/BasicFilters/src/sitkImageFilter.cxx
+++ b/Code/BasicFilters/src/sitkImageFilter.cxx
@@ -69,43 +69,26 @@ namespace
 
 //----------------------------------------------------------------------------
 
-//
-// Default constructor that initializes parameters
-//
-template< unsigned int N >
-ImageFilter< N >::ImageFilter () = default;
-//
-// Default destructor
-//
-template< unsigned int N >
-ImageFilter< N >::~ImageFilter () = default;
+ImageFilter::ImageFilter () = default;
+
+ImageFilter::~ImageFilter () = default;
 
 
 
-template< unsigned int N >
-void ImageFilter< N >::CheckImageMatchingDimension(const Image &image1, const Image& image2, const std::string &image2Name)
+void ImageFilter::CheckImageMatchingDimension(const Image &image1, const Image& image2, const std::string &image2Name)
 {
   return itk::simple::CheckImageMatchingDimension(image1, image2, image2Name, this->GetName());
 }
 
-template< unsigned int N >
-void ImageFilter< N >::CheckImageMatchingPixelType(const Image &image1, const Image& image2, const std::string &image2Name)
+void ImageFilter::CheckImageMatchingPixelType(const Image &image1, const Image& image2, const std::string &image2Name)
 {
   return itk::simple::CheckImageMatchingPixelType(image1, image2, image2Name, this->GetName());
 }
 
-template< unsigned int N >
-void ImageFilter< N >::CheckImageMatchingSize(const Image &image1, const Image& image2, const std::string &image2Name)
+void ImageFilter::CheckImageMatchingSize(const Image &image1, const Image& image2, const std::string &image2Name)
 {
   return itk::simple::CheckImageMatchingSize(image1, image2, image2Name, this->GetName());
 }
-
-template class ImageFilter<0>;
-template class ImageFilter<1>;
-template class ImageFilter<2>;
-template class ImageFilter<3>;
-template class ImageFilter<4>;
-template class ImageFilter<5>;
 
 } // end namespace simple
 } // end namespace itk

--- a/Code/BasicFilters/templates/sitkMultiInputImageFilterTemplate.h.in
+++ b/Code/BasicFilters/templates/sitkMultiInputImageFilterTemplate.h.in
@@ -37,7 +37,7 @@ $(if detaileddescription and (detaileddescription:len() >0) then OUT=[[${detaile
 \sa itk::simple::${name:gsub("ImageFilter$", "")} for the procedural interface
    */
     class SITKBasicFilters_EXPORT ${name}
-      : public ImageFilter<3>
+      : public ImageFilter
     {
     public:
       using Self = ${name};

--- a/ExpandTemplateGenerator/Components/ClassDeclaration.h.in
+++ b/ExpandTemplateGenerator/Components/ClassDeclaration.h.in
@@ -15,7 +15,7 @@ $(if true then
 OUT=OUT..[[ for the Doxygen on the original ITK class.]]
 end)
      */
-    class SITKBasicFilters_EXPORT ${name} : public $(if number_of_inputs then OUT=[[ImageFilter<${number_of_inputs}>]] else OUT=[[ImageFilter<1>]] end) {
+    class SITKBasicFilters_EXPORT ${name} : public $(if number_of_inputs then OUT=[[ImageFilter]] else OUT=[[ImageFilter<1>]] end) {
     public:
       using Self = ${name};
 

--- a/Testing/Unit/sitkBasicFiltersTests.cxx
+++ b/Testing/Unit/sitkBasicFiltersTests.cxx
@@ -299,7 +299,7 @@ TEST(BasicFilters,ImageFilter) {
   namespace sitk = itk::simple;
 
   sitk::CastImageFilter caster;
-  sitk::ImageFilter<1> &filter = caster;
+  sitk::ImageFilter &filter = caster;
 
   filter.DebugOn();
 }

--- a/Wrapping/Common/SimpleITK_Common.i
+++ b/Wrapping/Common/SimpleITK_Common.i
@@ -178,13 +178,6 @@ namespace std
 %include "sitkProcessObject.h"
 %include "sitkImageFilter.h"
 
-%template(ImageFilter_0) itk::simple::ImageFilter<0>;
-%template(ImageFilter_1) itk::simple::ImageFilter<1>;
-%template(ImageFilter_2) itk::simple::ImageFilter<2>;
-%template(ImageFilter_3) itk::simple::ImageFilter<3>;
-%template(ImageFilter_4) itk::simple::ImageFilter<4>;
-%template(ImageFilter_5) itk::simple::ImageFilter<5>;
-
 // IO
 %include "sitkShow.h"
 %include "sitkImageFileWriter.h"

--- a/Wrapping/R/mkNamespace.R
+++ b/Wrapping/R/mkNamespace.R
@@ -66,11 +66,8 @@ manualexclusions <- c("DoubleDoubleMap", "RCommand", "VectorBool", "VectorDouble
                       "VectorInt16", "VectorInt32", "VectorInt64",
                       "VectorInt8", "VectorOfImage", "VectorString",
                       "VectorUInt16", "VectorUInt32", "VectorUInt64",
-                      "VectorUInt8", "VectorUIntList", "ImageFilter_0",
-                      "ImageFilter_1", "ImageFilter_2", "ImageFilter_3",
-                      "ImageFilter_4", "ImageFilter_5", "ImageFilter_6",
-                      "ImageFilter_7", "ImageFilter_8", "ImageFilter_9",
-                      "ProcessObject", "ImageReaderBase")
+                      "VectorUInt8", "VectorUIntList", "ProcessObject",
+                      "ImageFilter", "ImageReaderBase")
 
 
 newNAMESPACE <- function(oldnamespace, targetnamespace) {


### PR DESCRIPTION
This parameter is no longer being used. Removing it will reduce the
code size.