### PR TITLE
Updating ITK version along 5.1 release for superbuild

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -55,7 +55,7 @@ set(ITK_GIT_REPOSITORY "${git_protocol}://github.com/InsightSoftwareConsortium/I
 mark_as_advanced(ITK_GIT_REPOSITORY)
 sitk_legacy_naming(ITK_GIT_REPOSITORY ITK_REPOSITORY)
 
-set(_DEFAULT_ITK_GIT_TAG "d23cb9295e3f69e734baae94d91bd0ca8928cd00")
+set(_DEFAULT_ITK_GIT_TAG "1ab2baa9ab21da47ff5a13a49f969a537cc23f2d")
 set(ITK_GIT_TAG "${_DEFAULT_ITK_GIT_TAG}" CACHE STRING "Tag in ITK git repo")
 mark_as_advanced(ITK_GIT_TAG)
 set(ITK_TAG_COMMAND GIT_TAG "${ITK_GIT_TAG}")


### PR DESCRIPTION
Log of changes to ITK:
af780e8a03 BUG: Disable dynamic threading in noise filter.
449c571897 BUG: CUFFTW paths were not being set and unnecessary FFTW files used
d9e73e9a8b STYLE: apply clang-format
0b970d803d STYLE: make column limit more stringent in the examples
43a8972077 BUG: Add StatisticsImageFilter::SetNumberOfStreamDivisions Python
8c4d3da09d COMP: Add missing const qualifier
355c6cbda3 BUG: Double scaling introduced in refactoring