### PR TITLE
Correct setting of command ownership

### DIFF
--- a/Code/Common/src/sitkProcessObject.cxx
+++ b/Code/Common/src/sitkProcessObject.cxx
@@ -359,7 +359,7 @@ int ProcessObject::AddCommand(itk::simple::EventEnum event, const std::function<
   cmd->SetCallbackFunction(func);
 
   int id = this->AddCommand(event, *cmd.get());
-  cmd->GetOwnedByObjects();
+  cmd->OwnedByObjectsOn();
   cmd.release();
   return id;
 }


### PR DESCRIPTION
This fixes memory leaks from not deleting these command object. The
code was incorrectly updated with the new ObjectOwnedBase class.