### PR TITLE
STYLE: Use `unique_ptr` for Elastix and Transformix Pimpl data members

### DIFF
--- a/Code/ElastixTransformixWrappers/include/sitkElastixImageFilter.h
+++ b/Code/ElastixTransformixWrappers/include/sitkElastixImageFilter.h
@@ -23,6 +23,7 @@
 #include "sitkImage.h"
 
 #include <map>
+#include <memory> // For unique_ptr.
 #include <string>
 #include <vector>
 
@@ -174,7 +175,7 @@ public:
 private:
 
   class ElastixImageFilterImpl;
-  ElastixImageFilterImpl* m_Pimple;
+  const std::unique_ptr<ElastixImageFilterImpl> m_Pimple;
 
 };
 

--- a/Code/ElastixTransformixWrappers/include/sitkTransformixImageFilter.h
+++ b/Code/ElastixTransformixWrappers/include/sitkTransformixImageFilter.h
@@ -23,6 +23,7 @@
 #include "sitkImage.h"
 
 #include <map>
+#include <memory> // For unique_ptr.
 #include <string>
 #include <vector>
 
@@ -122,7 +123,7 @@ public:
 private:
 
   class TransformixImageFilterImpl;
-  TransformixImageFilterImpl* m_Pimple;
+  const std::unique_ptr<TransformixImageFilterImpl> m_Pimple;
 
 };
 

--- a/Code/ElastixTransformixWrappers/src/sitkElastixImageFilter.cxx
+++ b/Code/ElastixTransformixWrappers/src/sitkElastixImageFilter.cxx
@@ -8,16 +8,12 @@ namespace itk {
   namespace simple {
 
 ElastixImageFilter
-::ElastixImageFilter() : m_Pimple( new ElastixImageFilterImpl )
+::ElastixImageFilter() : m_Pimple(std::make_unique<ElastixImageFilterImpl>())
 {
 }
 
 ElastixImageFilter
-::~ElastixImageFilter()
-{
-  delete m_Pimple;
-  m_Pimple = NULL;
-}
+::~ElastixImageFilter() = default;
 
 const std::string
 ElastixImageFilter

--- a/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilter.cxx
+++ b/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilter.cxx
@@ -8,16 +8,12 @@ namespace itk {
   namespace simple {
 
 TransformixImageFilter
-::TransformixImageFilter() : m_Pimple( new TransformixImageFilterImpl )
+::TransformixImageFilter() : m_Pimple(std::make_unique<TransformixImageFilterImpl>())
 {
 }
 
 TransformixImageFilter
-::~TransformixImageFilter()
-{
-  delete m_Pimple;
-  m_Pimple = NULL;
-}
+::~TransformixImageFilter() = default;
 
 const std::string
 TransformixImageFilter


### PR DESCRIPTION
Following C++ Core Guidelines, April 10, 2022, "A raw pointer (a T*) is non-owning":
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#r3-a-raw-pointer-a-t-is-non-owning