### PR TITLE
Add CompositeTransform class

### DIFF
--- a/Code/Common/include/SimpleITK.h
+++ b/Code/Common/include/SimpleITK.h
@@ -50,6 +50,7 @@
 #include "sitkTranslationTransform.h"
 #include "sitkVersorTransform.h"
 #include "sitkVersorRigid3DTransform.h"
+#include "sitkCompositeTransform.h"
 #include "sitkShow.h"
 
 #include "sitkInterpolator.h"

--- a/Code/Common/include/sitkAffineTransform.h
+++ b/Code/Common/include/sitkAffineTransform.h
@@ -84,8 +84,6 @@ protected:
 
 private:
 
-  using Superclass::AddTransform;
-
   struct MyVisitor
   {
     itk::TransformBase *transform;

--- a/Code/Common/include/sitkBSplineTransform.h
+++ b/Code/Common/include/sitkBSplineTransform.h
@@ -94,8 +94,6 @@ protected:
 
 private:
 
-  using Superclass::AddTransform;
-
   struct MyVisitor
   {
     itk::TransformBase *transform;

--- a/Code/Common/include/sitkCompositeTransform.h
+++ b/Code/Common/include/sitkCompositeTransform.h
@@ -93,7 +93,7 @@ public:
    *
    * An exception is thrown if the vector is empty.
    */
-   explicit CompositeTransform(const std::vector<Transform> &);
+  explicit CompositeTransform(const std::vector<itk::simple::Transform> &);
 
   ~CompositeTransform() override;
 

--- a/Code/Common/include/sitkCompositeTransform.h
+++ b/Code/Common/include/sitkCompositeTransform.h
@@ -1,0 +1,194 @@
+/*=========================================================================
+*
+*  Copyright NumFOCUS
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*         http://www.apache.org/licenses/LICENSE-2.0.txt
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*=========================================================================*/
+
+
+#ifndef sitkCompositeTransform_h
+#define sitkCompositeTransform_h
+
+#include "sitkCommon.h"
+#include "sitkTransform.h"
+
+namespace itk
+{
+
+
+template <typename TParametersValueType, unsigned int NInputDimensions, unsigned int NOutputDimensions>
+class Transform;
+
+namespace simple
+{
+
+/** \class CompositeTransform
+ * \brief This class contains a stack of transforms and concatenates them by composition.
+ *
+ * The transforms are composed in \b reverse order with the back being applied
+ * first:
+ *    \f$ T_0 o T_1 = T_0(T_1(x)) \f$
+ * Transforms are stored in a queue, in the following order:
+ *    \f$ T_0, T_1, ... , T_N-1 \f$
+ *
+ * Transforms are added via AddTransform(). This adds the transforms to the back
+ * of the queue.
+ *
+ * The only parameters of the transform at the back of the queue are exposed and
+ * optimizable for registration.
+ *
+ * Inverse:
+ * The inverse transform is created by retrieving the inverse from each
+ * sub transform and adding them to a composite transform in reverse order.
+ * The m_TransformsToOptimizeFlags is copied in reverse for the inverse.
+ *
+ * \sa itk::CompositeTransform
+ */
+class SITKCommon_EXPORT CompositeTransform
+    : public Transform {
+public:
+  using Self = CompositeTransform;
+  using Superclass = Transform;
+
+  /** \brief Construct an empty CompositeTransform
+   *
+   *  The created CompositeTransform is initialized with zero transforms.
+   *  Additional transforms of dimensions can be added.
+   */
+  explicit CompositeTransform(unsigned int dimensions);
+
+  /** \brief Create CompositeTransform converted or holding the transform argument.
+   *
+   * If the Transform is internally a CompositeTransform, a shallow copy to
+   * the internal transform will be made. Otherwise a new CompositeTransform is
+   * constructed which holds the transform argument.
+   *
+   */
+  CompositeTransform( const Transform & );
+
+  /** \brief A lazy copy constructor
+   *
+   * The new SimpleITK object will reference to the same underlying ITK
+   * CompositeTransform. A deep-copy will be made when the object is modified.
+   */
+  CompositeTransform( const CompositeTransform & );
+
+  /** \brief Create a composite from a vector of Transform
+   *
+   * The CompositeTransform is constructed from deep copies of the
+   * Transforms. If the vector contains additional composite
+   * transforms, deep copies will be made and nested composite
+   * transforms will be constructed.
+   *
+   * An exception is thrown if the vector is empty.
+   */
+   explicit CompositeTransform(const std::vector<Transform> &);
+
+  ~CompositeTransform() override;
+
+  CompositeTransform &operator=( const CompositeTransform &);
+
+  /** Name of this class */
+  std::string GetName( ) const override  { return std::string("CompositeTransform");}
+
+
+  /** \brief Removes nested composite transforms
+   *
+   * If this transform contains additional composite transforms, then these
+   * nested composite transformed are removed, while preserving the order of the
+   * regular transforms and transferring ownership to the parent
+   * CompositeTransform.
+   *
+   * Nested composite transform may not be written to a file.
+   */
+  SITK_RETURN_SELF_TYPE_HEADER FlattenTransform();
+
+  /** \brief Add a transform to the back of the stack.
+   *
+   * A deep-copy of the transform is performed. The added transform will have
+   * the optimizable parameters, while the other parameters are part of the
+   * fixed parameters.
+   */
+  SITK_RETURN_SELF_TYPE_HEADER AddTransform( Transform t );
+
+  /** \brief The number of transforms in the stack */
+  unsigned int GetNumberOfTransforms() const;
+
+  /** \brief Remove all transforms from the stack. */
+  void ClearTransforms();
+
+  /** \brief Remove the active transform at the back.
+   *
+   * If the stack is empty an exception will be thrown.
+   */
+  void RemoveTransform();
+
+  /** \brief Get a copy of the back transform.
+   *
+   * If the stack is empty an exception will be thrown.
+   */
+  Transform GetBackTransform();
+
+  /** \brief Get a copy of a transform in the stack.
+   *
+   * If n is equal or greater than the number of transforms, then an exception
+   * will be thrown.
+   * */
+  Transform GetNthTransform(unsigned int n);
+
+protected:
+
+  void SetPimpleTransform( PimpleTransformBase * ) override;
+
+private:
+
+
+  struct MyVisitor
+  {
+    itk::TransformBase *transform;
+    CompositeTransform *that;
+    template< typename TransformType >
+    void operator() ( )
+    {
+      TransformType *t = dynamic_cast<TransformType*>(transform);
+      if (t)
+      {
+        that->InternalInitialization(t);
+        // set to null to stop trying dynamic_cast
+        transform = nullptr;
+      }
+    }
+  };
+
+  void InternalInitialization(itk::TransformBase *transform);
+
+  template<unsigned int NDimension>
+  void InternalInitialization(itk::CompositeTransform< double, NDimension > *);
+
+  template <unsigned int NDimensions>
+  void InternalInitialization(itk::Transform<double, NDimensions, NDimensions> *);
+
+  std::function<void ()> m_pfFlattenTransform;
+  std::function<void ( Transform & )> m_pfAddTransform;
+  std::function<void ()> m_pfRemoveTransform;
+  std::function<Transform ()> m_pfBackTransform;
+  std::function<Transform (unsigned int)> m_pfGetNthTransform;
+  std::function<unsigned int ()> m_pfGetNumberOfTransforms;
+  std::function<void ()> m_pfClearTransformQueue;
+};
+
+}
+}
+
+#endif // sitkCompositeTransform_h

--- a/Code/Common/include/sitkDisplacementFieldTransform.h
+++ b/Code/Common/include/sitkDisplacementFieldTransform.h
@@ -112,8 +112,6 @@ protected:
 
 private:
 
-  using Superclass::AddTransform;
-
   struct MyVisitor
   {
     itk::TransformBase *transform;

--- a/Code/Common/include/sitkEuler2DTransform.h
+++ b/Code/Common/include/sitkEuler2DTransform.h
@@ -78,8 +78,6 @@ protected:
 
 private:
 
-  using Superclass::AddTransform;
-
   void InternalInitialization(itk::TransformBase *transform);
 
   template <typename TransformType>

--- a/Code/Common/include/sitkEuler3DTransform.h
+++ b/Code/Common/include/sitkEuler3DTransform.h
@@ -89,8 +89,6 @@ void SetPimpleTransform( PimpleTransformBase *pimpleTransform ) override;
 
 private:
 
-using Superclass::AddTransform;
-
 void InternalInitialization(itk::TransformBase *transform);
 
 template <typename TransformType>

--- a/Code/Common/include/sitkScaleSkewVersor3DTransform.h
+++ b/Code/Common/include/sitkScaleSkewVersor3DTransform.h
@@ -95,8 +95,6 @@ protected:
 
 private:
 
-  using Superclass::AddTransform;
-
   void InternalInitialization(itk::TransformBase *transform);
 
   template <typename TransformType>

--- a/Code/Common/include/sitkScaleTransform.h
+++ b/Code/Common/include/sitkScaleTransform.h
@@ -70,8 +70,6 @@ protected:
 
 private:
 
-  using Superclass::AddTransform;
-
   struct MyVisitor
   {
     itk::TransformBase *transform;

--- a/Code/Common/include/sitkScaleVersor3DTransform.h
+++ b/Code/Common/include/sitkScaleVersor3DTransform.h
@@ -91,8 +91,6 @@ protected:
 
 private:
 
-  using Superclass::AddTransform;
-
   void InternalInitialization(itk::TransformBase *transform);
 
   template <typename TransformType>

--- a/Code/Common/include/sitkSimilarity2DTransform.h
+++ b/Code/Common/include/sitkSimilarity2DTransform.h
@@ -82,8 +82,6 @@ protected:
 
 private:
 
-  using Superclass::AddTransform;
-
   void InternalInitialization(itk::TransformBase *transform);
 
   template <typename TransformType>

--- a/Code/Common/include/sitkSimilarity3DTransform.h
+++ b/Code/Common/include/sitkSimilarity3DTransform.h
@@ -89,8 +89,6 @@ void SetPimpleTransform( PimpleTransformBase *pimpleTransform ) override;
 
 private:
 
-using Superclass::AddTransform;
-
 void InternalInitialization(itk::TransformBase *transform);
 
 template <typename TransformType>

--- a/Code/Common/include/sitkTransform.h
+++ b/Code/Common/include/sitkTransform.h
@@ -175,21 +175,6 @@ public:
   /** Get the number of fixed parameters */
   unsigned int GetNumberOfFixedParameters( ) const;
 
-  // Make composition
-  SITK_RETURN_SELF_TYPE_HEADER AddTransform( Transform t );
-
-
-  /** \brief Remove nested composite transforms
-   *
-   * This method has no effect on non-composite transforms.
-   *
-   * If this transform is a composite which contains another nested
-   * composite transform, then the nested composite's transforms are
-   * placed into this transform. Nested composite transform may not be
-   * written to a file.
-   */
-   SITK_RETURN_SELF_TYPE_HEADER FlattenTransform();
-
   /** Apply transform to a point.
    *
    * The dimension of the point must match the transform.

--- a/Code/Common/include/sitkTransform.h
+++ b/Code/Common/include/sitkTransform.h
@@ -122,7 +122,7 @@ public:
    *
    * \deprecated This constructor will be removed in future releases.
    */
-  Transform( Image &displacement, TransformEnum type = sitkDisplacementField );
+  explicit Transform( Image &displacement, TransformEnum type = sitkDisplacementField );
 
   virtual ~Transform( );
 

--- a/Code/Common/include/sitkTransform.h
+++ b/Code/Common/include/sitkTransform.h
@@ -30,7 +30,9 @@ namespace itk
 template< typename TScalar > class TransformBaseTemplate;
 using TransformBase = TransformBaseTemplate<double>;
 
+#if !defined(SWIG)
 template< typename TScalar, unsigned int NDimension> class CompositeTransform;
+#endif
 
 namespace simple
 {

--- a/Code/Common/include/sitkTranslationTransform.h
+++ b/Code/Common/include/sitkTranslationTransform.h
@@ -62,8 +62,6 @@ void SetPimpleTransform( PimpleTransformBase *pimpleTransform ) override;
 
 private:
 
-using Superclass::AddTransform;
-
 struct MyVisitor
 {
   itk::TransformBase *transform;

--- a/Code/Common/include/sitkTranslationTransform.h
+++ b/Code/Common/include/sitkTranslationTransform.h
@@ -46,7 +46,7 @@ explicit TranslationTransform(unsigned int dimensions,
 
 TranslationTransform( const TranslationTransform & );
 
-TranslationTransform( const Transform & );
+explicit TranslationTransform( const Transform & );
 
 TranslationTransform &operator=( const TranslationTransform & );
 

--- a/Code/Common/include/sitkVersorRigid3DTransform.h
+++ b/Code/Common/include/sitkVersorRigid3DTransform.h
@@ -86,8 +86,6 @@ protected:
 
 private:
 
-  using Superclass::AddTransform;
-
   void InternalInitialization(itk::TransformBase *transform);
 
   template <typename TransformType>

--- a/Code/Common/include/sitkVersorTransform.h
+++ b/Code/Common/include/sitkVersorTransform.h
@@ -82,8 +82,6 @@ protected:
 
 private:
 
-  using Superclass::AddTransform;
-
   void InternalInitialization(itk::TransformBase *transform);
 
   template <typename TransformType>

--- a/Code/Common/src/CMakeLists.txt
+++ b/Code/Common/src/CMakeLists.txt
@@ -3,6 +3,7 @@ set ( SimpleITKCommonSource
   sitkImageExplicit.cxx
   sitkProcessObject.cxx
   sitkTransform.cxx
+  sitkCompositeTransform.cxx
   sitkAffineTransform.cxx
   sitkBSplineTransform.cxx
   sitkDisplacementFieldTransform.cxx

--- a/Code/Common/src/sitkCompositeTransform.cxx
+++ b/Code/Common/src/sitkCompositeTransform.cxx
@@ -1,0 +1,223 @@
+/*=========================================================================
+*
+*  Copyright NumFOCUS
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*         http://www.apache.org/licenses/LICENSE-2.0.txt
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*=========================================================================*/
+#include "sitkCompositeTransform.h"
+#include "sitkTransformHelper.hxx"
+#include "sitkPimpleTransform.hxx"
+
+#include "itkCompositeTransform.h"
+
+namespace itk
+{
+namespace simple
+{
+
+CompositeTransform::~CompositeTransform() = default;
+
+CompositeTransform::CompositeTransform(unsigned int dimensions )
+    : Transform(dimensions, sitkComposite)
+
+{
+  Self::InternalInitialization(Self::GetITKBase());
+}
+
+
+CompositeTransform::CompositeTransform( const CompositeTransform &arg )
+    : Transform(arg)
+{
+  Self::InternalInitialization(Self::GetITKBase());
+}
+
+
+CompositeTransform::CompositeTransform( const Transform &arg )
+    : Transform(arg)
+{
+  Self::InternalInitialization(Self::GetITKBase());
+}
+
+CompositeTransform::CompositeTransform( const std::vector<Transform> &transformList )
+    : Transform(transformList.at(0).GetDimension(),sitkComposite)
+{
+  Self::InternalInitialization(Self::GetITKBase());
+
+  for( auto &t : transformList)
+  {
+    Self::AddTransform(t);
+  }
+}
+
+CompositeTransform &CompositeTransform::operator=( const CompositeTransform &arg )
+{
+  Superclass::operator=(arg);
+  return *this;
+}
+
+void CompositeTransform::SetPimpleTransform( PimpleTransformBase *pimpleTransform )
+{
+  Superclass::SetPimpleTransform(pimpleTransform);
+  Self::InternalInitialization(this->GetITKBase());
+}
+
+void CompositeTransform::InternalInitialization(itk::TransformBase *transform)
+{
+
+  MyVisitor visitor;
+  visitor.transform = transform;
+  visitor.that = this;
+
+  // The list is traversed from the end to the beginning. The transform is first tested
+  // to see if it is an itk::CompositeTransform, then if it is a regular transform
+  // a CompositeTransform will be constructed and the transform added to it.
+  typedef typelist::MakeTypeList<
+      itk::CompositeTransform<double, 3>,
+      itk::CompositeTransform<double, 2>,
+      itk::Transform<double, 2, 2>,
+      itk::Transform<double, 3, 3> >::Type TransformTypeList;
+
+  typelist::Visit<TransformTypeList> callInternalInitialization;
+
+  // explicitly remove all function pointer with reference to prior transform
+  this->m_pfFlattenTransform = nullptr;
+  this->m_pfAddTransform = nullptr;
+  this->m_pfGetNumberOfTransforms = nullptr;
+  this->m_pfClearTransformQueue = nullptr;
+
+  callInternalInitialization(visitor);
+
+  if ( this->m_pfFlattenTransform == nullptr)
+  {
+
+    sitkExceptionMacro("Transform is not of type " << this->GetName() << "!" );
+  }
+
+}
+
+
+CompositeTransform &CompositeTransform::AddTransform( Transform t )
+{
+  this->MakeUnique();
+  this->m_pfAddTransform(t);
+  return *this;
+}
+
+
+CompositeTransform &CompositeTransform::FlattenTransform()
+{
+  this->MakeUnique();
+  this->m_pfFlattenTransform();
+  return *this;
+}
+
+unsigned int CompositeTransform::GetNumberOfTransforms() const
+{
+  return this->m_pfGetNumberOfTransforms();
+}
+
+void CompositeTransform::ClearTransforms()
+{
+  this->MakeUnique();
+  return this->m_pfClearTransformQueue();
+}
+
+void CompositeTransform::RemoveTransform()
+{
+  if (this->GetNumberOfTransforms() > 0)
+  {
+    this->MakeUnique();
+    return this->m_pfRemoveTransform();
+  }
+  else
+  {
+    sitkExceptionMacro("No transform to remote");
+  }
+}
+
+Transform CompositeTransform::GetBackTransform()
+{
+  if (this->GetNumberOfTransforms() > 0)
+  {
+    Transform tx = this->m_pfBackTransform();
+    tx.MakeUnique();
+    return tx;
+  }
+  else
+  {
+    sitkExceptionMacro("No transforms");
+  }
+}
+
+
+
+Transform CompositeTransform::GetNthTransform(unsigned int n)
+{
+  if (this->GetNumberOfTransforms() <= n) {
+    sitkExceptionMacro("CompositeTransform index out of range");
+  }
+  else
+    {
+    Transform tx = this->m_pfGetNthTransform(n);
+    tx.MakeUnique();
+    return tx;
+  }
+}
+
+
+template<unsigned int NDimension>
+void CompositeTransform::InternalInitialization(itk::CompositeTransform< double, NDimension > *t)
+{
+  using TransformType = itk::CompositeTransform< double, NDimension >;
+  m_pfFlattenTransform = [t]() { return t->FlattenTransformQueue(); };
+  m_pfGetNumberOfTransforms = [t]() {return t->GetNumberOfTransforms();};
+  m_pfClearTransformQueue = [t]() {return t->ClearTransformQueue();};
+  m_pfRemoveTransform = [t]() {return t->RemoveTransform();};
+  m_pfBackTransform = [t]() {return Transform(t->GetTransformQueue().back());};
+  m_pfGetNthTransform = [t](unsigned int n) {return Transform(t->GetNthTransform(n));};
+  m_pfAddTransform = [t](Transform add)
+  {
+    if ( add.GetDimension() != TransformType::InputSpaceDimension )
+    {
+      sitkExceptionMacro( "Transform  argument has dimension " << add.GetDimension()
+                                                              << " does not match this dimension of " << TransformType::InputSpaceDimension );
+    }
+
+    // perform deep-copy to prevent aliasing.
+    add.MakeUnique();
+    auto baseAdd = dynamic_cast<itk::Transform<double, NDimension, NDimension> *>(add.GetITKBase());
+    t->AddTransform( baseAdd );
+    t->SetAllTransformsToOptimizeOff();
+    t->SetOnlyMostRecentTransformToOptimizeOn();
+  };
+
+}
+
+template <unsigned int NDimensions>
+void CompositeTransform::InternalInitialization(itk::Transform<double, NDimensions, NDimensions> *tx)
+{
+  // Construct a new itk::CompositeTransform and hold the argument transform.
+  using CompositeTransformType = itk::CompositeTransform<double, NDimensions>;
+
+  auto ctx = CompositeTransformType::New();
+
+  ctx->AddTransform(tx);
+
+  // Call InternalInitialization again with a CompositeTransform the second time.
+  Self::SetPimpleTransform(new PimpleTransform<CompositeTransformType >(ctx));
+}
+
+
+}
+}

--- a/Code/Common/src/sitkTransform.cxx
+++ b/Code/Common/src/sitkTransform.cxx
@@ -396,19 +396,11 @@ void Transform::SetPimpleTransform( PimpleTransformBase *pimpleTransform )
             }
           }
 
-
-        if ( compositeTransform->IsTransformQueueEmpty() )
-          {
-
-          // Load an identity transform in case no transforms are loaded.
-          using IdentityTransformType = itk::IdentityTransform<double, VDimension>;
-          typename IdentityTransformType::Pointer identityTransform = IdentityTransformType::New();
-
-          compositeTransform->AddTransform( identityTransform );
-          }
-
-        compositeTransform->SetAllTransformsToOptimizeOff();
-        compositeTransform->SetOnlyMostRecentTransformToOptimizeOn();
+        if (!compositeTransform->IsTransformQueueEmpty())
+        {
+            compositeTransform->SetAllTransformsToOptimizeOff();
+            compositeTransform->SetOnlyMostRecentTransformToOptimizeOn();
+        }
 
         temp = new PimpleTransform<itk::CompositeTransform<double, VDimension> >( compositeTransform );
 

--- a/Code/Common/src/sitkTransform.cxx
+++ b/Code/Common/src/sitkTransform.cxx
@@ -477,19 +477,6 @@ void Transform::SetPimpleTransform( PimpleTransformBase *pimpleTransform )
     return this->m_PimpleTransform->GetNumberOfFixedParameters();
   }
 
-  Transform &Transform::AddTransform( Transform t )
-  {
-    assert( m_PimpleTransform );
-    this->MakeUnique();
-    // this returns a pointer which may be the same or a new object
-    PimpleTransformBase *temp = this->m_PimpleTransform->AddTransform( t );
-    if ( temp != this->m_PimpleTransform )
-      {
-      this->SetPimpleTransform(temp);
-      }
-    return *this;
-  }
-
   std::vector< double > Transform::TransformPoint( const std::vector< double > &point ) const
   {
     assert( m_PimpleTransform );
@@ -545,14 +532,6 @@ std::vector< double > Transform::TransformVector( const std::vector< double > &v
       sitkExceptionMacro("Unable to create inverse!");
       }
     return tx;
-  }
-
-  Transform &Transform::FlattenTransform()
-  {
-    assert( m_PimpleTransform );
-    this->MakeUnique();
-    this->m_PimpleTransform->FlattenTransform();
-    return *this;
   }
 
 

--- a/Examples/ImageRegistrationMethodDisplacement1/ImageRegistrationMethodDisplacement1.R
+++ b/Examples/ImageRegistrationMethodDisplacement1/ImageRegistrationMethodDisplacement1.R
@@ -68,17 +68,17 @@ R$SetOptimizerAsGradientDescent(learningRate=1.0,
                                 estimateLearningRate = 'EachIteration')
 R$SetOptimizerScalesFromPhysicalShift()
 
-R$SetInitialTransform(initialTx, inPlace=TRUE)
+R$SetInitialTransform(initialTx)
 
 R$SetInterpolator('sitkLinear')
 
 R$AddCommand( 'sitkIterationEvent', function() commandIteration(R) )
 R$AddCommand( 'sitkMultiResolutionIterationEvent', function() commandMultiIteration(R) )
 
-outTx <- R$Execute(fixed, moving)
+outTx1 <- R$Execute(fixed, moving)
 
 cat("-------\n")
-outTx
+outTx1
 cat("Optimizer stop condition:", R$GetOptimizerStopConditionDescription(), '\n')
 cat("Iteration:", R$GetOptimizerIteration(), '\n')
 cat("Metric value:", R$GetMetricValue(), '\n')
@@ -91,7 +91,7 @@ rm(displacementField)
 displacementTx$SetSmoothingGaussianOnUpdate(varianceForUpdateField=0.0,
                                             varianceForTotalField=1.5)
 
-R$SetMovingInitialTransform(outTx)
+R$SetMovingInitialTransform(outTx1)
 R$SetInitialTransform(displacementTx, inPlace=TRUE)
 
 R$SetMetricAsANTSNeighborhoodCorrelation(4)
@@ -107,12 +107,18 @@ R$SetOptimizerAsGradientDescent(learningRate=1,
                                 convergenceWindowSize=10,
                                 estimateLearningRate = 'EachIteration')
 
-outTx$AddTransform( R$Execute(fixed, moving) )
+R$Execute(fixed, moving)
+
+
 
 cat("-------\n")
-outTx
+displacementTx
 cat("Optimizer stop condition:", R$GetOptimizerStopConditionDescription(), '\n')
 cat("Iteration:", R$GetOptimizerIteration(), '\n')
 cat("Metric value:", R$GetMetricValue(), '\n')
+
+outTx <- CompositeTransform(outTx1$GetDimension())
+outTx$AddTransform(outTx1)
+outTx$AddTransform(displacementTx)
 
 WriteTransform(outTx,  args[[3]])

--- a/Examples/ImageRegistrationMethodDisplacement1/ImageRegistrationMethodDisplacement1.cxx
+++ b/Examples/ImageRegistrationMethodDisplacement1/ImageRegistrationMethodDisplacement1.cxx
@@ -137,7 +137,7 @@ int main(int argc, char *argv[])
   }
   R.SetOptimizerScalesFromPhysicalShift();
 
-  R.SetInitialTransform(initialTx, true);
+  R.SetInitialTransform(initialTx);
 
   R.SetInterpolator(sitk::sitkLinear);
 
@@ -147,10 +147,10 @@ int main(int argc, char *argv[])
   MultiResolutionIterationUpdate cmd2(R);
   R.AddCommand( sitk::sitkMultiResolutionIterationEvent, cmd2);
 
-  sitk::Transform outTx = R.Execute( fixed, moving );
+  sitk::Transform outTx1 = R.Execute( fixed, moving );
 
   std::cout << "-------" << std::endl;
-  std::cout << outTx.ToString() << std::endl;
+  std::cout << outTx1.ToString() << std::endl;
   std::cout << "Optimizer stop condition: " << R.GetOptimizerStopConditionDescription() << std::endl;
   std::cout << " Iteration: " << R.GetOptimizerIteration() << std::endl;
   std::cout << " Metric value: " << R.GetMetricValue() << std::endl;
@@ -166,7 +166,7 @@ int main(int argc, char *argv[])
 
 
 
-  R.SetMovingInitialTransform(outTx);
+  R.SetMovingInitialTransform(outTx1);
   R.SetInitialTransform(displacementTx, true);
 
   R.SetMetricAsANTSNeighborhoodCorrelation(4);
@@ -197,15 +197,17 @@ int main(int argc, char *argv[])
                                    estimateLearningRate
     );
   }
-  outTx.AddTransform( R.Execute(fixed, moving) );
+  R.Execute(fixed, moving);
+
 
   std::cout << "-------" << std::endl;
-  std::cout << outTx.ToString() << std::endl;
+  std::cout << displacementTx.ToString() << std::endl;
   std::cout << "Optimizer stop condition: " << R.GetOptimizerStopConditionDescription() << std::endl;
   std::cout << " Iteration: " << R.GetOptimizerIteration() << std::endl;
   std::cout << " Metric value: " << R.GetMetricValue() << std::endl;
 
 
+  sitk::CompositeTransform outTx( {outTx1, displacementTx} );
   sitk::WriteTransform(outTx, argv[3]);
 
   return 0;

--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -55,7 +55,7 @@ set(ITK_GIT_REPOSITORY "${git_protocol}://github.com/InsightSoftwareConsortium/I
 mark_as_advanced(ITK_GIT_REPOSITORY)
 sitk_legacy_naming(ITK_GIT_REPOSITORY ITK_REPOSITORY)
 
-set(_DEFAULT_ITK_GIT_TAG "1ab2baa9ab21da47ff5a13a49f969a537cc23f2d")
+set(_DEFAULT_ITK_GIT_TAG "6eb2bb0005da1d32065dd91b44b3796d44a84f0f")
 set(ITK_GIT_TAG "${_DEFAULT_ITK_GIT_TAG}" CACHE STRING "Tag in ITK git repo")
 mark_as_advanced(ITK_GIT_TAG)
 set(ITK_TAG_COMMAND GIT_TAG "${ITK_GIT_TAG}")

--- a/Testing/Unit/R/RTransformTests.R
+++ b/Testing/Unit/R/RTransformTests.R
@@ -29,13 +29,14 @@ compositeAddTransformTest <- function()
   tx2 <- c(3,4)
   translation2 <- TranslationTransform(dimension, tx2)
 
-  composite_transform <- Transform(translation1)
+  composite_transform <- CompositeTransform(translation1)
   dummy <- composite_transform$AddTransform(translation2)
   if (!is.null(dummy))
   {
     cat("failure in", fname, "\n")
     quit(save="no", status=1)
    }
+
 }
 
 translationTest()

--- a/Wrapping/Common/SimpleITK_Common.i
+++ b/Wrapping/Common/SimpleITK_Common.i
@@ -96,6 +96,7 @@ namespace std
   %template(VectorFloat) vector<float>;
   %template(VectorDouble) vector<double>;
   %template(VectorOfImage) vector< itk::simple::Image >;
+  %template(VectorOfTransform) vector< itk::simple::Transform >;
   %template(VectorUIntList) vector< vector<unsigned int> >;
   %template(VectorString) vector< std::string >;
 
@@ -172,6 +173,7 @@ namespace std
 %include "sitkTranslationTransform.h"
 %include "sitkVersorTransform.h"
 %include "sitkVersorRigid3DTransform.h"
+%include "sitkCompositeTransform.h"
 
 
 // Basic Filter Base

--- a/Wrapping/Python/sitkTransform.i
+++ b/Wrapping/Python/sitkTransform.i
@@ -59,6 +59,13 @@
           elif downcasted.__class__ is BSplineTransform:
             args = (tuple(downcasted.GetCoefficientImages()), downcasted.GetOrder())
             S = (version, )
+          elif downcasted.__class__ == CompositeTransform:
+            if downcasted.GetNumberOfTransforms() > 0:
+               args = ([ downcasted.GetNthTransform(n) for n in range(downcasted.GetNumberOfTransforms()) ], )
+            else:
+               args = (downcasted.GetDimension(),)
+            S = (version, )
+
           else:
             args = ()
             if downcasted.__class__ in [AffineTransform, ScaleTransform, TranslationTransform]:
@@ -88,7 +95,7 @@
                 sitkScaleSkewVersor: ( None, ScaleSkewVersor3DTransform),
                 sitkScaleVersor: ( None, ScaleVersor3DTransform),
                 sitkAffine: (AffineTransform, AffineTransform),
-                sitkComposite: (Transform, Transform),
+                sitkComposite: (CompositeTransform, CompositeTransform),
                 sitkDisplacementField: (DisplacementFieldTransform, DisplacementFieldTransform),
                 sitkBSplineTransform: (BSplineTransform, BSplineTransform)
             }


### PR DESCRIPTION
This PR removes the composite related functionality from the Transform base class.

Closes #1112 by adding pickling for CompositeTransforms.