### PR TITLE
Remove old CentOS devtoolset 3,4 and 6

### DIFF
--- a/Testing/CI/Azure/azure-pipelines-batch.yml
+++ b/Testing/CI/Azure/azure-pipelines-batch.yml
@@ -154,12 +154,6 @@ jobs:
          ctest.cache_extra: |
            ITK_GIT_TAG:STRING=master
            CMAKE_CXX_STANDARD:STRING=11
-       devtools-3:
-         env_file: '/opt/rh/devtoolset-3/enable'
-       devtools-4:
-         env_file: '/opt/rh/devtoolset-4/enable'
-       devtools-6:
-         env_file: '/opt/rh/devtoolset-6/enable'
        devtools-7:
          env_file: '/opt/rh/devtoolset-7/enable'
        devtools-8:


### PR DESCRIPTION
These development packages are no longer available on the OS.