### PR TITLE
Update ProcessObject with ITKv5 threading models

### DIFF
--- a/Code/Common/include/sitkProcessObject.h
+++ b/Code/Common/include/sitkProcessObject.h
@@ -116,14 +116,6 @@ namespace itk {
       static bool GetGlobalWarningDisplay();
       /**@}*/
 
-      /** Set the number of threads that all new process objects are
-       *  initialized with.
-       * @{
-       */
-      static void SetGlobalDefaultNumberOfThreads(unsigned int n);
-      static unsigned int GetGlobalDefaultNumberOfThreads();
-      /**@}*/
-
       /** \brief Access the global tolerance to determine congruent spaces.
        *
        * The default tolerance is governed by the
@@ -143,13 +135,83 @@ namespace itk {
       static void SetGlobalDefaultDirectionTolerance(double);
       /**@}*/
 
+
+      /** \brief Set/Get the default threader used for process objects.
+       *
+       * The possible available multi-threaders are:
+       *  - "POOL" itk::PoolMultiThreader
+       *  - "TBB" itk::TBBThreader (optional)
+       *  - "PLATFORM" itk::PlatformMultiThreader
+       *
+       * The default and the available multi-threaders are
+       * dependent upon ITK's configuration. See the ITK
+       * documentation for more details about the behavior of the
+       * multi-threaders.
+       *
+       * The environment variable "ITK_GLOBAL_DEFAULT_THREADER" can be
+       * used to initialize this value.
+       *
+       * The set method returns true when the threader string is valid
+       * and ITK's default is updated, otherwise false is returned. The
+       * threader argument is not case sensitive.
+       *
+       * \sa itk::MultiThreaderBase itk::PoolMultiThreader
+       * itk::TBBThreader itk::PlatformMultiThreader
+       * @{
+       */
+      static bool SetGlobalDefaultThreader(const std::string &threader);
+      static std::string GetGlobalDefaultThreader();
+      /**@{*/
+
+      /** Set the number of threads with which new process objects are
+       *  initialized.
+       *
+       * If the environment variable
+       * "ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS" is defined, then this
+       * value is initialized as defined in the
+       * environment. Otherwise, the value will be initialized with
+       * the number of virtual CPUs on the system.
+       *
+       * \note After the "POOL" multi-thread initially constructs the
+       * thread pool, this value will has no effect on the thread pool.
+       * @{
+       */
+      static void SetGlobalDefaultNumberOfThreads(unsigned int n);
+      static unsigned int GetGlobalDefaultNumberOfThreads();
+      /**@}*/
+
       /** The number of threads used when executing a filter if the
-       * filter is multi-threaded
+       * filter is multi-threaded.
+       *
+       * With ITK version 5, this parameter now corresponds to
+       * itk::MultiThreaderBase::SetMaximumNumberOfThreads and the
+       * corresponding get method. The is clamped to be limited by the
+       * "global" maximum.
+       *
+       * \note The "POOL" multi-threader cannot reduce the number of
+       * threads. As the "POOL" multi-threader  has a single instance
+       * of a thread pool, the number of threads will increased for
+       * subsequent processes.
        * @{
        */
       virtual void SetNumberOfThreads(unsigned int n);
       virtual unsigned int GetNumberOfThreads() const;
       /**@}*/
+
+      /** The work (image) is requested to be divided into this number
+       * of sub-tasks.
+       *
+       * If zero then, the default number from the process object and
+       * the multi-threader will be used.
+       *
+       * \note The "PLATFORM" multi-threader set the number of threads
+       * equal to the number of work units.
+       * @{
+       */
+      virtual void SetNumberOfWorkUnits(unsigned int n);
+      virtual unsigned int GetNumberOfWorkUnits() const;
+      /**@}*/
+
 
       /** \brief Add a Command Object to observer the event.
        *
@@ -348,6 +410,7 @@ namespace itk {
       bool m_Debug;
 
       unsigned int m_NumberOfThreads;
+      unsigned int m_NumberOfWorkUnits;
 
       std::list<EventCommand> m_Commands;
 

--- a/Code/Registration/src/sitkImageRegistrationMethod.cxx
+++ b/Code/Registration/src/sitkImageRegistrationMethod.cxx
@@ -913,7 +913,10 @@ Transform ImageRegistrationMethod::ExecuteInternal ( const Image &inFixed, const
   //
   // Configure Optimizer
   //
-  optimizer->SetNumberOfWorkUnits(this->GetNumberOfThreads());
+  if( this->GetNumberOfWorkUnits() > 0 )
+    {
+    optimizer->SetNumberOfWorkUnits(this->GetNumberOfWorkUnits());
+    }
   registration->SetOptimizer( optimizer );
 
   if ( !m_OptimizerWeights.empty() )
@@ -1110,7 +1113,10 @@ ImageRegistrationMethod::SetupMetric(
   const unsigned int ImageDimension = FixedImageType::ImageDimension;
   using SpatialObjectMaskType = itk::SpatialObject<ImageDimension>;
 
-  metric->SetMaximumNumberOfWorkUnits(this->GetNumberOfThreads());
+  if (this->GetNumberOfWorkUnits() > 0)
+    {
+    metric->SetMaximumNumberOfWorkUnits(this->GetNumberOfWorkUnits());
+    }
 
   metric->SetUseFixedImageGradientFilter( m_MetricUseFixedImageGradientFilter );
   metric->SetUseMovingImageGradientFilter( m_MetricUseMovingImageGradientFilter );

--- a/Testing/Unit/sitkCommonTests.cxx
+++ b/Testing/Unit/sitkCommonTests.cxx
@@ -27,8 +27,10 @@
 #include <sitkVersionConfig.h>
 #include <itkConfigure.h>
 
+#include <cctype>
 
-TEST( VersionTest, VersoinTest)
+
+TEST( VersionTest, VersionTest)
 {
   using Version = itk::simple::Version;
 
@@ -580,6 +582,28 @@ TEST( ProcessObject, Command_Ownership ) {
   EXPECT_EQ(5,destroyedCount);
 
 
+}
+
+TEST( ProcessObject, Threads )
+{
+  namespace sitk = itk::simple;
+
+  sitk::CastImageFilter po;
+
+  EXPECT_EQ( sitk::ProcessObject::GetGlobalDefaultNumberOfThreads(), po.GetNumberOfThreads() );
+
+
+  auto strupper = [](std::string s) {
+    std::transform( s.begin(), s.end(), s.begin(), [] ( char c ) { return (std::toupper( c ) ); } );
+    return s;
+  };
+
+  EXPECT_TRUE( sitk::ProcessObject::SetGlobalDefaultThreader("PLATFORM") );
+  EXPECT_EQ( "PLATFORM", strupper(sitk::ProcessObject::GetGlobalDefaultThreader()) );
+
+
+  EXPECT_TRUE( sitk::ProcessObject::SetGlobalDefaultThreader("POOL") );
+  EXPECT_EQ( "POOL", strupper(sitk::ProcessObject::GetGlobalDefaultThreader()) );
 }
 
 TEST( Command, Test2 ) {


### PR DESCRIPTION
Expose being able to set the default multi-thread, the number of work
units, and the number of threads. The behavior of these parameters
will vary deepening the threading model used.