### PR TITLE
BUG: The GetPixelAsComplexFloat64 in Python was not renamed.

### DIFF
--- a/Wrapping/Python/sitkImage.i
+++ b/Wrapping/Python/sitkImage.i
@@ -38,7 +38,7 @@
 %rename( __GetPixelAsVectorFloat32__ ) itk::simple::Image::GetPixelAsVectorFloat32;
 %rename( __GetPixelAsVectorFloat64__ ) itk::simple::Image::GetPixelAsVectorFloat64;
 %rename( __GetPixelAsComplexFloat32__ ) itk::simple::Image::GetPixelAsComplexFloat32;
-%rename( __GetPixelAsComplexFloat64__ ) itk::simple::Image::GetPixelAsComplextFloat64;
+%rename( __GetPixelAsComplexFloat64__ ) itk::simple::Image::GetPixelAsComplexFloat64;
 
 %rename( __SetPixelAsInt8__ ) itk::simple::Image::SetPixelAsInt8;
 %rename( __SetPixelAsUInt8__ ) itk::simple::Image::SetPixelAsUInt8;


### PR DESCRIPTION
The type specific GetPixelAsX methods are "hidden" via renaming, the
GetPixelAsComplexFloat64 was not hidden due to a spelling mistake.