### PR TITLE
Correct SinRegularizedHeaviside option

### DIFF
--- a/Code/BasicFilters/json/ScalarChanAndVeseDenseLevelSetImageFilter.json
+++ b/Code/BasicFilters/json/ScalarChanAndVeseDenseLevelSetImageFilter.json
@@ -7,6 +7,7 @@
   "filter_type" : "itk::ScalarChanAndVeseDenseLevelSetImageFilter<InputImageType, InputImageType, InputImageType, itk::ScalarChanAndVeseLevelSetFunction< InputImageType, InputImageType > >",
   "include_files" : [
     "itkAtanRegularizedHeavisideStepFunction.h",
+    "itkSinRegularizedHeavisideStepFunction.h",
     "itkHeavisideStepFunction.h"
   ],
   "inputs" : [
@@ -99,7 +100,7 @@
       ],
       "default" : "itk::simple::ScalarChanAndVeseDenseLevelSetImageFilter::AtanRegularizedHeaviside",
       "doc" : "Step functions",
-      "custom_itk_cast" : "if (m_HeavisideStepFunction == AtanRegularizedHeaviside) {\n    using DomainFunctionType =  itk::AtanRegularizedHeavisideStepFunction< typename InputImageType::PixelType, typename InputImageType::PixelType >;\n    typename DomainFunctionType::Pointer domainFunction = DomainFunctionType::New();\n    domainFunction->SetEpsilon(m_Epsilon);\n    filter->GetDifferenceFunction(0)->SetDomainFunction( domainFunction );\n  } else if ( m_HeavisideStepFunction == SinRegularizedHeaviside ) {\n    using DomainFunctionType = itk::AtanRegularizedHeavisideStepFunction< typename InputImageType::PixelType, typename InputImageType::PixelType >;\n    typename DomainFunctionType::Pointer domainFunction = DomainFunctionType::New();\n    domainFunction->SetEpsilon(m_Epsilon);\n    filter->GetDifferenceFunction(0)->SetDomainFunction( domainFunction );\n  } else {\n    using DomainFunctionType = itk::HeavisideStepFunction< typename InputImageType::PixelType, typename InputImageType::PixelType >;\n    typename DomainFunctionType::Pointer domainFunction = DomainFunctionType::New();\n    filter->GetDifferenceFunction(0)->SetDomainFunction( domainFunction );\n  }"
+      "custom_itk_cast" : "if (m_HeavisideStepFunction == AtanRegularizedHeaviside) {\n    using DomainFunctionType =  itk::AtanRegularizedHeavisideStepFunction< typename InputImageType::PixelType, typename InputImageType::PixelType >;\n    typename DomainFunctionType::Pointer domainFunction = DomainFunctionType::New();\n    domainFunction->SetEpsilon(m_Epsilon);\n    filter->GetDifferenceFunction(0)->SetDomainFunction( domainFunction );\n  } else if ( m_HeavisideStepFunction == SinRegularizedHeaviside ) {\n    using DomainFunctionType = itk::SinRegularizedHeavisideStepFunction< typename InputImageType::PixelType, typename InputImageType::PixelType >;\n    typename DomainFunctionType::Pointer domainFunction = DomainFunctionType::New();\n    domainFunction->SetEpsilon(m_Epsilon);\n    filter->GetDifferenceFunction(0)->SetDomainFunction( domainFunction );\n  } else {\n    using DomainFunctionType = itk::HeavisideStepFunction< typename InputImageType::PixelType, typename InputImageType::PixelType >;\n    typename DomainFunctionType::Pointer domainFunction = DomainFunctionType::New();\n    filter->GetDifferenceFunction(0)->SetDomainFunction( domainFunction );\n  }"
     },
     {
       "name" : "UseImageSpacing",


### PR DESCRIPTION
Fixes setting SineRegularizedHeaviside set function for the
ScalarChanAndVeseDenseLevelSetImageFilter.

Closes #1485