### PR TITLE
Add Java Image::GetGufferAsByteBuffer method

### DIFF
--- a/Wrapping/Java/Java.i
+++ b/Wrapping/Java/Java.i
@@ -24,12 +24,15 @@
   }
 %}
 
+%include "JavaBufferHelper.i"
 %include "JavaDoc.i"
 
 // Make Java method names follow the naming conventions
 // See the swig.swg file, and ruby.swg for details on how this works
 // Documented in: http://www.swig.org/Doc2.0/SWIG.html#SWIG_advanced_renaming
 %rename("%(firstlowercase)s", %$isfunction ) "";
+
+%rename( getBufferAsByteBuffer ) itk::simple::Image::GetBufferAsVoid;
 
 // Enable Java classes derived from Command Execute method to be
 // called from C++

--- a/Wrapping/Java/Java.i
+++ b/Wrapping/Java/Java.i
@@ -17,15 +17,7 @@
 *=========================================================================*/
 // Java
 #if SWIGJAVA
-%include "carrays.i"
-%array_class(int8_t, int8Array);
-%array_class(uint8_t, uint8Array);
-%array_class(int16_t, int16Array);
-%array_class(uint16_t, uint16Array);
-%array_class(int32_t, int32Array);
-%array_class(uint32_t, uint32Array);
-%array_class(float, floatArray);
-%array_class(double, doubleArray);
+
 %pragma(java) jniclasscode=%{
   static {
     System.loadLibrary ( "SimpleITKJava" );

--- a/Wrapping/Java/JavaBufferHelper.i
+++ b/Wrapping/Java/JavaBufferHelper.i
@@ -1,0 +1,13 @@
+/*
+ * void * typemap for returning ByteBuffer from Image::GetBufferAsVoid
+ */
+%typemap(jni) void * "jobject"
+%typemap(jtype) void * "java.nio.ByteBuffer"
+%typemap(jstype) void * "java.nio.ByteBuffer"
+%typemap(javaout) void * {
+  return $jnicall;
+}
+%typemap(out) void * {
+  const size_t size = arg1->GetNumberOfPixels()*arg1->GetNumberOfComponentsPerPixel()*arg1->GetSizeOfPixelComponent();
+  $result = JCALL2(NewDirectByteBuffer, jenv, $1, size);
+ }


### PR DESCRIPTION
Rename the `Image::GetBufferAsVoid`, to `Image::GetBufferAsByteBuffer` while construction a Java Buffer object to access the memory buffer from SimpleITK.