### PR TITLE
BUG: Calls to nonexistent methods weren't handled gracefully

### DIFF
--- a/Testing/Unit/R/CMakeLists.txt
+++ b/Testing/Unit/R/CMakeLists.txt
@@ -22,3 +22,6 @@ sitk_add_r_test( Transform
 sitk_add_r_test( Image2Array2Image
   "${CMAKE_CURRENT_SOURCE_DIR}/R2Img2R.R"
   )
+sitk_add_r_test( MethodExceptions
+  "${CMAKE_CURRENT_SOURCE_DIR}/Rmethodexceptions.R"
+  )

--- a/Testing/Unit/R/Rmethodexceptions.R
+++ b/Testing/Unit/R/Rmethodexceptions.R
@@ -1,0 +1,14 @@
+library(SimpleITK)
+# Test exceptions when an incorrect method name is used
+
+raiseAnException <- function() {
+  anonymous_transform_type <- Transform(TranslationTransform(2,c(1.0,0.0)))
+  try(anonymous_transform_type$GetOffset())
+  message("Exception caught, test passed")
+  quit(save="no", status=0)
+  return(TRUE)
+}
+
+raiseAnException()
+# something else went wrong if we get this far
+quit(save="no", status=1)

--- a/Wrapping/R/Packaging/SimpleITK/R/zFixes.R
+++ b/Wrapping/R/Packaging/SimpleITK/R/zFixes.R
@@ -7,3 +7,12 @@ function(value, .copy = FALSE)
 {
   PermuteAxesImageFilter_DefaultOrder_get(.copy)
 }
+
+if (existsMethod("$", "ExternalReference")) {
+  packageStartupMessage("SimpleITK - swig has been fixed so the $ method insize zFixes can be removed")
+} else {
+  setMethod("$", "ExternalReference",function(x, name){
+    msg <- paste0("Unknown method: ", sQuote(name), ". Check spelling, documentation etc.")
+    stop(msg)
+  })
+}


### PR DESCRIPTION
Added a '$' method to the base class from which everything in
SimpleITK descends that prints a meaningful error while
raising an exception.

Eventually this piece of code should be generated by SWIG.

There's a detection section that will warn us if this happens

A simple test is included.

See #1135