### PR TITLE
Fix unresolved symbol for Image::DispatchedInternalInitialization

### DIFF
--- a/Code/Common/include/sitkImage.h
+++ b/Code/Common/include/sitkImage.h
@@ -144,7 +144,7 @@ namespace simple
 
     template <typename TImageType>
       explicit Image( TImageType* image )
-      : m_PimpleImage( Self::DispatchedInternalInitialization<TImageType>(image) )
+      : m_PimpleImage( nullptr )
       {
       const PixelIDValueType type = ImageTypeToPixelIDValue<TImageType>::Result;
       const unsigned int     dimension = TImageType::ImageDimension;
@@ -152,7 +152,7 @@ namespace simple
       static_assert(type != sitkUnknown, "invalid pixel type");
       static_assert(dimension >= 2 && dimension <= SITK_MAX_DIMENSION, "Unsupported image dimension.");
 
-      //this->InternalInitialization(type, dimension, image);
+      this->InternalInitialization(type, dimension, image);
     }
     /**@}*/
 


### PR DESCRIPTION
The template DispatchedInternalInitialization method can not be called
in the inline constructor, as the implementation in not
available. Restored the usage of InternalInitialization method.