### PR TITLE
Fix GetVectorImageFromImage for 32-bits

### DIFF
--- a/Code/Common/include/sitkImageConvert.h
+++ b/Code/Common/include/sitkImageConvert.h
@@ -56,7 +56,7 @@ SITKCommon_HIDDEN
 typename itk::VectorImage<
   typename std::conditional<sizeof(typename itk::Offset< NLength >::OffsetValueType) == sizeof(int64_t),
     int64_t,
-    FalseType>::type, NImageDimension >::Pointer
+    int32_t>::type, NImageDimension >::Pointer
 GetVectorImageFromImage( itk::Image< itk::Offset< NLength >, NImageDimension> *img, bool transferOwnership = false );
 
 

--- a/Code/Common/include/sitkImageConvert.hxx
+++ b/Code/Common/include/sitkImageConvert.hxx
@@ -169,7 +169,7 @@ SITKCommon_HIDDEN
 typename itk::VectorImage<
   typename std::conditional<sizeof(typename itk::Offset< NLength >::OffsetValueType) == sizeof(int64_t),
     int64_t,
-    FalseType>::type, NImageDimension >::Pointer
+    int32_t>::type, NImageDimension >::Pointer
 GetVectorImageFromImage( itk::Image< itk::Offset< NLength >, NImageDimension> *img, bool transferOwnership )
 {
 


### PR DESCRIPTION
The FalseType was incorrectly specified for 32-bit systems.

Addresses compilation errors on windows 32-bit batch build.