### PR TITLE
Update ITK version to after 5.3rc02

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -61,7 +61,7 @@ set(ITK_GIT_REPOSITORY "${git_protocol}://github.com/InsightSoftwareConsortium/I
 mark_as_advanced(ITK_GIT_REPOSITORY)
 sitk_legacy_naming(ITK_GIT_REPOSITORY ITK_REPOSITORY)
 
-set(_DEFAULT_ITK_GIT_TAG "v5.3rc02")
+set(_DEFAULT_ITK_GIT_TAG "af32a779c4586304e52ddc27eb81656b949c9eeb")
 set(ITK_GIT_TAG "${_DEFAULT_ITK_GIT_TAG}" CACHE STRING "Tag in ITK git repo")
 mark_as_advanced(ITK_GIT_TAG)
 set(ITK_TAG_COMMAND GIT_TAG "${ITK_GIT_TAG}")


### PR DESCRIPTION
This includes a number of compilation warning fixes and a fix to the
windows linking error.