### PR TITLE
use exec over import in setup.py

### DIFF
--- a/Wrapping/Python/Packaging/setup.py.in
+++ b/Wrapping/Python/Packaging/setup.py.in
@@ -11,7 +11,8 @@ except ImportError:
 import re
 import os.path as osp
 
-from SimpleITK._version import __version__
+with open(os.path.join("SimpleITK", "_version.py")) as fp:
+    exec(fp.read())
 
 def to_package_relpath(filename, pkg_name='SimpleITK'):
     return osp.relpath(filename, osp.join(os.curdir, pkg_name))


### PR DESCRIPTION
Only the _version.py file needs to be loaded. By not using import
__init__.py is skipped and the SimpleITK library is not loaded.