### PR TITLE
Fix Python weak symbols conflict

### DIFF
--- a/Wrapping/Python/CMakeLists.txt
+++ b/Wrapping/Python/CMakeLists.txt
@@ -66,7 +66,17 @@ if ( MSVC )
       set_target_properties(${SWIG_MODULE_SimpleITK_TARGET_NAME}
         PROPERTIES RUNTIME_OUTPUT_DIRECTORY_${CMAKE_CONFIGURATION_TYPE} "${CMAKE_SWIG_OUTDIR}")
     endforeach( )
+  endif()
+
+# TODO add check to determine if compiler support linker script
+if (UNIX AND NOT APPLE AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  set(VERSION_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/symbols.map")
+  set_target_properties( ${SWIG_MODULE_SimpleITK_TARGET_NAME} PROPERTIES
+    LINK_DEPENDS "${VERSION_SCRIPT}")
+  set_property(TARGET ${SWIG_MODULE_SimpleITK_TARGET_NAME} APPEND_STRING PROPERTY
+    LINK_FLAGS " -Wl,--version-script=${VERSION_SCRIPT}")
 endif()
+
 set_source_files_properties(${swig_generated_file_fullname} PROPERTIES COMPILE_FLAGS "-w")
 sitk_strip_target( ${SWIG_MODULE_SimpleITKPython_TARGET_NAME} )
 

--- a/Wrapping/Python/symbols.map
+++ b/Wrapping/Python/symbols.map
@@ -1,0 +1,9 @@
+{
+  # Symbols marked as 'local' are not exported
+  local:
+    extern "C++" {
+      # The C++11 versioned symbol appears to conflict with the C++17 version between
+      # versions is libstdc++, so the symbol is marked local to avoid conflict.
+      *std::__once_call*;
+    };
+};


### PR DESCRIPTION

    This fix is inspired but the following article and linked changes:
    https://uwekorn.com/2019/09/15/how-we-build-apache-arrows-manylinux-wheels.html
    
    Use a linker script make only the one global symbol needed by Python
    visible, while the others remain local. This hides the weak C++/std symbol
    which can conflict with other libraries. Specifically, the
    std::call_once conflicting with tensorflow.
    
    Addresses #1208 and #1192.
