### PR TITLE
AZP Update CI to use windows 2019 and VS 16 2019

### DIFF
--- a/Testing/CI/Azure/azure-pipelines-batch.yml
+++ b/Testing/CI/Azure/azure-pipelines-batch.yml
@@ -23,10 +23,10 @@ jobs:
           CTEST_CMAKE_GENERATOR_TOOLSET: v141,host=x64
           CTEST_CMAKE_GENERATOR_PLATFORM: x64
           CTEST_CONFIGURATION_TYPE: Release
-          CTEST_CMAKE_GENERATOR: "Visual Studio 15 2017"
+          CTEST_CMAKE_GENERATOR: "Visual Studio 16 2019"
           ctest.cache_extra: |
             WRAP_CSHARP:BOOL=ON
-          imageName: 'vs2017-win2016'
+          imageName: 'windows-2019'
         v142-64:
           CTEST_CMAKE_GENERATOR_TOOLSET: v142,host=x64
           CTEST_CMAKE_GENERATOR_PLATFORM: x64
@@ -37,8 +37,8 @@ jobs:
           CTEST_CMAKE_GENERATOR_TOOLSET: v141
           CTEST_CMAKE_GENERATOR_PLATFORM: Win32
           CTEST_CONFIGURATION_TYPE: MinSizeRel
-          CTEST_CMAKE_GENERATOR: "Visual Studio 15 2017"
-          imageName: 'vs2017-win2016'
+          CTEST_CMAKE_GENERATOR: "Visual Studio 16 2019"
+          imageName: 'windows-2019'
 
     pool:
       vmImage: $(imageName)

--- a/Testing/CI/Azure/azure-pipelines.yml
+++ b/Testing/CI/Azure/azure-pipelines.yml
@@ -120,7 +120,7 @@ jobs:
   - job: Windows
     timeoutInMinutes: 0
     pool:
-      vmImage: 'vs2017-win2016'
+      vmImage: 'windows-2019'
     variables:
       PYTHON_ARCH: x64
       CMAKE_PLATFORM: x64
@@ -142,7 +142,7 @@ jobs:
         displayName: Build and test
         env:
           CTEST_OUTPUT_ON_FAILURE: 1
-          CTEST_CMAKE_GENERATOR: "Visual Studio 15 2017 Win64"
+          CTEST_CMAKE_GENERATOR: "Visual Studio 16 2019"
           CTEST_CMAKE_GENERATOR_TOOLSET: v141,host=x64
           CTEST_BINARY_DIRECTORY: $(coreBinaryDirectory)
           ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS: 2
@@ -169,7 +169,7 @@ jobs:
           rm -rf ${COREBINARYDIRECTORY}/ITK ${COREBINARYDIRECTORY}/ITK-build ${COREBINARYDIRECTORY}/SimpleITK-build
         displayName: Cleanup build
       - script: |
-          call  "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ variables.VCVAR_OPTIONS }} -vcvars_ver=14.0
+          call  "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ variables.VCVAR_OPTIONS }} -vcvars_ver=14.0
           bash $(Build.SourcesDirectory)/Testing/CI/Azure/scripts/win_build_java.sh
         displayName: Build Java
       - task: UsePythonVersion@0
@@ -178,6 +178,6 @@ jobs:
           versionSpec: '3.8'
           architecture: '${{ variables.PYTHON_ARCH }}'
       - script: |
-          call  "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"  ${{ variables.VCVAR_OPTIONS }} -vcvars_ver=14.0
+          call  "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"  ${{ variables.VCVAR_OPTIONS }} -vcvars_ver=14.0
           bash $(Build.SourcesDirectory)/Testing/CI/Azure/scripts/win_build_python.sh
         displayName: Build Python 38

--- a/Testing/CI/Azure/templates/package-win-job.yml
+++ b/Testing/CI/Azure/templates/package-win-job.yml
@@ -3,12 +3,12 @@ parameters:
   CMAKE_PLATFORM: x64
   VCVAR_OPTIONS: amd64
 jobs:
-  - job: VS2017
+  - job: VS2019
     dependsOn: Configure
     condition: ne( variables['configure.skipwindows'], 'true' )
     timeoutInMinutes: 0
     pool:
-      vmImage: 'vs2017-win2016'
+      vmImage: 'windows-2019'
     variables:
       coreBinaryDirectory:  '$(Agent.BuildDirectory)/sitk-build'
       CTEST_CONFIGURATION_TYPE: Release
@@ -25,9 +25,10 @@ jobs:
         continueOnError: true
         env:
           CTEST_OUTPUT_ON_FAILURE: 1
-          CTEST_CMAKE_GENERATOR: "Visual Studio 15 2017 Win64"
+          CTEST_CMAKE_GENERATOR: "Visual Studio 16 2019"
           CTEST_CMAKE_GENERATOR_TOOLSET: v141,host=x64
           CTEST_BINARY_DIRECTORY: $(coreBinaryDirectory)
+          CTEST_CMAKE_GENERATOR_PLATFORM: x64
           ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS: 2
           CXXFLAGS: /MP
           CFLAGS: /MP
@@ -45,7 +46,7 @@ jobs:
           rm -rf ${COREBINARYDIRECTORY}/SimpleITK-build
         displayName: Cleanup build
       - script: |
-          call  "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ parameters.VCVAR_OPTIONS }} -vcvars_ver=14.0
+          call  "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ parameters.VCVAR_OPTIONS }} -vcvars_ver=14.0
           bash $(Build.SourcesDirectory)/Testing/CI/Azure/scripts/win_build_java.sh
         displayName: Build Java
         continueOnError: true
@@ -55,7 +56,7 @@ jobs:
           artifactName: Java
         continueOnError: true
       - script: |
-          call  "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"  ${{ parameters.VCVAR_OPTIONS }} -vcvars_ver=14.0
+          call  "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"  ${{ parameters.VCVAR_OPTIONS }} -vcvars_ver=14.0
           bash $(Build.SourcesDirectory)/Testing/CI/Azure/scripts/win_build_csharp.sh
         displayName: Build CSharp
         continueOnError: true
@@ -72,7 +73,7 @@ jobs:
           versionSpec: '3.10'
           architecture: '${{ parameters.PYTHON_ARCH }}'
       - script: |
-          call  "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"  ${{ parameters.VCVAR_OPTIONS }} -vcvars_ver=14.0
+          call  "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"  ${{ parameters.VCVAR_OPTIONS }} -vcvars_ver=14.0
           bash $(Build.SourcesDirectory)/Testing/CI/Azure/scripts/win_build_python.sh
         displayName: Build Python 310
         continueOnError: true
@@ -82,7 +83,7 @@ jobs:
           versionSpec: '3.9'
           architecture: '${{ parameters.PYTHON_ARCH }}'
       - script: |
-          call  "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"  ${{ parameters.VCVAR_OPTIONS }} -vcvars_ver=14.0
+          call  "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"  ${{ parameters.VCVAR_OPTIONS }} -vcvars_ver=14.0
           bash $(Build.SourcesDirectory)/Testing/CI/Azure/scripts/win_build_python.sh
         displayName: Build Python 39
         continueOnError: true
@@ -92,7 +93,7 @@ jobs:
           versionSpec: '3.8'
           architecture: '${{ parameters.PYTHON_ARCH }}'
       - script: |
-          call  "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"  ${{ parameters.VCVAR_OPTIONS }} -vcvars_ver=14.0
+          call  "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"  ${{ parameters.VCVAR_OPTIONS }} -vcvars_ver=14.0
           bash $(Build.SourcesDirectory)/Testing/CI/Azure/scripts/win_build_python.sh
         displayName: Build Python 38
         continueOnError: true
@@ -102,7 +103,7 @@ jobs:
           versionSpec: '3.7'
           architecture: '${{ parameters.PYTHON_ARCH }}'
       - script: |
-          call  "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"  ${{ parameters.VCVAR_OPTIONS }} -vcvars_ver=14.0
+          call  "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"  ${{ parameters.VCVAR_OPTIONS }} -vcvars_ver=14.0
           bash $(Build.SourcesDirectory)/Testing/CI/Azure/scripts/win_build_python.sh
         displayName: Build Python 37
         continueOnError: true
@@ -112,7 +113,7 @@ jobs:
           versionSpec: '3.6'
           architecture: '${{ parameters.PYTHON_ARCH }}'
       - script: |
-          call  "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ parameters.VCVAR_OPTIONS }} -vcvars_ver=14.0
+          call  "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ parameters.VCVAR_OPTIONS }} -vcvars_ver=14.0
           bash $(Build.SourcesDirectory)/Testing/CI/Azure/scripts/win_build_python.sh
         displayName: Build Python 36
         continueOnError: true


### PR DESCRIPTION
AZP has deprecated window 2016:
https://github.com/actions/virtual-environments/issues/4312