### PR TITLE
Only require ITKCommon when finding ITK package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ include( sitkSITKLegacyNaming )
 include( sitkForbidDownloadsOption )
 include( sitkTargetUseITK )
 
-find_package(ITK REQUIRED )
+find_package(ITK COMPONENTS ITKCommon REQUIRED )
 #we require certain packages be turned on in ITK
 include(sitkCheckForITKModuleDependencies)
 

--- a/SuperBuild/SuperBuild.cmake
+++ b/SuperBuild/SuperBuild.cmake
@@ -365,7 +365,7 @@ option(SimpleITK_USE_SYSTEM_ITK "Use a pre-built version of ITK" OFF)
 sitk_legacy_naming( SimpleITK_USE_SYSTEM_ITK USE_SYSTEM_ITK )
 mark_as_advanced(SimpleITK_USE_SYSTEM_ITK)
 if(SimpleITK_USE_SYSTEM_ITK)
-  find_package(ITK REQUIRED)
+  find_package(ITK COMPONENTS ITKCommon REQUIRED)
   #we require certain packages be turned on in ITK
   include(sitkCheckForITKModuleDependencies)
 else()


### PR DESCRIPTION
Reduce the dependency requirements when finding ITK. All the available
ITK modules are still listed, but not loaded, so the introspection of
the ITK configuration can still be done.

Addresses build issues in 3D Slicer when ITKVTK module is
configured, but not all of VTK dependencies can be found automatically.

This is an alternative to #1471.