### PR TITLE
Explictly specify latest Ubuntu version

### DIFF
--- a/Testing/CI/Azure/azure-pipelines-package.yml
+++ b/Testing/CI/Azure/azure-pipelines-package.yml
@@ -37,6 +37,8 @@ jobs:
     dependsOn: Configure
     condition: ne( variables['configure.doxygen'], 'true' )
     timeoutInMinutes: 60
+    pool:
+      vmImage: 'ubuntu-latest'
     variables:
       SIMPLEITK_GIT_TAG: $[ dependencies.Configure.outputs['configure.BuildHash'] ]
     steps:

--- a/Testing/CI/Azure/templates/package-linux-job.yml
+++ b/Testing/CI/Azure/templates/package-linux-job.yml
@@ -7,6 +7,8 @@ jobs:
     dependsOn: Configure
     condition: ne( variables['configure.skiplinux'], 'true' )
     timeoutInMinutes: 300
+    pool:
+      vmImage: 'ubuntu-latest'
     variables:
       SIMPLEITK_GIT_TAG: $[ dependencies.Configure.outputs['configure.BuildHash'] ]
     steps:


### PR DESCRIPTION
When omitted the ubuntu16 pool was specified, and that is no longer
supported.