### PR TITLE
Remove explicit instantiating of Image of deque of LabelObjectLine

### DIFF
--- a/Code/Explicit/src/sitkExplicitITKImage.cxx
+++ b/Code/Explicit/src/sitkExplicitITKImage.cxx
@@ -60,8 +60,6 @@ template class SITKExplicit_EXPORT itk::Image<std::complex<double>, 2u>;
 template class SITKExplicit_EXPORT itk::Image<std::complex<double>, 3u>;
 template class SITKExplicit_EXPORT itk::Image<std::complex<float>, 2u>;
 template class SITKExplicit_EXPORT itk::Image<std::complex<float>, 3u>;
-template class SITKExplicit_EXPORT itk::Image<std::deque<itk::LabelObjectLine<2u>, std::allocator<itk::LabelObjectLine<2u> > >, 1u>;
-template class SITKExplicit_EXPORT itk::Image<std::deque<itk::LabelObjectLine<3u>, std::allocator<itk::LabelObjectLine<3u> > >, 2u>;
 template class SITKExplicit_EXPORT itk::Image<unsigned char, 1u>;
 template class SITKExplicit_EXPORT itk::Image<unsigned char, 2u>;
 template class SITKExplicit_EXPORT itk::Image<unsigned char, 3u>;


### PR DESCRIPTION
This LabelObjectLine does not have an operator== defined required for
the same Image operator.