### PR TITLE
Add Python interface for EvaluateAt methods

### DIFF
--- a/Testing/Unit/Python/sitkImageTests.py
+++ b/Testing/Unit/Python/sitkImageTests.py
@@ -327,6 +327,66 @@ class ImageTests(unittest.TestCase):
         image %= 4
         self.assertEqual(image[1, 1], 2)
 
+    def test_evaluate_at_continuous_index(self):
+        """Test for EvaluateAtContinuousIndex"""
+
+        for pixel_type in (sitk.sitkFloat32, sitk.sitkFloat64,
+                           sitk.sitkUInt8, sitk.sitkInt8,
+                           sitk.sitkUInt16, sitk.sitkInt16,
+                           sitk.sitkUInt32, sitk.sitkInt32,
+                           sitk.sitkUInt64, sitk.sitkInt64):
+            image = sitk.Image([2, 2], pixel_type)
+            result = image.EvaluateAtContinuousIndex([0.5, 0.5])
+            self.assertEqual(result, 0.0)
+            self.assertEqual(type(result), float)
+
+        for pixel_type in (sitk.sitkComplexFloat32,
+                           sitk.sitkComplexFloat64):
+            image = sitk.Image([2, 2], pixel_type)
+            result = image.EvaluateAtContinuousIndex([0.5, 0.5])
+            self.assertEqual(result, complex(0.0, 0.0))
+            self.assertEqual(type(result), complex)
+
+        for pixel_type in (sitk.sitkVectorFloat32, sitk.sitkVectorFloat64,
+                           sitk.sitkVectorUInt8, sitk.sitkVectorInt8,
+                           sitk.sitkVectorUInt16, sitk.sitkVectorInt16,
+                           sitk.sitkVectorUInt32, sitk.sitkVectorInt32,
+                           sitk.sitkVectorUInt64, sitk.sitkVectorInt64):
+            image = sitk.Image([2, 2], pixel_type, 7)
+            result = image.EvaluateAtContinuousIndex([0.5, 0.5])
+            self.assertEqual(len(result), 7)
+            self.assertTrue(all(i == 0 for i in result))
+
+    def test_evaluate_at_physical_point(self):
+        """Test for EvaluateAtPhysicalPoint"""
+
+        for pxiel_type in (sitk.sitkFloat32, sitk.sitkFloat64,
+                           sitk.sitkUInt8, sitk.sitkInt8,
+                           sitk.sitkUInt16, sitk.sitkInt16,
+                           sitk.sitkUInt32, sitk.sitkInt32,
+                           sitk.sitkUInt64, sitk.sitkInt64):
+            image = sitk.Image([2, 2], pxiel_type)
+            result = image.EvaluateAtPhysicalPoint([0.5, 0.5])
+            self.assertEqual(result, 0.0)
+            self.assertEqual(type(result), float)
+
+        for pxiel_type in (sitk.sitkComplexFloat32,
+                           sitk.sitkComplexFloat64):
+            image = sitk.Image([2, 2], pxiel_type)
+            result = image.EvaluateAtPhysicalPoint([0.5, 0.5])
+            self.assertEqual(result, complex(0.0, 0.0))
+            self.assertEqual(type(result), complex)
+
+        for pxiel_type in (sitk.sitkVectorFloat32, sitk.sitkVectorFloat64,
+                           sitk.sitkVectorUInt8, sitk.sitkVectorInt8,
+                           sitk.sitkVectorUInt16, sitk.sitkVectorInt16,
+                           sitk.sitkVectorUInt32, sitk.sitkVectorInt32,
+                           sitk.sitkVectorUInt64, sitk.sitkVectorInt64):
+            image = sitk.Image([2, 2], pxiel_type, 7)
+            result = image.EvaluateAtPhysicalPoint([0.5, 0.5])
+            self.assertEqual(len(result), 7)
+            self.assertTrue(all(i == 0 for i in result))
+
     def test_legacy(self):
         """ This is old testing cruft before unittest"""
 

--- a/Wrapping/Python/sitkImage.i
+++ b/Wrapping/Python/sitkImage.i
@@ -63,6 +63,8 @@
 %rename( __SetPixelAsComplexFloat32__ ) itk::simple::Image::SetPixelAsComplexFloat32;
 %rename( __SetPixelAsComplexFloat64__ ) itk::simple::Image::SetPixelAsComplextFloat64;
 
+%rename( __EvaluateAtContinuousIndex__ ) itk::simple::Image::EvaluateAtContinuousIndex;
+%rename( __EvaluateAtPhysicalPoint__ ) itk::simple::Image::EvaluateAtPhysicalPoint;
 
 %pythoncode %{
    import operator
@@ -885,6 +887,76 @@
 
           raise Exception("unknown pixel type")
 
+        @staticmethod
+        def _tuple_to_py_type(v, pixelID):
+          if pixelID in (sitkComplexFloat32, sitkComplexFloat64):
+              return complex(*v)
+          elif pixelID in (sitkVectorUInt8, sitkVectorInt8,
+                           sitkVectorUInt16, sitkVectorInt16,
+                           sitkVectorUInt32, sitkVectorInt32,
+                           sitkVectorUInt64, sitkVectorInt64,
+                           sitkVectorFloat32, sitkVectorFloat64):
+              return v
+          elif pixelID in (sitkUInt8, sitkInt8,
+                           sitkUInt16, sitkInt16,
+                           sitkUInt32, sitkInt32,
+                           sitkUInt64, sitkInt64,
+                           sitkFloat32, sitkFloat64,
+                           sitkLabelUInt8,
+                           sitkLabelUInt16,
+                           sitkLabelUInt32,
+                           sitkLabelUInt64):
+            assert(len(v)==1)
+            return v[0]
+          else:
+            raise ValueError(f"pixelID of {pixelID} is not supported.")
+
+        def EvaluateAtContinuousIndex(self, index, interp = sitkLinear):
+          """Interpolate pixel value at a continuous index.
+
+          This method is not supported for Label pixel types.
+
+          The valid range of continuous index is [-0.5, size-0.5] for each dimension. An exception is thrown if index is out of bounds.
+
+          Parameters
+          ----------
+          index
+            The continuous index must be at least the length of the image dimension.
+          interp
+            The interpolation type to use, only sitkNearest and sitkLinear are supported for Vector and Complex pixel types.
+
+          Returns
+          -------
+            The results will be of type float, complex, or an tuple of float of vectors.
+
+          """
+
+          r = self.__EvaluateAtContinuousIndex__(index, interp)
+
+          return self._tuple_to_py_type(r, self.GetPixelIDValue())
+
+        def EvaluateAtPhysicalPoint(self, point, interp = sitkLinear):
+          """ Interpolate pixel value at a physical point.
+
+          This method is not supported for Label pixel types.
+
+          An exception is thrown if the point is out of the defined region for the image.
+
+          Parameters
+          ----------
+          point
+            The physical point at which the interpolation is computed.
+          interp
+            The interpolation type to use, only sitkNearest and sitkLinear are supported for Vector and Complex pixel types.
+
+          Returns
+          -------
+            The results will be of type float, complex, or an tuple of float of vectors.
+          """
+
+          r = self.__EvaluateAtPhysicalPoint__(point, interp)
+
+          return self._tuple_to_py_type(r, self.GetPixelIDValue())
 
          %}
 


### PR DESCRIPTION
The Python methods change scalar type to be scalars (float), and
complex to be complex type, while the vector pixel types remain as
tuples.