### PR TITLE
Add CMake SimpleITK_MAX_DIMENSION option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,15 +120,22 @@ sitk_legacy_naming(SimpleITK_INT64_PIXELIDS)
 
 
 
-set(SimpleITK_4D_IMAGES_DEFAULT ON)
+set(SimpleITK_MAX_DIMENSION_DEFAULT 4)
 # 1900 = VS 14.0 (Visual Studio 2015)
 if(MSVC AND MSVC_VERSION VERSION_LESS 1900)
-  set( SimpleITK_4D_IMAGES_DEFAULT OFF )
-  message("disable")
+  set( SimpleITK_MAX_DIMENSION_DEFAULT 3 )
 endif()
-option( SimpleITK_4D_IMAGES "Add Image and I/O support for four spatial dimensions." ${SimpleITK_4D_IMAGES_DEFAULT} )
-mark_as_advanced( SimpleITK_4D_IMAGES )
-sitk_legacy_naming(SimpleITK_4D_IMAGES)
+if (DEFINED SimpleITK_4D_Image)
+  message(WARNING "SimpleITK variable \"SimpleITK_4D_Image\" is \
+                   deprecated set \"SimpleITK_MAX_DIMENSION\" instead." )
+  if (NOT SimpleITK_4D_Image)
+    set( SimpleITK_MAX_DIMENSION_DEFAULT 3 )
+  endif()
+endif()
+set( "SimpleITK_MAX_DIMENSION" "${SimpleITK_MAX_DIMENSION_DEFAULT}"
+  CACHE STRING "Add Image and I/O support up to max dimension (integer)." )
+mark_as_advanced( SimpleITK_MAX_DIMENSION )
+
 
 
 # Setup build locations.

--- a/Code/BasicFilters/json/ExtractImageFilter.json
+++ b/Code/BasicFilters/json/ExtractImageFilter.json
@@ -6,12 +6,12 @@
   "doc" : "Extract image filter extracts a 2D image from a 2D or 3D image and a 3D image from a 4D image. If the same dimension output is required then the RegionOfInterestFilter should be used.",
   "pixel_types" : "NonLabelPixelIDTypeList",
   "filter_type" : "itk::ExtractImageFilter<InputImageType, typename InputImageType::template Rebind<typename InputImageType::PixelType, (InputImageType::ImageDimension-1<2?2:InputImageType::ImageDimension-1)>::Type >",
-  "custom_register" : " this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 4 > ();\n  this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 3 > ();\n  this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 2 > ();",
+  "custom_register" : " this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 2, SITK_MAX_DIMENSION > ();",
   "members" : [
     {
       "name" : "Size",
       "type" : "unsigned int",
-      "default" : "std::vector<unsigned int>(4, 1)",
+      "default" : "std::vector<unsigned int>(SITK_MAX_DIMENSION, 1)",
       "dim_vec" : 1,
       "itk_type" : "typename InputImageType::SizeType",
       "briefdescriptionSet" : "",

--- a/Code/BasicFilters/json/JoinSeriesImageFilter.json
+++ b/Code/BasicFilters/json/JoinSeriesImageFilter.json
@@ -5,7 +5,7 @@
   "number_of_inputs" : 1,
   "pixel_types" : "NonLabelPixelIDTypeList",
   "output_image_type" : "typename InputImageType::template Rebind<typename InputImageType::PixelType, InputImageType::ImageDimension+1>::Type",
-  "custom_register" : "this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 2 > ();\n  #ifdef SITK_4D_IMAGES\n    this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 3 > ();\n  #endif",
+  "custom_register" : "this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 2, SITK_MAX_DIMENSION-1 > ();\n",
   "members" : [
     {
       "name" : "Origin",

--- a/Code/BasicFilters/json/SliceImageFilter.json
+++ b/Code/BasicFilters/json/SliceImageFilter.json
@@ -4,7 +4,7 @@
   "template_test_filename" : "ImageFilter",
   "number_of_inputs" : 1,
   "pixel_types" : "NonLabelPixelIDTypeList",
-  "custom_register" : "#ifdef SITK_4D_IMAGES\n  this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 4 > ();\n  #endif\n  this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 3 > ();\n  this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 2 > ();",
+  "custom_register" : "this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 2, SITK_MAX_DIMENSION > ();\n",
   "members" : [
     {
       "name" : "Start",

--- a/Code/BasicFilters/src/sitkHashImageFilter.cxx
+++ b/Code/BasicFilters/src/sitkHashImageFilter.cxx
@@ -37,13 +37,8 @@ namespace itk {
 
       this->m_MemberFactory.reset( new detail::MemberFunctionFactory<MemberFunctionType>( this ) );
 
-      this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 4 > ();
-      this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 3 > ();
-      this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 2 > ();
-
-      this->m_MemberFactory->RegisterMemberFunctions < LabelPixelIDTypeList, 4, detail::ExecuteInternalLabelImageAddressor<MemberFunctionType> > ();
-      this->m_MemberFactory->RegisterMemberFunctions < LabelPixelIDTypeList, 3, detail::ExecuteInternalLabelImageAddressor<MemberFunctionType> > ();
-      this->m_MemberFactory->RegisterMemberFunctions < LabelPixelIDTypeList, 2, detail::ExecuteInternalLabelImageAddressor<MemberFunctionType> > ();
+      this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 2, SITK_MAX_DIMENSION > ();
+      this->m_MemberFactory->RegisterMemberFunctions < LabelPixelIDTypeList, 2, SITK_MAX_DIMENSION, detail::ExecuteInternalLabelImageAddressor<MemberFunctionType> > ();
     }
 
     std::string HashImageFilter::ToString() const {

--- a/Code/Common/include/sitkImage.h
+++ b/Code/Common/include/sitkImage.h
@@ -471,7 +471,7 @@ namespace simple
      * This method internally utlizes the member function factory to
      * dispatch to methods instantiated on the image of the pixel ID
      */
-    void Allocate ( unsigned int width, unsigned int height, unsigned int depth, unsigned int dim4, PixelIDValueEnum valueEnum, unsigned int numberOfComponents );
+    void Allocate ( const std::vector<unsigned int > &size, PixelIDValueEnum valueEnum, unsigned int numberOfComponents );
 
     /** \brief Dispatched methods for allocating images
      *
@@ -482,15 +482,15 @@ namespace simple
      */
     template<class TImageType>
     typename std::enable_if<IsBasic<TImageType>::Value>::type
-    AllocateInternal ( unsigned int width, unsigned int height, unsigned int depth, unsigned int dim4, unsigned int numberOfComponents );
+    AllocateInternal ( const std::vector<unsigned int > &size, unsigned int numberOfComponents );
 
     template<class TImageType>
     typename std::enable_if<IsVector<TImageType>::Value>::type
-    AllocateInternal ( unsigned int width, unsigned int height, unsigned int depth, unsigned int dim4, unsigned int numberOfComponents );
+    AllocateInternal ( const std::vector<unsigned int > &size, unsigned int numberOfComponents );
 
     template<class TImageType>
     typename std::enable_if<IsLabel<TImageType>::Value>::type
-    AllocateInternal ( unsigned int width, unsigned int height, unsigned int depth, unsigned int dim4, unsigned int numberOfComponents );
+    AllocateInternal ( const std::vector<unsigned int > &size, unsigned int numberOfComponents );
     /**@}*/
 
 

--- a/Code/Common/include/sitkMemberFunctionFactory.h
+++ b/Code/Common/include/sitkMemberFunctionFactory.h
@@ -129,21 +129,11 @@ public:
   }
 
   template < typename TPixelIDTypeList, unsigned int VImageDimension, unsigned int VImageDimensionStop >
-  typename std::enable_if<(VImageDimensionStop > VImageDimension)>::type
+  void
    RegisterMemberFunctions( )
   {
     using AddressorType = detail::MemberFunctionAddressor< TMemberFunctionPointer >;
-    this->RegisterMemberFunctions< TPixelIDTypeList, VImageDimensionStop, AddressorType >();
-    this->RegisterMemberFunctions< TPixelIDTypeList, VImageDimension, VImageDimensionStop - 1 >();
-  }
-  template < typename TPixelIDTypeList,
-             unsigned int VImageDimension,
-             unsigned int VImageDimensionStop >
-  typename std::enable_if<(VImageDimensionStop == VImageDimension)>::type
-   RegisterMemberFunctions( )
-  {
-    using AddressorType = detail::MemberFunctionAddressor< TMemberFunctionPointer >;
-    this->RegisterMemberFunctions< TPixelIDTypeList, VImageDimensionStop, AddressorType >();
+    this->RegisterMemberFunctions< TPixelIDTypeList, VImageDimension, VImageDimensionStop, AddressorType >();
   }
   template < typename TPixelIDTypeList,
              unsigned int VImageDimension,

--- a/Code/Common/include/sitkMemberFunctionFactory.h
+++ b/Code/Common/include/sitkMemberFunctionFactory.h
@@ -110,6 +110,11 @@ public:
    * this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 3 > ();
    * this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 2 > ();
    * \endcode
+   *
+   * A range can also be used:
+   * \code
+   * this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 2, 3 > ();
+   * \endcode
    * @{
    */
   template < typename TPixelIDTypeList,
@@ -121,6 +126,44 @@ public:
   {
     using AddressorType = detail::MemberFunctionAddressor< TMemberFunctionPointer >;
     this->RegisterMemberFunctions< TPixelIDTypeList, VImageDimension, AddressorType >();
+  }
+
+  template < typename TPixelIDTypeList, unsigned int VImageDimension, unsigned int VImageDimensionStop >
+  typename std::enable_if<(VImageDimensionStop > VImageDimension)>::type
+   RegisterMemberFunctions( )
+  {
+    using AddressorType = detail::MemberFunctionAddressor< TMemberFunctionPointer >;
+    this->RegisterMemberFunctions< TPixelIDTypeList, VImageDimensionStop, AddressorType >();
+    this->RegisterMemberFunctions< TPixelIDTypeList, VImageDimension, VImageDimensionStop - 1 >();
+  }
+  template < typename TPixelIDTypeList,
+             unsigned int VImageDimension,
+             unsigned int VImageDimensionStop >
+  typename std::enable_if<(VImageDimensionStop == VImageDimension)>::type
+   RegisterMemberFunctions( )
+  {
+    using AddressorType = detail::MemberFunctionAddressor< TMemberFunctionPointer >;
+    this->RegisterMemberFunctions< TPixelIDTypeList, VImageDimensionStop, AddressorType >();
+  }
+  template < typename TPixelIDTypeList,
+             unsigned int VImageDimension,
+             unsigned int VImageDimensionStop,
+             typename TAddressor
+               >
+    typename std::enable_if<(VImageDimensionStop > VImageDimension)>::type
+   RegisterMemberFunctions( )
+  {
+    this->RegisterMemberFunctions< TPixelIDTypeList, VImageDimensionStop, TAddressor >();
+    this->RegisterMemberFunctions< TPixelIDTypeList, VImageDimension, VImageDimensionStop - 1, TAddressor >();
+  }
+  template < typename TPixelIDTypeList,
+             unsigned int VImageDimension,
+             unsigned int VImageDimensionStop,
+             typename TAddressor  >
+  typename std::enable_if<(VImageDimensionStop == VImageDimension)>::type
+   RegisterMemberFunctions( )
+  {
+    this->RegisterMemberFunctions< TPixelIDTypeList, VImageDimensionStop, TAddressor >();
   }
   /** @} */
 

--- a/Code/Common/include/sitkPixelIDTokens.h
+++ b/Code/Common/include/sitkPixelIDTokens.h
@@ -95,11 +95,8 @@ template <typename TPixelIDType, unsigned int VImageDimension =0>
 struct IsInstantiated
 {
   static const bool Value = ((int)PixelIDToPixelIDValue<TPixelIDType>::Result != (int)sitkUnknown)
-    &&  ( (VImageDimension == 0)||(VImageDimension == 2) || (VImageDimension == 3)
-#ifdef SITK_4D_IMAGES
-          || (VImageDimension == 4)
-#endif
-      );
+    &&  ( (VImageDimension == 0) ||
+          (VImageDimension >= 2 && VImageDimension <= SITK_MAX_DIMENSION));
   using ValueType = typename std::integral_constant<bool, Value>::value_type;
   using Type = typename std::integral_constant<bool, Value>::type;
 };

--- a/Code/Common/src/sitkConfigure.h.in
+++ b/Code/Common/src/sitkConfigure.h.in
@@ -27,12 +27,13 @@
 #endif
 #cmakedefine SITK_SimpleITKExplit_STATIC
 
+#define SITK_MAX_DIMENSION @SimpleITK_MAX_DIMENSION@
+
 // defined if compiler supports using template keyword to disambiguate
 // dependent names
 #cmakedefine SITK_HAS_TEMPLATE_DISAMBIGUATOR_DEPENDENT_NAME
 
 #cmakedefine SITK_INT64_PIXELIDS
-#cmakedefine SITK_4D_IMAGES
 
 #cmakedefine SITK_EXPLICIT_INSTANTIATION
 

--- a/Code/Common/src/sitkImage.cxx
+++ b/Code/Common/src/sitkImage.cxx
@@ -41,7 +41,7 @@ namespace itk
   Image::Image( )
     : m_PimpleImage( nullptr )
   {
-    Allocate ( 0, 0, 0, 0, sitkUInt8, 1 );
+    Allocate ( {0, 0}, sitkUInt8, 1 );
   }
 
   Image::Image( const Image &img )
@@ -70,34 +70,19 @@ namespace itk
     Image::Image( unsigned int Width, unsigned int Height, PixelIDValueEnum ValueEnum )
       : m_PimpleImage( nullptr )
     {
-      Allocate ( Width, Height, 0, 0, ValueEnum, 0 );
+      Allocate ( {Width, Height}, ValueEnum, 0 );
     }
 
     Image::Image( unsigned int Width, unsigned int Height, unsigned int Depth, PixelIDValueEnum ValueEnum )
       : m_PimpleImage( nullptr )
     {
-      Allocate ( Width, Height, Depth, 0, ValueEnum, 0 );
+      Allocate ( {Width, Height, Depth}, ValueEnum, 0 );
     }
 
     Image::Image( const std::vector< unsigned int > &size, PixelIDValueEnum ValueEnum, unsigned int numberOfComponents )
       : m_PimpleImage( nullptr )
     {
-      if ( size.size() == 2 )
-        {
-        Allocate ( size[0], size[1], 0, 0, ValueEnum, numberOfComponents );
-        }
-      else if ( size.size() == 3 )
-        {
-        Allocate ( size[0], size[1], size[2], 0, ValueEnum, numberOfComponents );
-        }
-      else if ( size.size() == 4 )
-        {
-        Allocate ( size[0], size[1], size[2], size[3], ValueEnum, numberOfComponents );
-        }
-      else
-        {
-        sitkExceptionMacro("Unsupported number of dimesions specified by size: " << size << "!");
-        }
+      Allocate( size, ValueEnum, numberOfComponents );
     }
 
     itk::DataObject* Image::GetITKBase( )

--- a/Code/Common/src/sitkImage.hxx
+++ b/Code/Common/src/sitkImage.hxx
@@ -72,7 +72,7 @@ namespace itk
 
   template<class TImageType>
   typename std::enable_if<IsBasic<TImageType>::Value>::type
-  Image::AllocateInternal ( unsigned int Width, unsigned int Height, unsigned int Depth, unsigned int dim4, unsigned int numberOfComponents )
+  Image::AllocateInternal ( const std::vector<unsigned int > &_size, unsigned int numberOfComponents )
   {
     if ( numberOfComponents != 1  && numberOfComponents != 0 )
       {
@@ -80,29 +80,12 @@ namespace itk
                           << " but did not specify pixelID as a vector type!" );
       }
 
-    typename TImageType::IndexType  index;
-    typename TImageType::SizeType   size;
-    typename TImageType::RegionType region;
-
+    typename TImageType::IndexType index;
     index.Fill ( 0 );
-    size.Fill(1);
-    size[0] = Width;
-    size[1] = Height;
 
-    if ( TImageType::ImageDimension > 2 )
-      {
-      assert( Depth != 0 );
-      size[2] = Depth;
-      }
+    typename TImageType::SizeType size = sitkSTLVectorToITK<typename TImageType::SizeType>(_size);
 
-    if ( TImageType::ImageDimension > 3 )
-      {
-      assert(  dim4 != 0 );
-      size[3] =  dim4;
-      }
-
-    region.SetSize ( size );
-    region.SetIndex ( index );
+    typename TImageType::RegionType region{index, size};
 
     typename TImageType::Pointer image = TImageType::New();
     image->SetRegions ( region );
@@ -116,7 +99,7 @@ namespace itk
 
   template<class TImageType>
   typename std::enable_if<IsVector<TImageType>::Value>::type
-  Image::AllocateInternal ( unsigned int Width, unsigned int Height, unsigned int Depth, unsigned int dim4, unsigned int numberOfComponents )
+  Image::AllocateInternal ( const std::vector<unsigned int > &_size, unsigned int numberOfComponents )
   {
     if ( numberOfComponents == 0 )
       {
@@ -124,29 +107,12 @@ namespace itk
       }
 
     typename TImageType::IndexType  index;
-    typename TImageType::SizeType   size;
-    typename TImageType::RegionType region;
-    typename TImageType::PixelType  zero;
-
     index.Fill ( 0 );
-    size.Fill(1);
-    size[0] = Width;
-    size[1] = Height;
 
-    if ( TImageType::ImageDimension > 2 )
-      {
-      assert( Depth != 0 );
-      size[2] = Depth;
-      }
+    typename TImageType::SizeType   size = sitkSTLVectorToITK<typename TImageType::SizeType>(_size);
 
-    if ( TImageType::ImageDimension > 3 )
-      {
-      assert(  dim4 != 0 );
-      size[3] =  dim4;
-      }
-
-    region.SetSize ( size );
-    region.SetIndex ( index );
+    typename TImageType::RegionType region{index, size};
+    typename TImageType::PixelType  zero;
 
     zero.SetSize( numberOfComponents );
     zero.Fill ( itk::NumericTraits<typename TImageType::PixelType::ValueType>::Zero );
@@ -165,7 +131,7 @@ namespace itk
 
   template<class TImageType>
   typename std::enable_if<IsLabel<TImageType>::Value>::type
-  Image::AllocateInternal ( unsigned int Width, unsigned int Height, unsigned int Depth, unsigned int dim4, unsigned int numberOfComponents )
+  Image::AllocateInternal ( const std::vector<unsigned int > &_size, unsigned int numberOfComponents )
   {
     if ( numberOfComponents != 1 && numberOfComponents != 0 )
       {
@@ -173,29 +139,12 @@ namespace itk
                           << " but did not specify pixelID as a vector type!" );
       }
 
-    typename TImageType::IndexType  index;
-    typename TImageType::SizeType   size;
-    typename TImageType::RegionType region;
-
+    typename TImageType::IndexType index;
     index.Fill ( 0 );
-    size.Fill(1);
-    size[0] = Width;
-    size[1] = Height;
 
-    if ( TImageType::ImageDimension > 2 )
-      {
-      assert( Depth != 0 );
-      size[2] = Depth;
-      }
+    typename TImageType::SizeType size = sitkSTLVectorToITK<typename TImageType::SizeType>(_size);
 
-    if ( TImageType::ImageDimension > 3 )
-      {
-      assert(  dim4 != 0 );
-      size[3] =  dim4;
-      }
-
-    region.SetSize ( size );
-    region.SetIndex ( index );
+    typename TImageType::RegionType region{index, size};
 
     typename TImageType::Pointer image = TImageType::New();
     image->SetRegions ( region );

--- a/Code/Common/src/sitkImageExplicit.cxx
+++ b/Code/Common/src/sitkImageExplicit.cxx
@@ -37,14 +37,14 @@ namespace itk
 {
   namespace simple
   {
-    void Image::Allocate ( unsigned int Width, unsigned int Height, unsigned int Depth, unsigned int dim4, PixelIDValueEnum ValueEnum, unsigned int numberOfComponents )
+    void Image::Allocate ( const std::vector<unsigned int> &_size, PixelIDValueEnum ValueEnum, unsigned int numberOfComponents )
     {
       // initialize member function factory for allocating images
 
       // The pixel IDs supported
       using PixelIDTypeList = AllPixelIDTypeList;
 
-      typedef void ( Self::*MemberFunctionType )( unsigned int, unsigned int, unsigned int, unsigned int, unsigned int );
+      typedef void ( Self::*MemberFunctionType )( const std::vector<unsigned int> &, unsigned int );
 
       using AllocateAddressor = AllocateMemberFunctionAddressor< MemberFunctionType >;
 
@@ -58,18 +58,12 @@ namespace itk
         sitkExceptionMacro( "Unable to construct image of unsupported pixel type" );
         }
 
-      if ( Depth == 0 )
+      if (_size.size() < 2 || _size.size() >= 4)
         {
-        allocateMemberFactory.GetMemberFunction( ValueEnum, 2 )( Width, Height, Depth, dim4, numberOfComponents );
+        sitkExceptionMacro("Unsupported number of dimesions specified by size: " << _size << "!");
         }
-      else if ( dim4 == 0 )
-        {
-        allocateMemberFactory.GetMemberFunction( ValueEnum, 3 )( Width, Height, Depth, dim4, numberOfComponents );
-        }
-      else
-        {
-        allocateMemberFactory.GetMemberFunction( ValueEnum, 4 )( Width, Height, Depth, dim4, numberOfComponents );
-        }
+
+      allocateMemberFactory.GetMemberFunction( ValueEnum, _size.size() )( _size, numberOfComponents );
     }
   }
 }

--- a/Code/Common/src/sitkImageExplicit.cxx
+++ b/Code/Common/src/sitkImageExplicit.cxx
@@ -58,7 +58,8 @@ namespace itk
 
       if (_size.size() < 2 || _size.size() > SITK_MAX_DIMENSION)
         {
-        sitkExceptionMacro("Unsupported number of dimesions specified by size: " << _size << "!");
+        sitkExceptionMacro("Unsupported number of dimesions specified by size: " << _size << "!\n"
+                           << "The maximum supported Image dimension is " << SITK_MAX_DIMENSION << "." );
         }
 
       allocateMemberFactory.GetMemberFunction( ValueEnum, _size.size() )( _size, numberOfComponents );
@@ -75,20 +76,31 @@ namespace itk
 // explicitly instantiate for the expected image types.
 //
 
-#define SITK_TEMPLATE_InternalInitialization_D( _I, _D )                \
+#define SITK_TEMPLATE_InternalInitialization_D( I, D )                \
   namespace itk { namespace simple {                                    \
-  template SITKCommon_EXPORT void Image::InternalInitialization<_I,_D>(  PixelIDToImageType< typelist::TypeAt<InstantiatedPixelIDTypeList, \
-                                                                                            _I>::Result, \
-                                                                           _D>::ImageType *i ); \
+  template SITKCommon_EXPORT void \
+  Image::InternalInitialization<I,D>(  PixelIDToImageType< typelist::TypeAt<InstantiatedPixelIDTypeList, \
+                                       I>::Result,                      \
+                                       D>::ImageType *i );              \
   } }
 
-#if SITK_MAX_DIMENSION == 5
-#define SITK_TEMPLATE_InternalInitialization( _I ) SITK_TEMPLATE_InternalInitialization_D( _I, 2 ) SITK_TEMPLATE_InternalInitialization_D( _I, 3 ) SITK_TEMPLATE_InternalInitialization_D( _I, 4 ) SITK_TEMPLATE_InternalInitialization_D( _I, 5 )
-#elif SITK_MAX_DIMENSION == 4
-#define SITK_TEMPLATE_InternalInitialization( _I ) SITK_TEMPLATE_InternalInitialization_D( _I, 2 ) SITK_TEMPLATE_InternalInitialization_D( _I, 3 ) SITK_TEMPLATE_InternalInitialization_D( _I, 4 )
-#else
-#define SITK_TEMPLATE_InternalInitialization( _I ) SITK_TEMPLATE_InternalInitialization_D( _I, 2 ) SITK_TEMPLATE_InternalInitialization_D( _I, 3 )
+#if SITK_MAX_DIMENSION < 2 || SITK_MAX_DIMENSION > 9
+#error "Unsupported SITK_MAX_DIMENSION value".
 #endif
+
+#define SITK_TEMPLATE_InternalInitialization_2( _I ) SITK_TEMPLATE_InternalInitialization_D( _I, 2 )
+#define SITK_TEMPLATE_InternalInitialization_3( _I ) SITK_TEMPLATE_InternalInitialization_D( _I, 3 ) SITK_TEMPLATE_InternalInitialization_2( _I )
+#define SITK_TEMPLATE_InternalInitialization_4( _I ) SITK_TEMPLATE_InternalInitialization_D( _I, 4 ) SITK_TEMPLATE_InternalInitialization_3( _I )
+#define SITK_TEMPLATE_InternalInitialization_5( _I ) SITK_TEMPLATE_InternalInitialization_D( _I, 5 ) SITK_TEMPLATE_InternalInitialization_4( _I )
+#define SITK_TEMPLATE_InternalInitialization_6( _I ) SITK_TEMPLATE_InternalInitialization_D( _I, 6 ) SITK_TEMPLATE_InternalInitialization_5( _I )
+#define SITK_TEMPLATE_InternalInitialization_7( _I ) SITK_TEMPLATE_InternalInitialization_D( _I, 7 ) SITK_TEMPLATE_InternalInitialization_6( _I )
+#define SITK_TEMPLATE_InternalInitialization_8( _I ) SITK_TEMPLATE_InternalInitialization_D( _I, 8 ) SITK_TEMPLATE_InternalInitialization_7( _I )
+#define SITK_TEMPLATE_InternalInitialization_9( _I ) SITK_TEMPLATE_InternalInitialization_D( _I, 9 ) SITK_TEMPLATE_InternalInitialization_8( _I )
+
+
+#define SITK_TEMPLATE_InternalInitialization_CONCAT( I ) sitkMacroJoin( SITK_TEMPLATE_InternalInitialization_, SITK_MAX_DIMENSION ) ( I )
+
+#define SITK_TEMPLATE_InternalInitialization( I ) SITK_TEMPLATE_InternalInitialization_CONCAT ( I )
 
 
 // Instantiate for all types in the lists

--- a/Code/Common/src/sitkImageExplicit.cxx
+++ b/Code/Common/src/sitkImageExplicit.cxx
@@ -49,16 +49,14 @@ namespace itk
       using AllocateAddressor = AllocateMemberFunctionAddressor< MemberFunctionType >;
 
       detail::MemberFunctionFactory< MemberFunctionType > allocateMemberFactory( this );
-      allocateMemberFactory.RegisterMemberFunctions< PixelIDTypeList, 2, AllocateAddressor > ();
-      allocateMemberFactory.RegisterMemberFunctions< PixelIDTypeList, 3, AllocateAddressor > ();
-      allocateMemberFactory.RegisterMemberFunctions< PixelIDTypeList, 4, AllocateAddressor > ();
+      allocateMemberFactory.RegisterMemberFunctions< PixelIDTypeList, 2, SITK_MAX_DIMENSION, AllocateAddressor > ();
 
       if ( ValueEnum == sitkUnknown )
         {
         sitkExceptionMacro( "Unable to construct image of unsupported pixel type" );
         }
 
-      if (_size.size() < 2 || _size.size() >= 4)
+      if (_size.size() < 2 || _size.size() > SITK_MAX_DIMENSION)
         {
         sitkExceptionMacro("Unsupported number of dimesions specified by size: " << _size << "!");
         }
@@ -84,7 +82,9 @@ namespace itk
                                                                            _D>::ImageType *i ); \
   } }
 
-#ifdef SITK_4D_IMAGES
+#if SITK_MAX_DIMENSION == 5
+#define SITK_TEMPLATE_InternalInitialization( _I ) SITK_TEMPLATE_InternalInitialization_D( _I, 2 ) SITK_TEMPLATE_InternalInitialization_D( _I, 3 ) SITK_TEMPLATE_InternalInitialization_D( _I, 4 ) SITK_TEMPLATE_InternalInitialization_D( _I, 5 )
+#elif SITK_MAX_DIMENSION == 4
 #define SITK_TEMPLATE_InternalInitialization( _I ) SITK_TEMPLATE_InternalInitialization_D( _I, 2 ) SITK_TEMPLATE_InternalInitialization_D( _I, 3 ) SITK_TEMPLATE_InternalInitialization_D( _I, 4 )
 #else
 #define SITK_TEMPLATE_InternalInitialization( _I ) SITK_TEMPLATE_InternalInitialization_D( _I, 2 ) SITK_TEMPLATE_InternalInitialization_D( _I, 3 )

--- a/Code/Common/src/sitkPimpleImageBase.hxx
+++ b/Code/Common/src/sitkPimpleImageBase.hxx
@@ -61,10 +61,10 @@ namespace itk
     PimpleImage ( ImageType* image )
       : m_Image( image )
       {
-        static_assert( ImageType::ImageDimension == 4 || ImageType::ImageDimension == 3 || ImageType::ImageDimension == 2,
-                          "Image Dimension out of range" );
+        static_assert( ImageType::ImageDimension <= SITK_MAX_DIMENSION && ImageType::ImageDimension >= 2,
+                       "Image Dimension out of range" );
         static_assert( ImageTypeToPixelIDValue<ImageType>::Result != (int)sitkUnknown,
-                          "invalid pixel type" );
+                       "invalid pixel type" );
 
         if ( image == nullptr )
           {

--- a/Code/IO/src/sitkImageFileWriter.cxx
+++ b/Code/IO/src/sitkImageFileWriter.cxx
@@ -44,9 +44,7 @@ ImageFileWriter::ImageFileWriter()
 
   this->m_MemberFactory.reset( new detail::MemberFunctionFactory<MemberFunctionType>( this ) );
 
-  this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 4 > ();
-  this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 3 > ();
-  this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 2 > ();
+  this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 1, SITK_MAX_DIMENSION > ();
 
 }
 

--- a/Code/IO/src/sitkImageSeriesReader.cxx
+++ b/Code/IO/src/sitkImageSeriesReader.cxx
@@ -82,8 +82,7 @@ namespace itk {
 
     this->m_MemberFactory.reset( new detail::MemberFunctionFactory<MemberFunctionType>( this ) );
 
-    this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 3 > ();
-    this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 2 > ();
+    this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 2, SITK_MAX_DIMENSION > ();
     }
 
   ImageSeriesReader::~ImageSeriesReader()
@@ -158,7 +157,7 @@ namespace itk {
         }
       }
 
-    if ( dimension != 2 && dimension != 3 )
+    if ( dimension < 2 || dimension > SITK_MAX_DIMENSION )
       {
       sitkExceptionMacro( "The file in the series have unsupported " << dimension - 1 << " dimensions." );
       }

--- a/SuperBuild/SuperBuild.cmake
+++ b/SuperBuild/SuperBuild.cmake
@@ -144,14 +144,26 @@ option(BUILD_SHARED_LIBS "Build SimpleITK ITK with shared libraries. This does n
 # as this option does not robustly work across platforms it will be marked as advanced
 mark_as_advanced( FORCE BUILD_SHARED_LIBS )
 
-set(SimpleITK_4D_IMAGES_DEFAULT ON)
+set(SimpleITK_MAX_DIMENSION_DEFAULT 4)
 # 1900 = VS 14.0 (Visual Studio 2015)
 if(MSVC AND MSVC_VERSION VERSION_LESS 1900)
-  set( SimpleITK_4D_IMAGES_DEFAULT OFF )
+  set( SimpleITK_MAX_DIMENSION_DEFAULT 3 )
 endif()
-option( SimpleITK_4D_IMAGES "Add Image and I/O support for four spatial dimensions." ${SimpleITK_4D_IMAGES_DEFAULT} )
-mark_as_advanced( SimpleITK_4D_IMAGES )
-unset(SimpleITK_4D_IMAGES_DEFAULT)
+
+if (DEFINED SimpleITK_4D_Image)
+  message(WARNING "SimpleITK variable \"SimpleITK_4D_Image\" is deprecated set \"SimpleITK_MAX_DIMENSION\" instead." )
+  if (NOT SimpleITK_4D_Image)
+    set( SimpleITK_MAX_DIMENSION_DEFAULT 3 )
+  endif()
+  unset( SimpleITK_4D_Image CACHE )
+endif()
+set( "SimpleITK_MAX_DIMENSION" "${SimpleITK_MAX_DIMENSION_DEFAULT}"
+  CACHE STRING "Add Image and I/O support up to max dimension (integer)." )
+mark_as_advanced( SimpleITK_MAX_DIMENSION )
+unset(SimpleITK_MAX_DIMENSION_DEFAULT)
+
+
+
 
 #-----------------------------------------------------------------------------
 # Setup build type

--- a/Testing/Unit/CMakeLists.txt
+++ b/Testing/Unit/CMakeLists.txt
@@ -32,7 +32,7 @@ set ( SimpleITKUnitTestSource
   sitkImageViewerTest.cxx
   )
 
-if ( SimpleITK_4D_IMAGES )
+if ( SimpleITK_MAX_DIMENSION GREATER_EQUAL 4 )
   list(APPEND SimpleITKUnitTestSource sitkImage4DTests.cxx )
 endif()
 

--- a/Testing/Unit/itkHashImageFilterTest.cxx
+++ b/Testing/Unit/itkHashImageFilterTest.cxx
@@ -88,7 +88,7 @@ TEST_F(HashImageFilterTest, InstantiateTest) {
   using DOUBLEHasherType = itk::HashImageFilter< itk::Image<double, 3> >;
   EXPECT_TRUE( DOUBLEHasherType::New().IsNotNull() );
 
-#ifdef SITK_4D_IMAGES
+#if SITK_MAX_DIMENSION >= 4
   using DOUBLE4DHasherType = itk::HashImageFilter< itk::Image<double, 4> >;
   EXPECT_TRUE( DOUBLE4DHasherType::New().IsNotNull() );
 #endif
@@ -121,7 +121,7 @@ TEST_F(HashImageFilterTest, SHA1HashValues ) {
 
   this->CheckImageHashSHA1<int, 3>("Input/Ramp-Down-Short.nrrd",  "3dc54908746f25fd42f17c5fe44935013e508b1b" );
 
-#ifdef SITK_4D_IMAGES
+#if SITK_MAX_DIMENSION >= 4
   this->CheckImageHashSHA1<short, 4>("Input/4D.nii.gz", "9e81d4b3cdf10a4da5d54c8cd7c4954449d76d5d" );
 #endif
 }


### PR DESCRIPTION
This option replaces the SimpleITK_4D_Image option, and will allow for instantiation of higher dimensional images and time series.