### PR TITLE
BUG: Fix GenericException assignment by using `shared_ptr` internally

### DIFF
--- a/Code/Common/include/sitkExceptionObject.h
+++ b/Code/Common/include/sitkExceptionObject.h
@@ -21,6 +21,8 @@
 #include "sitkMacro.h"
 #include "sitkCommon.h"
 
+#include <memory> // For shared_ptr.
+
 #ifndef sitkMacro_h
 #error "sitkMacro.h must be included before sitkExceptionObject.h"
 #endif // sitkMacro_h
@@ -98,7 +100,7 @@ public:
   virtual unsigned int GetLine() const;
 
 private:
-  const ExceptionObject *m_PimpleException;
+  std::shared_ptr<const ExceptionObject> m_PimpleException;
 };
 
 #ifdef _MSC_VER

--- a/Code/Common/src/sitkExceptionObject.cxx
+++ b/Code/Common/src/sitkExceptionObject.cxx
@@ -33,28 +33,13 @@ GenericException::GenericException() noexcept
   : m_PimpleException( nullptr )
 {}
 
-GenericException::GenericException( const GenericException &e ) noexcept
-
-  : std::exception( e )
-{
-  try
-    {
-    if ( e.m_PimpleException != nullptr )
-      {
-      m_PimpleException =  new itk::ExceptionObject( *e.m_PimpleException );
-      }
-    }
-  catch(...) // prevent exception from leaving constructor
-    {
-    this->m_PimpleException = nullptr;
-    }
-}
+GenericException::GenericException( const GenericException &e ) noexcept = default;
 
 GenericException::GenericException(const char *file, unsigned int lineNumber) noexcept
 {
   try
     {
-    m_PimpleException =  new itk::ExceptionObject( file, lineNumber );
+    m_PimpleException = std::make_shared<itk::ExceptionObject>( file, lineNumber );
     }
   catch(...) // prevent exception from leaving constructor
     {
@@ -67,7 +52,7 @@ GenericException::GenericException(const std::string & file, unsigned int lineNu
 {
   try
     {
-    m_PimpleException =  new itk::ExceptionObject( file, lineNumber );
+    m_PimpleException = std::make_shared<itk::ExceptionObject>( file, lineNumber );
     }
   catch(...) // prevent exception from leaving constructor
     {
@@ -82,7 +67,7 @@ GenericException::GenericException(const std::string & file,
 {
   try
     {
-    m_PimpleException =  new itk::ExceptionObject( file, lineNumber, desc );
+    m_PimpleException = std::make_shared<itk::ExceptionObject>( file, lineNumber, desc );
     }
   catch(...) // prevent exception from leaving constructor
     {
@@ -90,10 +75,7 @@ GenericException::GenericException(const std::string & file,
     }
 }
 
-GenericException::~GenericException() noexcept
-{
-  delete this->m_PimpleException;
-}
+GenericException::~GenericException() noexcept = default;
 
 
 GenericException & GenericException::operator=(const GenericException & orig)

--- a/Testing/Unit/sitkExceptionsTests.cxx
+++ b/Testing/Unit/sitkExceptionsTests.cxx
@@ -109,3 +109,21 @@ TEST_F(sitkExceptionsTest, Test3) {
   EXPECT_NO_THROW( empty.what() );
 
 }
+
+
+TEST_F(sitkExceptionsTest, TestDestructionAfterAssignment) {
+
+    // Test that the program does not crash when two GenericException
+    // variables get destructed (automatically, by getting out of scope),
+    // when one of them is assigned to the other. (Such a crash might occur
+    // with previous versions of SimpleITK, version <= v2.2rc3.)
+
+    const itk::simple::GenericException source(__FILE__, __LINE__);
+    itk::simple::GenericException target;
+
+    target = source;
+
+    // After assignment, the variables should compare equal, but moreover,
+    // when they get out of scope, their destructors should not crash.
+    EXPECT_EQ(target, source);
+}


### PR DESCRIPTION
The assignment operator of `GenericException` originally just copied the "raw" internal pointer (`m_PimpleException`), causing `delete` to be called twice on the very same pointer, when both the original and the copy of the GenericException are destructed. Which would have undefined behavior. Fixed by using `shared_ptr` instead of a raw pointer.

Used `= default` to implement its copy-constructor and its destructor, as `shared_ptr` now takes care of doing the right thing "by default".