### PR TITLE
WIP: Return an sitk::Transform with ITK specific pimple object

### DIFF
--- a/Code/Registration/src/sitkImageRegistrationMethod.cxx
+++ b/Code/Registration/src/sitkImageRegistrationMethod.cxx
@@ -994,23 +994,14 @@ Transform ImageRegistrationMethod::ExecuteInternal ( const Image &inFixed, const
     }
   else
     {
-    // TOOD: It should not be necessary to return a composite
-    // transform the sitk::Transform class is missing a constructor
-    // which accepts an arbitrary ITK transform.
     typename RegistrationType::OutputTransformType* itkOutTx = registration->GetModifiableTransform();
-
-    using CompositeTransformType = itk::CompositeTransform<double, ImageDimension>;
-
-    typename CompositeTransformType::Pointer comp = CompositeTransformType::New();
-    comp->ClearTransformQueue();
-    comp->AddTransform( itkOutTx );
 
     if (m_pfUpdateWithBestValue)
       {
-      m_pfUpdateWithBestValue(comp);
+      m_pfUpdateWithBestValue(itkOutTx);
       }
 
-    return Transform(comp.GetPointer());
+    return Transform(itkOutTx);
     }
 }
 


### PR DESCRIPTION
The returned object from ImageRegistrationMethod::Execute when the
InitialTransform had inPlace=False, was an sitk::Transform holding a
itk::CompositeTransform pimple object. The composite transform then
held an optimized transform of the initial type.

While the return type for the method remains a sitk::Transform, the
object held in the pimple transform is now the optimized transform of
the initial type.