### PR TITLE
Move datetime code to python file

### DIFF
--- a/Utilities/Doxygen/Doxygen.cmake
+++ b/Utilities/Doxygen/Doxygen.cmake
@@ -73,9 +73,14 @@ if (BUILD_DOXYGEN)
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/Utilities/Doxygen
     )
 
-  execute_process(COMMAND ${PYTHON_EXECUTABLE}
-    -c "import  time;import sys; sys.stdout.write(time.strftime('%a, %d %b %Y %H:%M:%S +0000', time.gmtime()))"
-             OUTPUT_VARIABLE _DATETIME)
+  execute_process(COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_LIST_DIR}/datetime.py"
+    RESULT_VARIABLE CMD_RESULT
+    OUTPUT_VARIABLE _DATETIME)
+
+  if (CMD_RESULT)
+    message(FATAL_ERROR "Datetime failed!")
+  endif()
+
 
   configure_file(${PROJECT_SOURCE_DIR}/Utilities/Doxygen/build_text.js.in
     "${PROJECT_BINARY_DIR}/Documentation/html/build_text.js")

--- a/Utilities/Doxygen/datetime.py
+++ b/Utilities/Doxygen/datetime.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+#
+#  Copyright NumFOCUS
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Writes the date and time in RFC 2822 format to stdout
+
+import  time
+import sys
+sys.stdout.write(time.strftime('%a, %d %b %Y %H:%M:%S +0000', time.gmtime()))

--- a/Utilities/Doxygen/docker/run.sh
+++ b/Utilities/Doxygen/docker/run.sh
@@ -23,6 +23,7 @@ mkdir -p ${BLD_DIR} && \
     cmake -G Ninja\
           -DBUILD_DOXYGEN=ON\
           -DWRAP_DEFAULT=OFF\
+          -DPYTHON_EXECUTABLE=$(which python)\
           -DSimpleITK_BUILD_DISTRIBUTE:BOOL=ON\
           ${SRC_DIR}/SuperBuild/ && \
     cmake --build . --target SimpleITK-doc && \

--- a/Utilities/Doxygen/header.html
+++ b/Utilities/Doxygen/header.html
@@ -47,7 +47,7 @@ $extrastylesheet
   <!--BEGIN PROJECT_NAME-->
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">$projectname
-   <!--BEGIN PROJECT_NUMBER-->&#160;<span id="projectnumber">unknown</span><!--END PROJECT_NUMBER-->
+   <!--BEGIN PROJECT_NUMBER-->&#160;<span id="projectnumber"></span><!--END PROJECT_NUMBER-->
    </div>
    <!--BEGIN PROJECT_BRIEF--><div id="projectbrief">$projectbrief</div><!--END PROJECT_BRIEF-->
   </td>


### PR DESCRIPTION
The python files use "env" to locate a python executable if
PYTHON_EXECUTABLE is not defined in CMake.