### PR TITLE
Python Resample procedure fix keyword exception

### DIFF
--- a/Testing/Unit/Python/sitkBasicFilterTests.py
+++ b/Testing/Unit/Python/sitkBasicFilterTests.py
@@ -80,6 +80,27 @@ class BasicFiltersTests(unittest.TestCase):
         self.assertImageAlmostEqual( baseline_image,
                                      sitk.Resample(img, size=(64, 64), transform=tx, defaultPixelValue=255.0, outputPixelType=sitk.sitkFloat64 ) )
 
+        with self.assertRaises(TypeError) as cm:
+             sitk.Resample(img, img, wrong_keyword1=img)
+        self.assertTrue("unexpected keyword argument" in str(cm.exception))
+
+        with self.assertRaises(TypeError) as cm:
+            sitk.Resample(img, [64,64], wrong_keyword2=img)
+        self.assertTrue("unexpected keyword argument" in str(cm.exception))
+
+        with self.assertRaises(TypeError) as cm:
+            sitk.Resample(img, referenceImage=img, wrong_keyword3=img)
+        self.assertTrue("unexpected keyword argument" in str(cm.exception))
+
+        with self.assertRaises(TypeError) as cm:
+            sitk.Resample(img, size=[64,64], wrong_keyword4=img)
+        self.assertTrue("unexpected keyword argument" in str(cm.exception))
+
+        with self.assertRaises(TypeError) as cm:
+            sitk.Resample(img, tx, wrong_keyword5=img)
+        self.assertTrue("unexpected keyword argument" in str(cm.exception))
+
+
     def test_paste_filter(self):
 
         img1 = sitk.GaborSource(sitk.sitkFloat32, [64, 64, 64], frequency=.05)

--- a/Wrapping/Python/SimpleITK/extra.py
+++ b/Wrapping/Python/SimpleITK/extra.py
@@ -111,9 +111,10 @@ def Resample(
         if not isinstance(args[0], Transform):
             try:
                 iter(args[0])
-                return _r(*args, **kwargs)
             except TypeError:
                 pass
+            else:
+                return _r(*args, **kwargs)
 
     if referenceImage is not None:
         return _r_image(referenceImage, *args, **kwargs)


### PR DESCRIPTION
Correctly raise keyword exceptions when incorrect keywords arguments
are provided.

closes #1596