### PR TITLE
Remove ITKv4 code conditionally used by ITK version

### DIFF
--- a/Code/Common/include/sitkTransform.h
+++ b/Code/Common/include/sitkTransform.h
@@ -27,16 +27,8 @@
 namespace itk
 {
 
-// Forward declaration for pointer
-// After ITK_VERSION 4.5 (Actually after June 20th, 2013) the ITK Transform
-// classes are now templated.  This requires forward declarations to be defined
-// differently.
-#if ( ( SITK_ITK_VERSION_MAJOR == 4 ) && ( SITK_ITK_VERSION_MINOR < 5 ) )
-class TransformBase;
-#else
 template< typename TScalar > class TransformBaseTemplate;
 using TransformBase = TransformBaseTemplate<double>;
-#endif
 
 template< typename TScalar, unsigned int NDimension> class CompositeTransform;
 

--- a/Code/Common/src/sitkPimpleTransform.hxx
+++ b/Code/Common/src/sitkPimpleTransform.hxx
@@ -261,65 +261,6 @@ public:
       sitkExceptionMacro( "SetIdentity does is not implemented for transforms of type " << self->GetNameOfClass() );
     }
 
-#if ( ( SITK_ITK_VERSION_MAJOR == 4 ) && ( SITK_ITK_VERSION_MINOR < 7 ) )
-  template <typename UScalar, unsigned int UDimension>
-  void SetIdentity( itk::DisplacementFieldTransform<UScalar, UDimension> *self)
-      {
-        using DFTType = itk::DisplacementFieldTransform<UScalar, UDimension>;
-        typename DFTType::DisplacementFieldType *displacementField;
-
-        displacementField = self->GetModifiableDisplacementField();
-        if (displacementField)
-          {
-          displacementField->FillBuffer(typename DFTType::OutputVectorType(0.0));
-          }
-        displacementField = self->GetModifiableInverseDisplacementField();
-        if (displacementField)
-          {
-          displacementField->FillBuffer(typename DFTType::OutputVectorType(0.0));
-          }
-      }
-
-  template <typename UScalar, unsigned int UDimension>
-  void SetIdentity( itk::BSplineSmoothingOnUpdateDisplacementFieldTransform<UScalar, UDimension> *self)
-      {
-        using DFTType = itk::DisplacementFieldTransform<UScalar, UDimension>;
-        typename DFTType::DisplacementFieldType *displacementField;
-
-        displacementField = self->GetModifiableDisplacementField();
-        if (displacementField)
-          {
-          displacementField->FillBuffer(typename DFTType::OutputVectorType(0.0));
-          }
-        displacementField = self->GetModifiableInverseDisplacementField();
-        if (displacementField)
-          {
-          displacementField->FillBuffer(typename DFTType::OutputVectorType(0.0));
-          }
-      }
-
-  template <typename UScalar, unsigned int UDimension>
-  void SetIdentity( itk::GaussianSmoothingOnUpdateDisplacementFieldTransform<UScalar, UDimension> *self)
-      {
-        using DFTType = itk::DisplacementFieldTransform<UScalar, UDimension>;
-        typename DFTType::DisplacementFieldType *displacementField;
-
-        displacementField = self->GetModifiableDisplacementField();
-        if (displacementField)
-          {
-          displacementField->FillBuffer(typename DFTType::OutputVectorType(0.0));
-          }
-        displacementField = self->GetModifiableInverseDisplacementField();
-        if (displacementField)
-          {
-          displacementField->FillBuffer(typename DFTType::OutputVectorType(0.0));
-          }
-      }
-
-
-#endif
-
-
   void FlattenTransform() override
     {
       this->FlattenTransform(this->m_Transform.GetPointer());

--- a/Code/Common/src/sitkProcessObject.cxx
+++ b/Code/Common/src/sitkProcessObject.cxx
@@ -398,12 +398,7 @@ void ProcessObject::PreUpdate(itk::ProcessObject *p)
   assert(p);
 
   // propagate number of threads
-  #if ITK_VERSION_MAJOR < 5
-  p->SetNumberOfThreads(this->GetNumberOfThreads());
-  #else
   p->SetNumberOfWorkUnits(this->GetNumberOfThreads());
-  #endif
-
 
   try
     {

--- a/Code/Registration/src/sitkImageRegistrationMethod.cxx
+++ b/Code/Registration/src/sitkImageRegistrationMethod.cxx
@@ -913,12 +913,7 @@ Transform ImageRegistrationMethod::ExecuteInternal ( const Image &inFixed, const
   //
   // Configure Optimizer
   //
-  #if ITK_VERSION_MAJOR < 5
-  optimizer->SetNumberOfThreads(this->GetNumberOfThreads());
-  #else
   optimizer->SetNumberOfWorkUnits(this->GetNumberOfThreads());
-  #endif
-
   registration->SetOptimizer( optimizer );
 
   if ( !m_OptimizerWeights.empty() )
@@ -1115,12 +1110,7 @@ ImageRegistrationMethod::SetupMetric(
   const unsigned int ImageDimension = FixedImageType::ImageDimension;
   using SpatialObjectMaskType = itk::SpatialObject<ImageDimension>;
 
-  #if ITK_VERSION_MAJOR < 5
-  metric->SetMaximumNumberOfThreads(this->GetNumberOfThreads());
-  #else
   metric->SetMaximumNumberOfWorkUnits(this->GetNumberOfThreads());
-  #endif
-
 
   metric->SetUseFixedImageGradientFilter( m_MetricUseFixedImageGradientFilter );
   metric->SetUseMovingImageGradientFilter( m_MetricUseMovingImageGradientFilter );


### PR DESCRIPTION
ITK version 5 is now required, so this code can no longer be
successfully used.