### PR TITLE
Fix number of components for vector distance map

### DIFF
--- a/Code/Common/include/sitkImageConvert.hxx
+++ b/Code/Common/include/sitkImageConvert.hxx
@@ -214,6 +214,7 @@ GetVectorImageFromImage( itk::Image< itk::Offset< NLength >, NImageDimension> *i
 
 
   out->CopyInformation( img );
+  out->SetNumberOfComponentsPerPixel(NLength);
   out->SetRegions( img->GetBufferedRegion() );
 
   assert(out->GetNumberOfComponentsPerPixel() == NLength);

--- a/Testing/Unit/sitkBasicFiltersTests.cxx
+++ b/Testing/Unit/sitkBasicFiltersTests.cxx
@@ -893,6 +893,7 @@ TEST(BasicFilters, SignedDanielssonDistanceMap_Measurements)
 
   voronoiMap = filter.GetVoronoiMap();
   vectorDistanceMap = filter.GetVectorDistanceMap();
+  EXPECT_EQ(img.GetDimension(), vectorDistanceMap.GetNumberOfComponentsPerPixel());
   }
 }
 


### PR DESCRIPTION
The internal ITK pixel type is Offset, which does not have
NumericTraits. The itk::Image::CopyInformation does not copy the
number of components correctly, so it is manually set.