### PR TITLE
Add downcast to Python ReadTransform procedure

### DIFF
--- a/Testing/Unit/Python/sitkTransformTests.py
+++ b/Testing/Unit/Python/sitkTransformTests.py
@@ -390,6 +390,12 @@ class TransformTests(unittest.TestCase):
                 sitk.WriteTransform(tx, fname)
                 read_tx = sitk.ReadTransform(fname)
                 self.assertEqual(tx, read_tx.Downcast(), msg=f"Testing I/O {k} with {ext}")
+                self.assertEqual(read_tx, read_tx.Downcast(), msg=f"Testing ReadTransform downcast")
+
+                sitk.WriteTransform(sitk.Transform(tx), fname)
+                read_tx = sitk.ReadTransform(fname)
+                self.assertEqual(tx, read_tx.Downcast(), msg=f"Testing I/O Transform {k} with {ext}")
+                self.assertEqual(read_tx, read_tx.Downcast(), msg=f"Testing ReadTransform downcast")
 
     def test_downcast_returned(self):
         """

--- a/Wrapping/Python/sitkTransform.i
+++ b/Wrapping/Python/sitkTransform.i
@@ -32,6 +32,11 @@
  val = val.Downcast()
 };
 
+%pythonappend itk::simple::ReadTransform( const std::string &filename )
+{
+ val = val.Downcast()
+};
+
 %extend itk::simple::Transform {
    %pythoncode
 %{


### PR DESCRIPTION
The returned class is now the concrete class derived from Transform.

closes  #1564