### PR TITLE
BUG: GetImageFromArray accepted arrays that had zero sized dimensions.

### DIFF
--- a/Testing/Unit/Python/sitkNumpyArrayConversionTest.py
+++ b/Testing/Unit/Python/sitkNumpyArrayConversionTest.py
@@ -87,6 +87,8 @@ class TestNumpySimpleITKInterface(unittest.TestCase):
         img = sitk.GetImageFromArray( sitk.GetArrayFromImage( img ) )
 
         self.assertEqual( h, sitk.Hash( img ))
+        # Do not accept a numpy array with one or more zero dimensions
+        self.assertRaises(ValueError, sitk.GetImageFromArray(np.zeros((40, 0, 1), dtype=np.uint64))
 
     def test_isVector(self):
         """ Test Behavior of isVector option. """

--- a/Wrapping/Python/SimpleITK/extra.py
+++ b/Wrapping/Python/SimpleITK/extra.py
@@ -292,6 +292,9 @@ def GetImageFromArray(arr, isVector=None):
         id = _get_sitk_pixelid(z)
         shape = z.shape[::-1]
 
+    if 0 in shape:
+        raise ValueError('One or more dimensions of the array are zero sized.')
+
     # SimpleITK throws an exception if the image dimension is not supported
     img = Image(shape, id, number_of_components)
 


### PR DESCRIPTION
Throw an exception when one of the numpy array sizes is zero.