### PR TITLE
Checkin of python-lint.yml

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -1,0 +1,29 @@
+name: Python Lint
+
+on:
+  push:
+    branches: [ master, release ]
+  pull_request:
+    branches: [ master, release ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 Examples --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 Examples --count --exit-zero --statistics

--- a/Examples/.flake8
+++ b/Examples/.flake8
@@ -1,0 +1,2 @@
+max-line-length = 120
+max-complexity = 10


### PR DESCRIPTION
Adapted from python-app.yml Github Action file.  That file sets up
an action that runs flake8 and pytest on any pull request.

For this one, the pytest call is removed, and flake8 is only run
on the Examples sub-directory.