### PR TITLE
Add missing SWIG mapping for int 64 and void pointer types

### DIFF
--- a/Testing/Unit/CSharp/CSharpImageTest.cs
+++ b/Testing/Unit/CSharp/CSharpImageTest.cs
@@ -85,6 +85,38 @@ namespace itk.simple {
                 image /= image;
                 CheckHash(image, "287046eafd10b9984977f6888ea50ea50fe846b5", ref success);  
 
+                image = new Image(100, 100, PixelId.sitkInt8);
+                IntPtr buffer = image.GetBufferAsInt8();
+                image = new Image(100, 100, PixelId.sitkUInt8);
+                buffer = image.GetBufferAsUInt8();
+
+                image = new Image(100, 100, PixelId.sitkInt16);
+                buffer = image.GetBufferAsInt16();
+                image = new Image(100, 100, PixelId.sitkUInt16);
+                buffer = image.GetBufferAsUInt16();
+
+                image = new Image(100, 100, PixelId.sitkInt32);
+                buffer = image.GetBufferAsInt32();
+                image = new Image(100, 100, PixelId.sitkUInt32);
+                buffer = image.GetBufferAsUInt32();
+
+                image = new Image(100, 100, PixelId.sitkInt64);
+                buffer = image.GetBufferAsInt64();
+                image = new Image(100, 100, PixelId.sitkUInt64);
+                buffer = image.GetBufferAsUInt64();
+
+                image = new Image(100, 100, PixelId.sitkFloat32);
+                buffer = image.GetBufferAsFloat();
+                image = new Image(100, 100, PixelId.sitkFloat64);
+                buffer = image.GetBufferAsDouble();
+
+                buffer = image.GetBufferAsVoid();
+
+                if (buffer == IntPtr.Zero)
+                {
+                  success = ExitFailure;
+                  Console.WriteLine("GetBufferAsVoid returned 0.");
+                }
 
             } catch (Exception ex) {
                 success = ExitFailure;

--- a/Wrapping/CSharp/CSharp.i
+++ b/Wrapping/CSharp/CSharp.i
@@ -40,8 +40,11 @@
 %CSharpTypemapHelper( uint16_t*, System.IntPtr )
 %CSharpTypemapHelper( int32_t*, System.IntPtr )
 %CSharpTypemapHelper( uint32_t*, System.IntPtr )
+%CSharpTypemapHelper( int64_t*, System.IntPtr )
+%CSharpTypemapHelper( uint64_t*, System.IntPtr )
 %CSharpTypemapHelper( float*, System.IntPtr )
 %CSharpTypemapHelper( double*, System.IntPtr )
+%CSharpTypemapHelper( void*, System.IntPtr )
 
 
 // CSharp does not hadle overloaded const methods. So they are


### PR DESCRIPTION
The CSharp Image methods GetBufferAsVoid, GetBufferAsUInt64 and
GetBufferAsInt64 return type was SWIGTYPE_p_void, etc. This
appropriate type map is not added to return these pointers as IntPtr
types.