### PR TITLE
DOC: Adding example of using Python logging with SimpleITK.

### DIFF
--- a/Examples/PythonFileLogging/CMakeLists.txt
+++ b/Examples/PythonFileLogging/CMakeLists.txt
@@ -1,0 +1,9 @@
+
+if ( NOT BUILD_TESTING )
+  return ()
+endif ()
+
+
+sitk_add_python_test( Example.PythonFileLogging
+  "${CMAKE_CURRENT_SOURCE_DIR}/FileLogging.py"
+  )

--- a/Examples/PythonFileLogging/Documentation.rst
+++ b/Examples/PythonFileLogging/Documentation.rst
@@ -1,0 +1,29 @@
+Python File Logging
+===================
+
+
+Overview
+--------
+
+SimpleITK is built on top of the C++ Insight Toolkit (ITK) which is wrapped
+for use in the Python language. Some of the ITK functions report warnings
+that are printed to standard error or standard output. There are three common
+approaches to dealing with these warnings:
+
+1. Do nothing, warnings are printed and we ignore them.
+2. Suppress them, :code:`sitk.ProcessObject_SetGlobalWarningDisplay(False)`, warnings are not printed.
+3. Include the warnings as part of a log file for program monitoring and debugging purposes.
+
+This example illustrates how to ingest the ITK warnings into a log file created using the
+Python logging framework.
+
+
+Code
+----
+
+.. tabs::
+  .. tab:: Python
+
+    .. literalinclude:: ../../Examples/PythonFileLogging/FileLogging.py
+       :language: python
+       :lines: 19-

--- a/Examples/PythonFileLogging/FileLogging.py
+++ b/Examples/PythonFileLogging/FileLogging.py
@@ -1,0 +1,89 @@
+# =========================================================================
+#
+#  Copyright NumFOCUS
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+# =========================================================================
+
+
+import os
+import sys
+import logging
+import SimpleITK as sitk
+
+
+class SimpleitkWarningRedirector:
+    """
+    Context manager which re-routes the file descriptors for the C/C++ outputs
+    to stdout, stderr but keeps those used by Python intact. This allows
+    the user to record warnings issued by the underlying C++ code as part of the
+    Python logging framework. Note that the C++ warnings will always be saved to
+    the log file, unlike the finer control available via the Python logging
+    setLevel mechanism.
+    """
+
+    def __init__(self, filename):
+        sys.stdout.flush()
+        sys.stderr.flush()
+        self.logfile = os.open(filename, os.O_WRONLY | os.O_APPEND | os.O_CREAT)
+
+    def __enter__(self):
+        # Assuming that for all operating systems, stdout file descriptor
+        # is 1 and stderr file descriptor is 2
+        self.orig_stdout = os.dup(1)
+        self.orig_stderr = os.dup(2)
+        self.new_stdout = os.dup(1)
+        self.new_stderr = os.dup(2)
+        os.dup2(self.logfile, 1)
+        os.dup2(self.logfile, 2)
+        sys.stdout = os.fdopen(self.new_stdout, "w")
+        sys.stderr = os.fdopen(self.new_stderr, "w")
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        sys.stdout.flush()
+        sys.stderr.flush()
+
+        os.dup2(self.orig_stdout, 1)
+        os.dup2(self.orig_stderr, 2)
+        os.close(self.orig_stdout)
+        os.close(self.orig_stderr)
+
+        os.close(self.logfile)
+
+
+log_file_name = "program.log"
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+formatter = logging.Formatter(
+    "%(asctime)s | %(levelname)s | %(message)s", "%m-%d-%Y %H:%M:%S"
+)
+file_handler = logging.FileHandler(log_file_name)
+# Set the file handler log level to info, so it doesn't pass all messages
+# logger sends (only those INFO and above, ignores DEBUG level messages).
+file_handler.setLevel(logging.INFO)
+file_handler.setFormatter(formatter)
+logger.addHandler(file_handler)
+
+with SimpleitkWarningRedirector(log_file_name):
+    print("I'm on stdout.", file=sys.stdout)
+    print("I'm on stderr.", file=sys.stderr)
+    logger.debug(
+        "1. debug message. Only appears in log file if you changed file_handler log level to DEBUG."
+    )
+    logger.info("2. information message.")
+    # There is no DICOM series in the current directory, the underlying C++ code issues a warning.
+    sitk.ImageSeriesReader_GetGDCMSeriesFileNames(".")
+    logger.info("3. information message.")
+sys.exit(0)

--- a/Examples/index.rst
+++ b/Examples/index.rst
@@ -41,3 +41,4 @@ Examples
   link_ImageIOSelection_docs
   link_RawImageReading_docs
   link_JavaGetSetBuffer_docs.rst
+  link_PythonFileLogging.rst

--- a/docs/source/link_PythonFileLogging.rst
+++ b/docs/source/link_PythonFileLogging.rst
@@ -1,0 +1,2 @@
+
+.. include:: ../../Examples/PythonFileLogging/Documentation.rst


### PR DESCRIPTION
ITK issues warnings for several situations which are relevant for
debugging. These warnings are written to stderr or stdout. This is
primarily relevant for registration where the warning that not enough
points are available for estimating the similarity metric is
issued. This example illustrates how to re-route the file descriptors
so that the warnings are written to a log file.