### PR TITLE
Ruby CMake fix naming

### DIFF
--- a/CMake/sitkAddTest.cmake
+++ b/CMake/sitkAddTest.cmake
@@ -124,7 +124,11 @@ function(sitk_add_ruby_test name)
     return()
   endif()
 
-  set(command "${RUBY_EXECUTABLE}")
+  if (DEFINED Ruby_EXECUTABLE)
+    set(command "${Ruby_EXECUTABLE}")
+  else()
+    set(command "${RUBY_EXECUTABLE}")
+  endif()
 
   # add extra command which may be needed on some systems
   if(CMAKE_OSX_ARCHITECTURES)

--- a/Wrapping/Ruby/CMakeLists.txt
+++ b/Wrapping/Ruby/CMakeLists.txt
@@ -20,12 +20,12 @@ target_link_libraries( ${SWIG_MODULE_simpleitk_TARGET_NAME}
   ${SimpleITK_LIBRARIES} )
 set_source_files_properties( ${swig_generated_file_fullname} PROPERTIES COMPILE_FLAGS "-w")
 
-if (Ruby_FOUND)
+if (Ruby_FOUND AND DEFINED Ruby_INCLUDE_DIRS)
   sitk_target_link_libraries_with_dynamic_lookup( ${SWIG_MODULE_simpleitk_TARGET_NAME} ${Ruby_LIBRARY} )
   target_include_directories( ${SWIG_MODULE_simpleitk_TARGET_NAME}
     PRIVATE
       ${Ruby_INCLUDE_DIRS} )
-  else()
+else()
     sitk_target_link_libraries_with_dynamic_lookup( ${SWIG_MODULE_simpleitk_TARGET_NAME} ${RUBY_LIBRARY} )
     target_include_directories( ${SWIG_MODULE_simpleitk_TARGET_NAME}
       PRIVATE


### PR DESCRIPTION
Address CMake issue of using Ruby_INCLUDE_DIRS when not defined.