### PR TITLE
Update Doxygen Docker image to use ubuntu 20.04

### DIFF
--- a/Utilities/Doxygen/docker/Dockerfile
+++ b/Utilities/Doxygen/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04 as simpleitk-doxygen
+FROM ubuntu:20.04 as simpleitk-doxygen
 
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y \


### PR DESCRIPTION
ITK 5.3 require CMake>=3.16.4. This requirement is available by
default in Ubunut 20.04.