### PR TITLE
Set the default ITK Multithreader to Platform in Superbuild

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -27,6 +27,10 @@ if (NOT DEFINED Module_ITKIOTransformMINC)
   set(Module_ITKIOTransformMINC ON)
 endif()
 
+if (NOT DEFINED ITK_DEFAULT_THREADER)
+  set( ITK_DEFAULT_THREADER "Platform")
+endif()
+
 get_cmake_property( _varNames VARIABLES )
 
 foreach (_varName ${_varNames})


### PR DESCRIPTION
The Pool multithreader has issues when the process is forked, which is
commonly done in Python multiprocessing. Additionally, the Platform
multithreader has better progress reporting than the Pool threader.