### PR TITLE
Doxygen add dynamic time stamp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,17 +312,16 @@ foreach(_f IN LISTS ITK_DOC_FILES)
   list( APPEND SimpleITK_DOC_FILES "${_o}" )
 endforeach()
 
-
-#------------------------------------------------------------------------------
-# Set up Documentation
-include(${SimpleITK_SOURCE_DIR}/Utilities/Doxygen/Doxygen.cmake)
-
 #------------------------------------------------------------------------------
 # Set up wrapping.
 #
 # Use CMake file which present options for wrapped languages, and finds languages as needed
 #
 include(sitkLanguageOptions)
+
+#------------------------------------------------------------------------------
+# Set up Documentation
+include(${SimpleITK_SOURCE_DIR}/Utilities/Doxygen/Doxygen.cmake)
 
 #------------------------------------------------------------------------------
 # Ensure that development strips have been setup

--- a/Utilities/Doxygen/Doxygen.cmake
+++ b/Utilities/Doxygen/Doxygen.cmake
@@ -73,7 +73,16 @@ if (BUILD_DOXYGEN)
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/Utilities/Doxygen
     )
 
-
+  # Create a "datetime.txt" file for a time stamp of the code
+  # generation. The time stamp in dynamically inserted into the HTML
+  # with javascript, to reduce the code change churn with regular
+  # updates.
+  add_custom_command(
+    TARGET Documentation
+    POST_BUILD
+    WORKING_DIRECTORY "${PROJECT_BINARY_DIR}/Documentation/html"
+    COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_LIST_DIR}/datetime.py"
+    )
 
   message( STATUS
     "To generate Doxygen's documentation, you need to build the Documentation target"

--- a/Utilities/Doxygen/Doxygen.cmake
+++ b/Utilities/Doxygen/Doxygen.cmake
@@ -24,8 +24,8 @@ if (BUILD_DOXYGEN)
       add_custom_command( OUTPUT "${ITK_DOXYGEN_TAGFILE}"
         COMMAND ${CMAKE_COMMAND} -D "PROJECT_SOURCE_DIR:PATH=${PROJECT_SOURCE_DIR}"
         -D "OUTPUT_PATH:PATH=${PROJECT_BINARY_DIR}/Documentation/Doxygen"
-        -P "${PROJECT_SOURCE_DIR}/Utilities/Doxygen/ITKDoxygenTags.cmake"
-        DEPENDS "${PROJECT_SOURCE_DIR}/Utilities/Doxygen/ITKDoxygenTags.cmake"
+        -P "${CMAKE_CURRENT_LIST_DIR}/ITKDoxygenTags.cmake"
+        DEPENDS "${CMAKE_CURRENT_LIST_DIR}/ITKDoxygenTags.cmake"
         )
     endif()
 
@@ -36,7 +36,7 @@ if (BUILD_DOXYGEN)
 
   set(DOXYGEN_MATHJAX_RELPATH
     "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/"
-    CACHE STRING "The destination or URK to contain the MathJax.js script")
+    CACHE STRING "The destination or URL to contain the MathJax.js script")
 
   set(SIMPLEITK_DOXYGEN_TAGFILE "${PROJECT_BINARY_DIR}/Utilities/Doxygen/SimpleITKDoxygen.tag")
 

--- a/Utilities/Doxygen/datetime.py
+++ b/Utilities/Doxygen/datetime.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+#
+#  Copyright NumFOCUS
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Writes the date and time in RFC 2822 format to the file "datetime.txt"
+
+import time
+
+with open("datetime.txt", "w") as fp:
+    fp.write(time.strftime("%a, %d %b %Y %H:%M:%S +0000", time.gmtime()))

--- a/Utilities/Doxygen/footer.html
+++ b/Utilities/Doxygen/footer.html
@@ -4,7 +4,8 @@
 <div id="nav-path" class="navpath"><!-- id is needed for treeview function! -->
   <ul>
     $navpath
-    <li class="footer">$generatedby
+    <li class="footer">
+    Generated on <span id="datetime">unknown</span> for $projectname by &#160;
     <a href="http://www.doxygen.org/index.html">
     <img class="footer" src="$relpath^doxygen.png" alt="doxygen"/></a> $doxygenversion </li>
   </ul>
@@ -12,7 +13,8 @@
 <!--END GENERATE_TREEVIEW-->
 <!--BEGIN !GENERATE_TREEVIEW-->
 <hr class="footer"/><address class="footer"><small>
-$generatedby &#160;<a href="http://www.doxygen.org/index.html">
+    Generated on <span id="datetime">unknown</span> for $projectname by &#160;
+    <a href="http://www.doxygen.org/index.html">
 <img class="footer" src="$relpath^doxygen.png" alt="doxygen"/>
 </a> $doxygenversion | <a href="https://simpleitk.org/privacy_policy.html">
       Privacy Policy</a>

--- a/Utilities/Doxygen/header.html
+++ b/Utilities/Doxygen/header.html
@@ -33,6 +33,11 @@ $extrastylesheet
                   height="0" width="0" style="display:none;visibility:hidden"></iframe>
 </noscript>
 <!-- End Google Tag Manager (noscript) -->
+<script>
+  $(function(){
+  $("#datetime").load("datetime.txt");
+  });
+</script>
 <div id="top"><!-- do not remove this div, it is closed by doxygen! -->
 
 <!--BEGIN TITLEAREA-->


### PR DESCRIPTION
Replace inline Doxygen generated time stamp with dynamic insertion
    
    The Doxygen footer macro "$generatedby" include the generate
    time. This create excessive HTML churn and useful modification time
    every time the Doxygen updated.
    
    This patch use JQuery to dynamically insert the time stamp from a
    generate "datetime.txt" file into the footer.