### PR TITLE
AZP is deprecating the macos-10.14 agent

### DIFF
--- a/Testing/CI/Azure/azure-pipelines-batch.yml
+++ b/Testing/CI/Azure/azure-pipelines-batch.yml
@@ -81,14 +81,11 @@ jobs:
           imageName: 'macos-10.15'
           xcodeVersion: 11.7
         XCode_11_2_1:
-          imageName: 'macos-10.14'
+          imageName: 'macos-10.15'
           xcodeVersion: 11.2.1
         XCode_10:
-          imageName: 'macos-10.14'
-          xcodeVersion: 10.2.1
-        XCode_9_4:
-          imageName: 'macos-10.14'
-          xcodeVersion: 9.4.1
+          imageName: 'macos-10.15'
+          xcodeVersion: 10.3
     pool:
       vmImage: $(imageName)
 

--- a/Testing/CI/Azure/azure-pipelines.yml
+++ b/Testing/CI/Azure/azure-pipelines.yml
@@ -63,8 +63,8 @@ jobs:
   - job: macOS
     timeoutInMinutes: 0
     variables:
-      imageName: 'macos-10.14'
-      xcodeVersion: 10.2
+      imageName: 'macos-10.15'
+      xcodeVersion: 10.3
     pool:
       vmImage: $(imageName)
 


### PR DESCRIPTION
Update requested angent, and remove old XCode versions.