### PR TITLE
Fix pickling of missing transform

### DIFF
--- a/Testing/Unit/Python/sitkTransformTests.py
+++ b/Testing/Unit/Python/sitkTransformTests.py
@@ -164,6 +164,33 @@ class TransformTests(unittest.TestCase):
 
         self.assertEqual(tx, tx2)
 
+    def test_default_pickle(self):
+        """Test pickling/unpickling of minimally constructed transforms"""
+
+        transforms = {
+            'AffineTransform': (3,),
+            'BSplineTransform': (3, 3),
+            'DisplacementFieldTransform': (3,),
+            'Euler2DTransform': (),
+            'Euler3DTransform': (),
+            'ScaleSkewVersor3DTransform': (),
+            'ScaleTransform': (3,),
+            'ScaleVersor3DTransform': (),
+            'Similarity2DTransform': (),
+            'Similarity3DTransform': (),
+            'Transform': (),
+            'TranslationTransform': (3,),
+            'VersorRigid3DTransform': (),
+            'VersorTransform': ()
+        }
+
+        for k, v in transforms.items():
+            tx = getattr(sitk, k)(*v)
+
+            tx2 = pickle.loads(pickle.dumps(tx))
+
+            self.assertEqual(tx, tx2, msg="Testing {0}".format(tx.GetName()))
+
     def test_deepcopy(self):
         """Test the custom __deepcopy__ method"""
 

--- a/Wrapping/Python/CMakeLists.txt
+++ b/Wrapping/Python/CMakeLists.txt
@@ -33,7 +33,9 @@ if( SimpleITK_PYTHON_THREADS )
 endif()
 set(CMAKE_SWIG_OUTDIR ${CMAKE_CURRENT_BINARY_DIR}/SimpleITK)
 set(SWIG_MODULE_SimpleITK_EXTRA_DEPS ${SWIG_EXTRA_DEPS}
-  ${CMAKE_CURRENT_SOURCE_DIR}/Python.i )
+  ${CMAKE_CURRENT_SOURCE_DIR}/Python.i
+  ${CMAKE_CURRENT_SOURCE_DIR}/sitkImage.i
+  ${CMAKE_CURRENT_SOURCE_DIR}/sitkTransform.i )
 SWIG_add_module ( SimpleITK python
   SimpleITK.i
   sitkPyCommand.cxx )

--- a/Wrapping/Python/sitkTransform.i
+++ b/Wrapping/Python/sitkTransform.i
@@ -45,13 +45,22 @@
           version = 0
 
           if self.__class__ is DisplacementFieldTransform:
-            args = (self.GetDisplacementField(), )
-            S = (version, )
-          if self.__class__ is BSplineTransform:
+            dis = self.GetDisplacementField()
+            if all( 0 == s for s in dis.GetSize() ):
+                # The null state needs special handling
+                args = (self.GetDimension(),)
+                S = (version, self.GetFixedParameters(), self.GetParameters())
+            else:
+                args = (dis, )
+                S = (version, )
+          elif self.__class__ is BSplineTransform:
             args = (tuple(self.GetCoefficientImages()), self.GetOrder())
             S = (version, )
           else:
-            args = (self.GetDimension(),)
+            args = ()
+            if self.__class__ in [AffineTransform, ScaleTransform, TranslationTransform]:
+                args = (self.GetDimension(),)
+
             S = (version, self.GetFixedParameters(), self.GetParameters())
 
           return self.__class__, args, S


### PR DESCRIPTION
This patch addresses picking of the derived transformed classes failing in issue #1112. Addressing pickling the Transform base class will be another PR.