### PR TITLE
Set CMake Policy version to 3.10 in Superbuild

### DIFF
--- a/SuperBuild/CMakeLists.txt
+++ b/SuperBuild/CMakeLists.txt
@@ -14,6 +14,7 @@ endif()
 
 cmake_minimum_required ( VERSION 3.10 )
 project ( SuperBuildSimpleITK )
+cmake_policy( VERSION 3.10 )
 
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
This address new cmake configuration warnings related to new CMake
policies.