### PR TITLE
Update ndarray.tostring to tobyte

### DIFF
--- a/Wrapping/Python/SimpleITK/extra.py
+++ b/Wrapping/Python/SimpleITK/extra.py
@@ -293,7 +293,7 @@ def GetImageFromArray(arr, isVector=None):
     # SimpleITK throws an exception if the image dimension is not supported
     img = Image(shape, id, number_of_components)
 
-    _SetImageFromArray(z.tostring(), img)
+    _SetImageFromArray(z.tobytes(), img)
 
     return img
 


### PR DESCRIPTION
Change to use numpy.ndarray.tobyte to avoid deprecated method
warning. In numpy 1.19 numpy.ndarray.tostring() is deprecated.

Closes #1150. 
Thanks to @fepegar for the report.