### PR TITLE
Add type annotation into Python wrapper

### DIFF
--- a/Wrapping/Python/CMakeLists.txt
+++ b/Wrapping/Python/CMakeLists.txt
@@ -94,7 +94,7 @@ configure_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/SimpleITK/_version.py.in"
   "${CMAKE_CURRENT_BINARY_DIR}/SimpleITK/_version.py" )
 
-set(SimpleITK_Py_Files "__init__.py" "extra.py" )
+set(SimpleITK_Py_Files "__init__.py" "extra.py" "py.typed" )
 
 if(DEFINED SKBUILD)
   # Currently this installation

--- a/Wrapping/Python/Packaging/setup.py.in
+++ b/Wrapping/Python/Packaging/setup.py.in
@@ -52,7 +52,7 @@ setup(
     author_email = 'insight-users@itk.org',
     ext_modules=[Extension('SimpleITK._SimpleITK', [r'SimpleITK/@SimpleITK_BINARY_MODULE@'])],
     packages= ['SimpleITK'],
-    package_data = {"SimpleITK": doc_files},
+    package_data = {"SimpleITK": doc_files + ["py.typed"]},
     platforms = [],
     description = r'SimpleITK is a simplified interface to the Insight Toolkit (ITK) for image registration and segmentation',
     long_description = long_description,

--- a/Wrapping/Python/SimpleITK/extra.py
+++ b/Wrapping/Python/SimpleITK/extra.py
@@ -16,11 +16,15 @@
 #
 # ========================================================================
 
+from pathlib import Path
 from SimpleITK.SimpleITK import *
 from SimpleITK.SimpleITK import _GetMemoryViewFromImage
 from SimpleITK.SimpleITK import _SetImageFromArray
 
-from typing import List, Optional, Type, Union
+from typing import Iterable, List, Optional, Type, Union
+
+
+PathType = Union[str, Path, Iterable[str], Iterable[Path]]
 
 
 def Resample(image1: Image, *args, **kwargs) -> Image:
@@ -301,7 +305,7 @@ def GetImageFromArray(arr: "numpy.ndarray", isVector: Optional[bool] = None) -> 
 
 
 def ReadImage(
-    fileName: Union[str, List[str]],
+    fileName: PathType,
     outputPixelType: int = sitkUnknown,
     imageIO: str = "",
 ) -> Image:
@@ -335,12 +339,12 @@ def ReadImage(
 
     """
 
-    if isinstance(fileName, str):
+    if isinstance(fileName, (str, Path)):
         reader = ImageFileReader()
-        reader.SetFileName(fileName)
+        reader.SetFileName(str(fileName))
     else:
         reader = ImageSeriesReader()
-        reader.SetFileNames(fileName)
+        reader.SetFileNames([str(name) for name in fileName])
 
     reader.SetImageIO(imageIO)
     reader.SetOutputPixelType(outputPixelType)
@@ -348,13 +352,13 @@ def ReadImage(
 
 
 def WriteImage(
-        image: Image,
-        fileName: Union[str, List[str]],
-        useCompression: bool = False,
-        compressionLevel: int = -1,
-        *,
-        imageIO: str = "",
-        compressor: str = "",
+    image: Image,
+    fileName: PathType,
+    useCompression: bool = False,
+    compressionLevel: int = -1,
+    *,
+    imageIO: str = "",
+    compressor: str = "",
 ) -> None:
     r"""
     WriteImage is a procedural interface to the ImageFileWriter and ImageSeriesWriter classes which is convenient for
@@ -383,12 +387,12 @@ def WriteImage(
      itk::simple::ImageFileWriter for writing a single file.
      itk::simple::ImageSeriesWriter for writing a series of files
     """
-    if isinstance(fileName, str):
+    if isinstance(fileName, (str, Path)):
         writer = ImageFileWriter()
-        writer.SetFileName(fileName)
+        writer.SetFileName(str(fileName))
     else:
         writer = ImageSeriesWriter()
-        writer.SetFileNames(fileName)
+        writer.SetFileNames([str(name) for name in fileName])
 
     writer.SetUseCompression(useCompression)
     writer.SetCompressionLevel(compressionLevel)

--- a/Wrapping/Python/SimpleITK/extra.py
+++ b/Wrapping/Python/SimpleITK/extra.py
@@ -27,7 +27,13 @@ from typing import Iterable, List, Optional, Type, Union
 PathType = Union[str, Path, Iterable[str], Iterable[Path]]
 
 
-def Resample(image1: Image, *args, **kwargs) -> Image:
+def Resample(
+    image1: Image,
+    *args,
+    referenceImage: Optional[Image] = None,
+    size: Optional[int] = None,
+    **kwargs,
+) -> Image:
     """
      Resample ( Image image1,
                 Transform transform = itk::simple::Transform(),
@@ -106,13 +112,13 @@ def Resample(image1: Image, *args, **kwargs) -> Image:
             try:
                 iter(args[0])
                 return _r(*args, **kwargs)
-            except TypeError as e:
+            except TypeError:
                 pass
 
-    if "referenceImage" in kwargs:
-        return _r_image(*args, **kwargs)
-    if "size" in kwargs:
-        return _r(*args, **kwargs)
+    if referenceImage is not None:
+        return _r_image(referenceImage, *args, **kwargs)
+    if size is not None:
+        return _r(size, *args, **kwargs)
 
     return _r_image(image1, *args, **kwargs)
 


### PR DESCRIPTION
1. Add type annotation to pure Python function in the Python wrapper.
2. Support [pathlib.Path](https://docs.python.org/3/library/pathlib.html) as the type of the `fileName` argument.
3. Add [py.typed](https://www.python.org/dev/peps/pep-0561/#packaging-type-information) into the wrapper. I'm not sure if it's properly packaged, though, it requires to rebuild the whole SimpleITK to test which is quite demanding for resources. So I'm more guessing there.
4. Improve arguments for Resample function: make `referenceImage` and `size` explicit arguments instead of hiding it inside `**kwargs`.