### PR TITLE
Remove debugging code from ComposeScaleSkewVersor3DTransform test

### DIFF
--- a/Code/Common/src/sitkTransform.cxx
+++ b/Code/Common/src/sitkTransform.cxx
@@ -104,6 +104,16 @@ bool RegisterMoreTransforms()
   using BSplineTransformO2Type = itk::BSplineTransform<double, Dimension, 2>;
   itk::TransformFactory<BSplineTransformO2Type>::RegisterTransform();
 
+  // This transform was not added to the IOFactory the initial release.
+  if (ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR == 2 && ITK_VERSION_PATCH == 0)
+  {
+    if (Dimension == 3)
+    {
+      using ComposeScaleSkewVersor3DTransformType = itk::ComposeScaleSkewVersor3DTransform<double>;
+      itk::TransformFactory<ComposeScaleSkewVersor3DTransformType>::RegisterTransform();
+    }
+  }
+
   return true;
 }
 

--- a/Testing/Unit/sitkTransformTests.cxx
+++ b/Testing/Unit/sitkTransformTests.cxx
@@ -438,11 +438,9 @@ TEST(TransformTest, ReadTransformConvert) {
   EXPECT_EQ(sitk::sitkScaleSkewVersor, tx.GetTransformEnum());
   }
   {
-    std::cout << "compose\n";
     sitk::ComposeScaleSkewVersor3DTransform tx;
-    sitk::WriteTransform(tx, "composeSSV.txt");
-    exit(0);
-    EXPECT_NO_THROW(tx = sitk::ComposeScaleSkewVersor3DTransform( sitk::ReadTransform("composeSSV.txt") ) );
+    sitk::WriteTransform(tx, filename);
+    EXPECT_NO_THROW(tx = sitk::ComposeScaleSkewVersor3DTransform( sitk::ReadTransform(filename) ) );
     EXPECT_EQ(tx.GetDimension(), 3u);
     EXPECT_EQ(sitk::sitkComposeScaleSkewVersor, tx.GetTransformEnum());
   }


### PR DESCRIPTION
The "exit" cased valgrid memory defects from objects not being
destroyed.