### PR TITLE
WIP: run Hello examples when testing; setting SITK_NOSHOW not quite r…

### DIFF
--- a/CMake/sitkAddTest.cmake
+++ b/CMake/sitkAddTest.cmake
@@ -41,6 +41,12 @@ function(sitk_add_test)
   # Add test with data in the SimpleITKData group.
   ExternalData_add_test(SimpleITKData NAME ${__NAME} COMMAND ${__COMMAND} ${__UNPARSED_ARGUMENTS})
 
+  if (SimpleITK_TESTING_NOSHOW)
+    set_property(TEST ${__NAME}
+        PROPERTY ENVIRONMENT SITK_NOSHOW=YES
+        )
+  endif()
+
 endfunction()
 
 
@@ -69,11 +75,6 @@ function(sitk_add_python_test name)
   set_property(TEST Python.${name}
       PROPERTY LABELS Python
       )
-  if (SimpleITK_TESTING_NOSHOW)
-    set_property(TEST Python.${name}
-        PROPERTY ENVIRONMENT SITK_NOSHOW=YES
-        )
-  endif()
   if (NOT SimpleITK_PYTHON_USE_VIRTUALENV)
     set_property(TEST Python.${name}
       APPEND PROPERTY ENVIRONMENT PYTHONPATH=${SimpleITK_Python_BINARY_DIR}
@@ -109,13 +110,8 @@ function(sitk_add_lua_test name)
     PROPERTY LABELS Lua
     )
   set_property(TEST Lua.${name}
-    PROPERTY ENVIRONMENT LUA_CPATH=$<TARGET_FILE:SimpleITKLuaModule_LUA>
+    APPEND PROPERTY ENVIRONMENT LUA_CPATH=$<TARGET_FILE:SimpleITKLuaModule_LUA>
     )
-  if (SimpleITK_TESTING_NOSHOW)
-    set_property(TEST Lua.${name}
-      APPEND PROPERTY ENVIRONMENT SITK_NOSHOW=YES
-      )
-  endif()
 endfunction()
 
 
@@ -145,7 +141,7 @@ function(sitk_add_ruby_test name)
     PROPERTY LABELS Ruby
     )
   set_property(TEST Ruby.${name}
-    PROPERTY ENVIRONMENT RUBYLIB=$<TARGET_FILE_DIR:simpleitk_RUBY>
+    APPEND PROPERTY ENVIRONMENT RUBYLIB=$<TARGET_FILE_DIR:simpleitk_RUBY>
     )
 endfunction()
 
@@ -265,7 +261,7 @@ function(sitk_add_r_test name)
   file(TO_NATIVE_PATH "${SimpleITK_R_BINARY_DIR}/R_libs" _native_path)
 
   set_property(TEST R.${name}
-    PROPERTY ENVIRONMENT R_LIBS=${_native_path}
+    APPEND PROPERTY ENVIRONMENT R_LIBS=${_native_path}
     )
 endfunction()
 

--- a/Examples/HelloWorld/CMakeLists.txt
+++ b/Examples/HelloWorld/CMakeLists.txt
@@ -7,38 +7,35 @@ if ( NOT BUILD_TESTING )
   return ()
 endif ()
 
-if ( NOT SimpleITK_TESTING_NOSHOW )
 
-  sitk_add_test( NAME CXX.Example.HelloWorld
-    COMMAND $<TARGET_FILE:HelloWorld>
-    )
+sitk_add_test( NAME CXX.Example.HelloWorld
+  COMMAND $<TARGET_FILE:HelloWorld>
+  )
 
-  sitk_add_csharp_test( Example.HelloWorld
-    "${CMAKE_CURRENT_SOURCE_DIR}/HelloWorld.cs"
-    )
+sitk_add_csharp_test( Example.HelloWorld
+  "${CMAKE_CURRENT_SOURCE_DIR}/HelloWorld.cs"
+  )
 
-  sitk_add_java_test( Example.HelloWorld
-    "${CMAKE_CURRENT_SOURCE_DIR}/HelloWorld.java"
-    )
+sitk_add_java_test( Example.HelloWorld
+  "${CMAKE_CURRENT_SOURCE_DIR}/HelloWorld.java"
+  )
 
-  sitk_add_lua_test( Example.HelloWorld
-    "${CMAKE_CURRENT_SOURCE_DIR}/HelloWorld.lua"
-    )
+sitk_add_lua_test( Example.HelloWorld
+  "${CMAKE_CURRENT_SOURCE_DIR}/HelloWorld.lua"
+  )
 
-  sitk_add_python_test( Example.HelloWorld
-    "${CMAKE_CURRENT_SOURCE_DIR}/HelloWorld.py"
-    )
+sitk_add_python_test( Example.HelloWorld
+  "${CMAKE_CURRENT_SOURCE_DIR}/HelloWorld.py"
+  )
 
-  sitk_add_r_test( Example.HelloWorld
-    "${CMAKE_CURRENT_SOURCE_DIR}/HelloWorld.R"
-    )
+sitk_add_r_test( Example.HelloWorld
+  "${CMAKE_CURRENT_SOURCE_DIR}/HelloWorld.R"
+  )
 
-  sitk_add_ruby_test( Example.HelloWorld
-    "${CMAKE_CURRENT_SOURCE_DIR}/HelloWorld.rb"
-    )
+sitk_add_ruby_test( Example.HelloWorld
+  "${CMAKE_CURRENT_SOURCE_DIR}/HelloWorld.rb"
+  )
 
-  sitk_add_tcl_test( Example.HelloWorld
-    "${CMAKE_CURRENT_SOURCE_DIR}/HelloWorld.tcl"
-    )
-
-endif ()
+sitk_add_tcl_test( Example.HelloWorld
+  "${CMAKE_CURRENT_SOURCE_DIR}/HelloWorld.tcl"
+  )


### PR DESCRIPTION
…ight.

I moved the Cmake code to enable SITK_NOSHOW from sitk_add_python_test and sitk_add_lua_test to sitk_add_test so that all tests get it.  However, for some reason, SITK_NOSHOW is not getting set for the Lua or R tests.  It is for Python, C++, Java, CSharp and TCL.