### PR TITLE
AZP update linux image to ubuntu-latest

### DIFF
--- a/Testing/CI/Azure/azure-pipelines-package.yml
+++ b/Testing/CI/Azure/azure-pipelines-package.yml
@@ -15,7 +15,7 @@ jobs:
   - job: Configure
     displayName: Configure Variables
     pool:
-      vmImage: 'Ubuntu-16.04'
+      vmImage: 'ubuntu-latest'
     steps:
       - checkout: none
       - bash: |


### PR DESCRIPTION
This build just used the host to run docker so the should be not
impact of rolling OS version.