### PR TITLE
Changed type from UInt32 to Int32

### DIFF
--- a/Code/BasicFilters/json/BinaryMagnitudeImageFilter.json
+++ b/Code/BasicFilters/json/BinaryMagnitudeImageFilter.json
@@ -22,8 +22,8 @@
       "description" : "3D",
       "settings" : [],
       "tolerance" : "1e-8",
-      "inputA_cast" : "sitkUInt32",
-      "inputB_cast" : "sitkUInt32",
+      "inputA_cast" : "sitkInt32",
+      "inputB_cast" : "sitkInt32",
       "inputs" : [
         "Input/RA-Short.nrrd",
         "Input/RA-Short.nrrd"


### PR DESCRIPTION
Negative numbers was causing the 3d BinaryMagnitudeImageFilter to fail on the Apple ARM process with the Release build.