### PR TITLE
Added size message

### DIFF
--- a/Examples/ImageIOSelection/ImageIOSelection.R
+++ b/Examples/ImageIOSelection/ImageIOSelection.R
@@ -53,4 +53,8 @@ image <- tryCatch(file_reader$Execute(),
                   }
                   )
 cat('Read image:',args[1],'\n')
+
+size <- image$GetSize()
+cat ("Image size:", size[1], size[2])
+
 quit(save="no", status=0)

--- a/Examples/ImageIOSelection/ImageIOSelection.cs
+++ b/Examples/ImageIOSelection/ImageIOSelection.cs
@@ -48,6 +48,9 @@ namespace itk.simple.examples {
                 Image image = reader.Execute();
                 Console.WriteLine("Read image: " + args[0]);
 
+                VectorUInt32 size = image.GetSize();
+                Console.WriteLine( "Image size: " + size[0] + " " + size[1] );
+
             } catch (Exception ex) {
                 Console.WriteLine("Read failed: " + ex);
             }

--- a/Examples/ImageIOSelection/ImageIOSelection.cxx
+++ b/Examples/ImageIOSelection/ImageIOSelection.cxx
@@ -61,6 +61,9 @@ int main ( int argc, char* argv[] )
     {
     sitk::Image image = reader.Execute();
     std::cout << "Read image: " << argv[1] << std::endl;
+
+    std::vector<unsigned int> size = image.GetSize();
+    std::cout << "Image size: " << size[0] << " " << size[1] << std::endl;
     }
   catch (std::exception& e)
     {

--- a/Examples/ImageIOSelection/ImageIOSelection.java
+++ b/Examples/ImageIOSelection/ImageIOSelection.java
@@ -49,8 +49,11 @@ class ImageIOSelection {
     reader.setFileName(argv[0]);
 
     try {
-      Image img = reader.execute();
+      Image image = reader.execute();
       System.out.println("Read image: " + argv[0]);
+
+      VectorUInt32 size = image.getSize();
+      System.out.println("Image size: " + size.get(0) + " " + size.get(1));
     } catch(Exception e) {
       System.out.println("Read failed: " + e);
     }

--- a/Examples/ImageIOSelection/ImageIOSelection.lua
+++ b/Examples/ImageIOSelection/ImageIOSelection.lua
@@ -49,17 +49,21 @@ reader:SetFileName ( arg[1] )
 -- We need a function to pass to pcall, the Lua error handler.
 -- So we embed the reader's Execute method in this function.
 function read_execute( reader )
-  reader:Execute()
+  return reader:Execute()
 end
 
 -- Call the reader's execute method through Lua's pcall error handler
 --
-local status, err = pcall(read_execute, reader)
+local status, rv = pcall(read_execute, reader)
 if status then
   -- The reader succeeded
   write("Read image: ")
   write(arg[1])
   write("\n")
+
+  image = rv
+  size = image:GetSize();
+  print("Image size:", size[0], size[1]);
 else
   -- The reader failed
   write("Read failed: ")

--- a/Examples/ImageIOSelection/ImageIOSelection.py
+++ b/Examples/ImageIOSelection/ImageIOSelection.py
@@ -43,6 +43,9 @@ file_reader.SetFileName(sys.argv[1])
 try:
     image = file_reader.Execute()
     print('Read image: ' + sys.argv[1])
+
+    size = image.GetSize()
+    print("Image size:", size[0], size[1])
 except Exception as err:
     print('Reading failed: ', err)
     sys.exit(1)

--- a/Examples/ImageIOSelection/ImageIOSelection.rb
+++ b/Examples/ImageIOSelection/ImageIOSelection.rb
@@ -45,6 +45,9 @@ reader.set_image_io("PNGImageIO")
 begin
   image = reader.execute
   puts "Read image: " + ARGV[0]
+
+  size = image.get_size
+  puts "Image size: " + size[0] +  " " + size[1]
 rescue StandardError => e
   puts "Read failed: " + e.message
 end

--- a/Examples/ImageIOSelection/ImageIOSelection.tcl
+++ b/Examples/ImageIOSelection/ImageIOSelection.tcl
@@ -37,6 +37,8 @@ reader SetImageIO "PNGImageIO"
 if {[catch {set image [ reader Execute ]} errmsg]} {
   puts "Read failed: $errmsg"
 }
+set size [ $image GetSize ]
+puts "Image size: $size"
 
 # Tcl requires explicit cleanup Cleanup
 reader -delete


### PR DESCRIPTION
The examples now print the image size.  Done to avoid a Mono compiler
warning about an unused variable.