### PR TITLE
Update to support CMake Ruby module prefix

### DIFF
--- a/CMake/sitkLanguageOptions.cmake
+++ b/CMake/sitkLanguageOptions.cmake
@@ -235,7 +235,9 @@ if( _do_find_package )
 
   find_package ( Ruby ${_find_package_extra_args} )
 
-  if ( RUBY_FOUND )
+  # CMake 3.15 switch to the conforming "Ruby" prefix, while
+  # supporting the legacy "RUBY"
+  if ( Ruby_FOUND OR RUBY_FOUND )
     set ( WRAP_RUBY_DEFAULT ${WRAP_DEFAULT} )
   else ( )
     set ( WRAP_RUBY_DEFAULT OFF )
@@ -245,14 +247,20 @@ endif()
 option ( WRAP_RUBY "Wrap Ruby" ${WRAP_RUBY_DEFAULT} )
 
 if ( WRAP_RUBY )
-  list( APPEND SITK_LANGUAGES_VARS
-    RUBY_EXECUTABLE
-    RUBY_INCLUDE_DIRS
-    RUBY_LIBRARY
-    RUBY_VERSION
-    RUBY_FOUND
-    RUBY_INCLUDE_PATH
-    )
+  if ( Ruby_FOUND )
+    list( APPEND SITK_LANGUAGES_VARS
+      Ruby_EXECUTABLE
+      Ruby_INCLUDE_DIRS
+      Ruby_LIBRARIES
+      )
+  else ()
+    list( APPEND SITK_LANGUAGES_VARS
+      RUBY_EXECUTABLE
+      RUBY_INCLUDE_DIRS
+      RUBY_LIBRARY
+      RUBY_VERSION
+      )
+  endif()
 endif()
 
 

--- a/Wrapping/Ruby/CMakeLists.txt
+++ b/Wrapping/Ruby/CMakeLists.txt
@@ -16,10 +16,19 @@ set(SWIG_MODULE_simpleitk_EXTRA_DEPS ${SWIG_EXTRA_DEPS}
   ${CMAKE_CURRENT_SOURCE_DIR}/Ruby.i)
 
 SWIG_add_module( simpleitk ruby SimpleITK.i  )
-target_link_libraries( ${SWIG_MODULE_simpleitk_TARGET_NAME} ${SimpleITK_LIBRARIES} )
-sitk_target_link_libraries_with_dynamic_lookup( ${SWIG_MODULE_simpleitk_TARGET_NAME} ${RUBY_LIBRARY} )
+target_link_libraries( ${SWIG_MODULE_simpleitk_TARGET_NAME}
+  ${SimpleITK_LIBRARIES} )
 set_source_files_properties( ${swig_generated_file_fullname} PROPERTIES COMPILE_FLAGS "-w")
-target_include_directories( ${SWIG_MODULE_simpleitk_TARGET_NAME}
-  PRIVATE
-    ${RUBY_INCLUDE_DIRS} )
+
+if (Ruby_FOUND)
+  sitk_target_link_libraries_with_dynamic_lookup( ${SWIG_MODULE_simpleitk_TARGET_NAME} ${Ruby_LIBRARY} )
+  target_include_directories( ${SWIG_MODULE_simpleitk_TARGET_NAME}
+    PRIVATE
+      ${Ruby_INCLUDE_DIRS} )
+  else()
+    sitk_target_link_libraries_with_dynamic_lookup( ${SWIG_MODULE_simpleitk_TARGET_NAME} ${RUBY_LIBRARY} )
+    target_include_directories( ${SWIG_MODULE_simpleitk_TARGET_NAME}
+      PRIVATE
+        ${RUBY_INCLUDE_DIRS} )
+endif()
 sitk_strip_target( ${SWIG_MODULE_simpleitk_TARGET_NAME} )


### PR DESCRIPTION
CMake 3.15, change the recommended prefix for the Ruby find package
module to match the case of the package name. The CMake code is update
to support the undated naming. This addresses configuration error
related to this name change in SimpleITK Superbuild.

The usage of the Ruby libraries is update to prefer to use the new
names.