### PR TITLE
COMP: Fix using "not" in preprocessor

### DIFF
--- a/Code/Common/include/Ancillary/type_list2.h
+++ b/Code/Common/include/Ancillary/type_list2.h
@@ -139,7 +139,7 @@ struct index_of<typelist<t0, Ts...>, T>
  */
 template <typename Typelist, typename T>
 struct has_type;
-#if not defined(_MSC_VER) || _MSC_VER >= 1930
+#if !defined(_MSC_VER) || _MSC_VER >= 1930
 // note the following causes a syntax error with MS VS 16
 template <typename... Ts, typename T>
 struct has_type<typelist<Ts...>, T>


### PR DESCRIPTION
Addresses unexpected token warning in preprocessors.