### PR TITLE
Use "package_data" for SimpleITK documentation files.

### DIFF
--- a/Wrapping/Python/Packaging/setup.py.in
+++ b/Wrapping/Python/Packaging/setup.py.in
@@ -48,7 +48,7 @@ setup(
     author_email = 'insight-users@itk.org',
     ext_modules=[Extension('SimpleITK._SimpleITK', [r'SimpleITK/@SimpleITK_BINARY_MODULE@'])],
     packages= ['SimpleITK'],
-    data_files = [("", doc_files)],
+    package_data = {"SimpleITK": doc_files},
     platforms = [],
     description = r'SimpleITK is a simplified interface to the Insight Toolkit (ITK) for image registration and segmentation',
     long_description = long_description,


### PR DESCRIPTION
Place the files inside the installed package directory, this is a
change from the "data_files" behavior of the installation path being
relative to the installation prefix.