### PR TITLE
Fix AZP Linux packaging to build configure.BuildHash

### DIFF
--- a/Testing/CI/Azure/templates/package-linux-job.yml
+++ b/Testing/CI/Azure/templates/package-linux-job.yml
@@ -19,7 +19,6 @@ jobs:
           cd ${BUILD_SOURCESDIRECTORY}/Utilities/Distribution/manylinux
           docker run --rm \
                --user "$(id -u):$(id -g)" \
-               --mount type=bind,source=${BUILD_SOURCESDIRECTORY},destination=/tmp/SimpleITK,readonly \
                --mount type=bind,source=${ExternalData_OBJECT_STORES},destination=/var/io/.ExternalData \
                --env "ExternalData_OBJECT_STORES=/var/io/.ExternalData" \
                --env PYTHON_VERSIONS \


### PR DESCRIPTION
The SimpleITK repository hash used be built was incorrectly set to the
same path/checkout as the CI scripts. The docker run command was
mounting the CI SimpleITK source directory overriding the
SIMPLEITK_GIT_TAG env varible. This mount is removed.