### PR TITLE
Discontinue packaging Python 3.5

### DIFF
--- a/Testing/CI/Azure/templates/package-linux-job.yml
+++ b/Testing/CI/Azure/templates/package-linux-job.yml
@@ -1,6 +1,6 @@
 parameters:
   DOCKERFILE: Dockerfile-2010-x86_64
-  PYTHON_VERSIONS: "cp35-cp35m cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39"
+  PYTHON_VERSIONS: "cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39"
 
 jobs:
   - job: Linux_${{replace(parameters.DOCKERFILE, '-', '_')}}

--- a/Testing/CI/Azure/templates/package-mac-job.yml
+++ b/Testing/CI/Azure/templates/package-mac-job.yml
@@ -114,15 +114,3 @@ jobs:
       - bash: ${BUILD_SOURCESDIRECTORY}/Testing/CI/Azure/scripts/mac_build_python.sh
         displayName: Build Python 36
         continueOnError: true
-      - task: UsePythonVersion@0
-        displayName: Enable Python
-        inputs:
-          versionSpec: '3.5'
-          architecture: 'x64'
-      - bash: ${BUILD_SOURCESDIRECTORY}/Testing/CI/Azure/scripts/mac_build_python.sh
-        displayName: Build Python 35
-        continueOnError: true
-      - task: PublishBuildArtifacts@1
-        inputs:
-          pathtoPublish: $(Build.ArtifactStagingDirectory)/python
-          artifactName: Python

--- a/Testing/CI/Azure/templates/package-win-job.yml
+++ b/Testing/CI/Azure/templates/package-win-job.yml
@@ -106,17 +106,3 @@ jobs:
           bash $(Build.SourcesDirectory)/Testing/CI/Azure/scripts/win_build_python.sh
         displayName: Build Python 36
         continueOnError: true
-      - task: UsePythonVersion@0
-        displayName: Enable Python
-        inputs:
-          versionSpec: '3.5'
-          architecture: '${{ parameters.PYTHON_ARCH }}'
-      - script: |
-          call  "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"  ${{ parameters.VCVAR_OPTIONS }} -vcvars_ver=14.0
-          bash $(Build.SourcesDirectory)/Testing/CI/Azure/scripts/win_build_python.sh
-        displayName: Build Python 35
-        continueOnError: true
-      - task: PublishBuildArtifacts@1
-        inputs:
-          pathtoPublish: $(Build.ArtifactStagingDirectory)/python
-          artifactName: Python


### PR DESCRIPTION
Python 3.5 reached end of life with the final 3.5.10 release in
September 2020.