### PR TITLE
Fix Doxygen style comment for grouping

### DIFF
--- a/Code/IO/include/sitkImageFileReader.h
+++ b/Code/IO/include/sitkImageFileReader.h
@@ -114,7 +114,7 @@ namespace itk {
       const std::vector<double> &GetSpacing( ) const;
       const std::vector<double> &GetDirection() const;
       const std::vector<uint64_t> &GetSize( ) const;
-      /* @} */
+      /** @} */
 
       /** \brief Get the meta-data dictionary keys
        *


### PR DESCRIPTION
The ImageFileReader doxygen page did not have the member properly
grouped into public, private, and protected.