### PR TITLE
Address clang lambda capture warning

### DIFF
--- a/Testing/Unit/sitkDemonsRegistrationTests.cxx
+++ b/Testing/Unit/sitkDemonsRegistrationTests.cxx
@@ -48,7 +48,14 @@ sitk::DemonsRegistrationFilter filter;
 
 constexpr unsigned int stop_iteration = 2;
 
-auto stopLambda =  [&filter, stop_iteration] (){ if ( filter.GetElapsedIterations() >= stop_iteration ){ filter.StopRegistration();}};
+auto stopLambda =  [&filter, stop_iteration] ()
+{
+  (void) stop_iteration;
+  if ( filter.GetElapsedIterations() >= stop_iteration )
+  {
+    filter.StopRegistration();
+  }
+};
 filter.AddCommand(sitk::sitkIterationEvent, stopLambda);
 
 

--- a/Testing/Unit/sitkImageRegistrationMethodTests.cxx
+++ b/Testing/Unit/sitkImageRegistrationMethodTests.cxx
@@ -1193,6 +1193,7 @@ TEST_F(sitkRegistrationMethodTest, StopRegistration)
   constexpr unsigned int stop_iteration = 3;
   auto stopLambda =  [&R, stop_iteration] ()
   {
+    (void) stop_iteration;
     std::cout << R.GetOptimizerIteration() << " " << R.GetOptimizerPosition() << std::endl;
     if ( R.GetOptimizerIteration() >= stop_iteration )
     {


### PR DESCRIPTION
Fixes the following compilation warning:
warning: lambda capture 'stop_iteration' is not required to be
captured for this use [-Wunused-lambda-capture]