### PR TITLE
remove firstline to avoid commenting C++ example

### DIFF
--- a/Examples/FastMarchingSegmentation/Documentation.rst
+++ b/Examples/FastMarchingSegmentation/Documentation.rst
@@ -54,7 +54,7 @@ Code
 
     .. literalinclude:: ../../Examples/FastMarchingSegmentation/FastMarchingSegmentation.cxx
        :language: C++
-       :lines: 1,19-
+       :lines: 19-
 
   .. tab:: Python
 


### PR DESCRIPTION
line 1 comments the whole thing - small change to remove this

https://simpleitk.readthedocs.io/en/master/link_FastMarchingSegmentation_docs.html