### PR TITLE
Return sitkBSplineTransform for b-splines with non-default order

### DIFF
--- a/Code/Common/src/sitkPimpleTransform.hxx
+++ b/Code/Common/src/sitkPimpleTransform.hxx
@@ -463,8 +463,8 @@ public:
   template <typename VScalar, unsigned int VDimension>
     TransformEnum GetTransformEnum( const itk::CompositeTransform< VScalar, VDimension > *) const {return sitkComposite;}
 
-  template <typename VScalar, unsigned int VDimension>
-    TransformEnum GetTransformEnum( const itk::BSplineTransform< VScalar, VDimension > *) const {return sitkBSplineTransform;}
+  template <typename VScalar, unsigned int VDimension, unsigned int VSplineOrder>
+    TransformEnum GetTransformEnum( const itk::BSplineTransform< VScalar, VDimension, VSplineOrder > *) const {return sitkBSplineTransform;}
 
   template <typename VScalar, unsigned int VDimension>
     TransformEnum GetTransformEnum( const itk::DisplacementFieldTransform< VScalar, VDimension > *) const {return sitkDisplacementField;}

--- a/Testing/Unit/Python/sitkTransformTests.py
+++ b/Testing/Unit/Python/sitkTransformTests.py
@@ -222,13 +222,14 @@ class TransformTests(unittest.TestCase):
 
 
     def test_downcast(self):
-        """Test downcasting"""
+        """Test Downcast method with minimally constructed transforms"""
 
         transforms = {
             'AffineTransform': (3,),
             'AffineTransform': (2,),
             'BSplineTransform': (3, 3),
             'BSplineTransform': (2, 3),
+            'BSplineTransform': (2, 2),
             'DisplacementFieldTransform': (3,),
             'DisplacementFieldTransform': (2,),
             'Euler2DTransform': (),

--- a/Testing/Unit/sitkTransformTests.cxx
+++ b/Testing/Unit/sitkTransformTests.cxx
@@ -584,6 +584,15 @@ TEST(TransformTest, ReadTransformConvert) {
   EXPECT_EQ(tx.GetOrder(), 3u);
   EXPECT_EQ(sitk::sitkBSplineTransform, tx.GetTransformEnum());
   }
+  {
+  sitk::BSplineTransform tx(3,2);
+  EXPECT_EQ(sitk::sitkBSplineTransform, tx.GetTransformEnum());
+  sitk::WriteTransform(tx, filename);
+  EXPECT_NO_THROW( tx = sitk::BSplineTransform( sitk::ReadTransform(filename) ) );
+  EXPECT_EQ(tx.GetDimension(), 3u);
+  EXPECT_EQ(tx.GetOrder(), 2u);
+  EXPECT_EQ(sitk::sitkBSplineTransform, tx.GetTransformEnum());
+  }
 
 }
 


### PR DESCRIPTION
The sitkUnknowTransform was being returned because of the VSplineOrder
was not templated in the internal GetTransformEnum method.