### PR TITLE
AZP restore publishing of OSX and MS Windows Python packages

### DIFF
--- a/Testing/CI/Azure/templates/package-mac-job.yml
+++ b/Testing/CI/Azure/templates/package-mac-job.yml
@@ -114,3 +114,7 @@ jobs:
       - bash: ${BUILD_SOURCESDIRECTORY}/Testing/CI/Azure/scripts/mac_build_python.sh
         displayName: Build Python 36
         continueOnError: true
+      - task: PublishBuildArtifacts@1
+        inputs:
+          pathtoPublish: $(Build.ArtifactStagingDirectory)/python
+          artifactName: Python

--- a/Testing/CI/Azure/templates/package-win-job.yml
+++ b/Testing/CI/Azure/templates/package-win-job.yml
@@ -106,3 +106,7 @@ jobs:
           bash $(Build.SourcesDirectory)/Testing/CI/Azure/scripts/win_build_python.sh
         displayName: Build Python 36
         continueOnError: true
+      - task: PublishBuildArtifacts@1
+        inputs:
+          pathtoPublish: $(Build.ArtifactStagingDirectory)/python
+          artifactName: Python


### PR DESCRIPTION
These task steps were mistakenly removed.