### PR TITLE
For Release - Fix python packaging of SimpleITK docs files

### DIFF
--- a/Wrapping/Python/LegacyPackaging.cmake
+++ b/Wrapping/Python/LegacyPackaging.cmake
@@ -1,18 +1,26 @@
 if ( SimpleITK_DOC_FILES )
-  # create a python list for the import documents to include in
-  # packaging
+  # Copy the documentation files into the SimpleITK python package
+  # directory under "docs" sub-directory. And create a list of the
+  # copied files in the python list syntax.
 
-  # specially handle the first element
-  list( GET SimpleITK_DOC_FILES 0 d )
-  file(TO_NATIVE_PATH "${d}" d )
-  set( SimpleITK_DOC_FILES_AS_LIST "[r'${d}'")
-  set( _doc_list "${SimpleITK_DOC_FILES}" )
-  list( REMOVE_AT _doc_list 0 )
+  set( SimpleITK_DOC_FILES_AS_LIST "")
 
-  foreach( d ${_doc_list} )
-    file(TO_NATIVE_PATH "${d}" d )
-    set( SimpleITK_DOC_FILES_AS_LIST "${SimpleITK_DOC_FILES_AS_LIST},r'${d}'")
+  foreach( d ${SimpleITK_DOC_FILES} )
+    get_filename_component(fn "${d}" NAME)
+    set(_out "${CMAKE_CURRENT_BINARY_DIR}/SimpleITK/docs/${fn}")
+    configure_file(
+      "${d}"
+      "${_out}"
+     COPYONLY )
+
+    file(TO_NATIVE_PATH "${_out}" d )
+    if (SimpleITK_DOC_FILES_AS_LIST STREQUAL "")
+        set( SimpleITK_DOC_FILES_AS_LIST "${SimpleITK_DOC_FILES_AS_LIST}[r'${_out}'")
+    else()
+        set( SimpleITK_DOC_FILES_AS_LIST "${SimpleITK_DOC_FILES_AS_LIST},r'${_out}'")
+    endif()
   endforeach()
+
   set( SimpleITK_DOC_FILES_AS_LIST "${SimpleITK_DOC_FILES_AS_LIST}]")
 
 endif()

--- a/Wrapping/Python/Packaging/setup.py.in
+++ b/Wrapping/Python/Packaging/setup.py.in
@@ -9,10 +9,14 @@ except ImportError:
     from distutils.command.build_ext import build_ext as _build_ext
 
 import re
+import os.path as osp
 
 from SimpleITK._version import __version__
 
-doc_files = @SimpleITK_DOC_FILES_AS_LIST@
+def to_package_relpath(filename, pkg_name='SimpleITK'):
+    return osp.relpath(filename, osp.join(os.curdir, pkg_name))
+
+doc_files = [to_package_relpath(f) for f in @SimpleITK_DOC_FILES_AS_LIST@]
 
 with open('@SimpleITK_SOURCE_DIR@/Readme.md', encoding='utf-8') as f:
     long_description = f.read()
@@ -48,7 +52,7 @@ setup(
     author_email = 'insight-users@itk.org',
     ext_modules=[Extension('SimpleITK._SimpleITK', [r'SimpleITK/@SimpleITK_BINARY_MODULE@'])],
     packages= ['SimpleITK'],
-    data_files = [("", doc_files)],
+    package_data = {"SimpleITK": doc_files},
     platforms = [],
     description = r'SimpleITK is a simplified interface to the Insight Toolkit (ITK) for image registration and segmentation',
     long_description = long_description,


### PR DESCRIPTION
The SimpleITK docs for packaging include SimpleITK and ITK's license
and readme files. The file are now copied to the SimpleITK python
package directory, and the relative paths are using in setup's
package_data parameter.