### PR TITLE
Use itk_generate_factory_registration and update to ITK 5.3rc03

### DIFF
--- a/CMake/sitkTargetUseITK.cmake
+++ b/CMake/sitkTargetUseITK.cmake
@@ -32,3 +32,17 @@ function(sitk_target_use_itk target_name interface_keyword)
   endif()
 
 endfunction()
+
+function(sitk_target_use_itk_factory target_name factory_name)
+  itk_generate_factory_registration(${factory_name} )
+
+  string(TOUPPER ${factory_name} factory_uc)
+
+  target_compile_definitions( ${target_name}
+    PRIVATE
+    ITK_${factory_uc}_FACTORY_REGISTER_MANAGER)
+
+  target_include_directories( ${target_name}
+    PRIVATE
+    "${CMAKE_CURRENT_BINARY_DIR}/ITKFactoryRegistration" )
+endfunction()

--- a/Code/BasicFilters/src/CMakeLists.txt
+++ b/Code/BasicFilters/src/CMakeLists.txt
@@ -58,7 +58,7 @@ function(add_filter_library library_name src_list_var itk_module_list_var)
 endfunction()
 
 
-find_package(ITK COMPONENTS ITKCommon REQUIRED)
+find_package(ITK COMPONENTS ITKCommon REQUIRED OPTIONAL_COMPONENTS ITKFFT )
 
 
 # common source which all basic filter libraries need to be linked against
@@ -169,3 +169,7 @@ add_filter_library(SimpleITKBasicFilters1 SimpleITKBasicFilters1Source no_itk_de
 
 target_link_libraries ( SimpleITKBasicFilters1
   PRIVATE ${PREV_SimpleITK_LIBRARIES} )
+
+sitk_target_use_itk_factory( SimpleITK_ITKFFT FFT )
+sitk_target_use_itk_factory( SimpleITK_ITKConvolution FFT )
+sitk_target_use_itk_factory( SimpleITK_ITKDeconvolution FFT )

--- a/Code/IO/src/CMakeLists.txt
+++ b/Code/IO/src/CMakeLists.txt
@@ -16,9 +16,12 @@ set(use_itk_modules  ITKCommon ITKLabelMap ITKImageCompose
   ITKImageIO ITKTransformIO )
 
 find_package(ITK COMPONENTS ${use_itk_modules} )
-include(${ITK_USE_FILE})
+
+
 add_library ( SimpleITKIO ${SimpleITKIOSource} )
 sitk_target_use_itk ( SimpleITKIO PRIVATE ${use_itk_modules} )
+sitk_target_use_itk_factory( SimpleITKIO ImageIO )
+sitk_target_use_itk_factory( SimpleITKIO TransformIO )
 target_link_libraries ( SimpleITKIO
   PUBLIC  SimpleITKCommon )
 if (SimpleITK_EXPLICIT_INSTANTIATION)

--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -62,7 +62,7 @@ set(ITK_GIT_REPOSITORY "${git_protocol}://github.com/InsightSoftwareConsortium/I
 mark_as_advanced(ITK_GIT_REPOSITORY)
 sitk_legacy_naming(ITK_GIT_REPOSITORY ITK_REPOSITORY)
 
-set(_DEFAULT_ITK_GIT_TAG "af32a779c4586304e52ddc27eb81656b949c9eeb")
+set(_DEFAULT_ITK_GIT_TAG "v5.3rc03")
 set(ITK_GIT_TAG "${_DEFAULT_ITK_GIT_TAG}" CACHE STRING "Tag in ITK git repo")
 mark_as_advanced(ITK_GIT_TAG)
 set(ITK_TAG_COMMAND GIT_TAG "${ITK_GIT_TAG}")

--- a/Testing/Unit/CMakeLists.txt
+++ b/Testing/Unit/CMakeLists.txt
@@ -2,8 +2,12 @@
 # libraries. So they are not needed again, additionally using ITK this
 # way will not cause the headers to be generated, so the managers
 # should not be used.
-set ( ITK_NO_IO_FACTORY_REGISTER_MANAGER 1 )
-set ( ITK_NO_FFT_FACTORY_REGISTER_MANAGER 1 )
+
+# set ( ITK_NO_IO_FACTORY_REGISTER_MANAGER 1 )
+foreach(_f ${ITK_FACTORY_LIST})
+  string(TOUPPER ${_f} _f)
+  set ( ITK_NO_${_f}_FACTORY_REGISTER_MANAGER 1 )
+endforeach()
 include(${ITK_USE_FILE})
 
 

--- a/Testing/Unit/Python/ConcurrentImageRead.py
+++ b/Testing/Unit/Python/ConcurrentImageRead.py
@@ -79,7 +79,7 @@ class ConcurrentImageRead(unittest.TestCase):
 
 
 # Programmatically generate tests for different file formats
-for p_ext_hash in [("jpg", "44fac4bedde4df04b9572ac665d3ac2c5cd00c7d"),
+for p_ext_hash in [("jpg", "44fac4bedde4df04b9572ac665d3ac2c5cd00c7d", sitk.sitkUInt8),
                    ("tiff", "ba713b819c1202dcb0d178df9d2b3222ba1bba44", sitk.sitkUInt16),
                    ("png", "ba713b819c1202dcb0d178df9d2b3222ba1bba44", sitk.sitkUInt16),
                    ("nii", "7b91dbdc56c5781edf6c8847b4aa6965566c5c75"),


### PR DESCRIPTION
ITK 5.3 adds FFT factories which need special configuration to
ensure the generated FFT factory code is generated and registered for
the appropriate SimpleITK targets.

Use new itk_generate_factory_registration CMake function to generate
private registration methods, which find grain control of factories.