### PR TITLE
AZP Use pipeline artifact

### DIFF
--- a/Testing/CI/Azure/azure-pipelines-package.yml
+++ b/Testing/CI/Azure/azure-pipelines-package.yml
@@ -53,7 +53,5 @@ jobs:
           docker cp sitk-dox:/SimpleITKDoxygen.tar.gz $(Build.ArtifactStagingDirectory)/Doxygen/SimpleITKDoxygen-${SIMPLEITK_GIT_TAG}.tar.gz
           docker cp sitk-dox:/SimpleITKDoxygenXML.tar.gz $(Build.ArtifactStagingDirectory)/Doxygen/SimpleITKDoxygenXML-${SIMPLEITK_GIT_TAG}.tar.gz
         displayName: Docker doxygen generation
-      - task: PublishBuildArtifacts@1
-        inputs:
-          pathtoPublish: $(Build.ArtifactStagingDirectory)/Doxygen
-          artifactName: Doxygen
+      - publish: $(Build.ArtifactStagingDirectory)/Doxygen
+        artifact: Doxygen

--- a/Testing/CI/Azure/templates/package-linux-job.yml
+++ b/Testing/CI/Azure/templates/package-linux-job.yml
@@ -37,7 +37,5 @@ jobs:
           contents: '*.whl'
           targetFolder: $(Build.ArtifactStagingDirectory)/python
           flattenFolders: true
-      - task: PublishBuildArtifacts@1
-        inputs:
-          pathtoPublish: $(Build.ArtifactStagingDirectory)/python
-          artifactName: Python
+      - publish: $(Build.ArtifactStagingDirectory)/python
+        artifact: Python

--- a/Testing/CI/Azure/templates/package-mac-job.yml
+++ b/Testing/CI/Azure/templates/package-mac-job.yml
@@ -122,7 +122,5 @@ jobs:
       - bash: ${BUILD_SOURCESDIRECTORY}/Testing/CI/Azure/scripts/mac_build_python.sh
         displayName: Build Python 36
         continueOnError: true
-      - task: PublishBuildArtifacts@1
-        inputs:
-          pathtoPublish: $(Build.ArtifactStagingDirectory)/python
-          artifactName: Python
+      - publish: $(Build.ArtifactStagingDirectory)/python
+        actifact: Python

--- a/Testing/CI/Azure/templates/package-win-job.yml
+++ b/Testing/CI/Azure/templates/package-win-job.yml
@@ -117,7 +117,5 @@ jobs:
           bash $(Build.SourcesDirectory)/Testing/CI/Azure/scripts/win_build_python.sh
         displayName: Build Python 36
         continueOnError: true
-      - task: PublishBuildArtifacts@1
-        inputs:
-          pathtoPublish: $(Build.ArtifactStagingDirectory)/python
-          artifactName: Python
+      - publish: $(Build.ArtifactStagingDirectory)/python
+        artifact: Python


### PR DESCRIPTION
The build artifacts and tasks are depricated. Use the publish keyword
which is an alias for the PublishPipelineArtifact.

The old PublishBuildArtifacts task was producing node js version
warninings on linux.