### PR TITLE
DOC: Listing each of the BSplineImage coefficient image interpolators.

### DIFF
--- a/Code/Common/include/sitkInterpolator.h
+++ b/Code/Common/include/sitkInterpolator.h
@@ -104,7 +104,7 @@ enum InterpolatorEnum {
    */
   sitkBlackmanWindowedSinc = 10,
 
-  /** \brief Interpolator for a BSpline coefficient image
+  /** \brief Interpolator for a <b>BSpline coefficient image</b>
    *
    *  This interpolator should be used with the resampling the image
    *  intensities of a BSpline coefficient image. The order specifies
@@ -114,10 +114,20 @@ enum InterpolatorEnum {
    *  \sa itk::BSplineResampleImageFunction
    */
   sitkBSplineResampler = 11,
+  /** \brief Interpolator for a <b>BSpline coefficient image</b>, order 3.
+   */
   sitkBSplineResamplerOrder3 = 11,
+  /** \brief Interpolator for a <b>BSpline coefficient image</b>, order 1.
+   */
   sitkBSplineResamplerOrder1 = 12,
+  /** \brief Interpolator for a <b>BSpline coefficient image</b>, order 2.
+   */
   sitkBSplineResamplerOrder2 = 13,
+  /** \brief Interpolator for a <b>BSpline coefficient image</b>, order 4.
+   */
   sitkBSplineResamplerOrder4 = 14,
+  /** \brief Interpolator for a <b>BSpline coefficient image</b>, order 5.
+   */
   sitkBSplineResamplerOrder5 = 15
 
 


### PR DESCRIPTION
User attempted to use the sitkBSplineResamplerOrder3 for a regular
image. Documentation was there only for the sitkBSplineResampler
and the specific order resamplers weren't documented as intended for use
with a BSpline coefficient image.