### PR TITLE
Support passing TBB_DIR to ITK in the Superbuild

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -33,7 +33,8 @@ foreach (_varName ${_varNames})
       OR _varName MATCHES "^ITKV4"
       OR _varName MATCHES "FFTW"
       OR _varName MATCHES "^GDCM_"
-      OR _varName MATCHES "^Module_")
+      OR _varName MATCHES "^Module_"
+      OR _varName STREQUAL "TBB_DIR")
     message( STATUS "Passing variable \"${_varName}=${${_varName}}\" to ITK external project.")
     list(APPEND ITK_VARS ${_varName})
   endif()


### PR DESCRIPTION
Building SimpleITK with TBB can more easily be done from the super build by defining the following CMake Variables:
```
 -DTBB_DIR=/path/to/tbb/cmake/ -DModule_ITKTBB:BOOL=ON
```