### PR TITLE
Updating documentation to v.2.2.0 functionality.

### DIFF
--- a/Examples/SimpleIO/SimpleIO.py
+++ b/Examples/SimpleIO/SimpleIO.py
@@ -59,7 +59,7 @@ def example3():
   sitk.WriteTransform(basic_transform, 'euler2D.tfm')
   read_result = sitk.ReadTransform('euler2D.tfm')
 
-  assert(str(type(read_result) != type(basic_transform)))
+  assert(type(read_result) == type(basic_transform))
 
 
 import sys

--- a/docs/source/IO.rst
+++ b/docs/source/IO.rst
@@ -215,8 +215,9 @@ reading it back, and then comparing the results.
        :language: tcl
        :lines: 47-59
 
-``read_result`` returns an object of the generic ``sitk.Transform()`` class and
-``basic_transform`` creates a ``sitk.Euler2DTransform()`` object, but both
+In all languages, except Python, ``read_result`` returns an object of the
+generic ``sitk.Transform()`` class and ``basic_transform`` creates a
+``sitk.Euler2DTransform()`` object, but both
 represent the same transformation. Although this example only uses a single
 SimpleITK transformation, a .tfm file can hold a composite (set of
 transformations).


### PR DESCRIPTION
Starting with v2.2.0 ReadTransform in Python automatically downcasts,
so the return type is the basic type and not the generic Transform().