### PR TITLE
STYLE: Remove include guards from cxx files

### DIFF
--- a/Code/ElastixTransformixWrappers/src/sitkElastixImageFilter.cxx
+++ b/Code/ElastixTransformixWrappers/src/sitkElastixImageFilter.cxx
@@ -1,6 +1,3 @@
-#ifndef __sitkelastiximagefilter_cxx_
-#define __sitkelastiximagefilter_cxx_
-
 #include "sitkElastixImageFilter.h"
 #include "sitkElastixImageFilterImpl.h"
 
@@ -804,5 +801,3 @@ Elastix( const Image& fixedImage, const Image& movingImage, ElastixImageFilter::
 
 } // end namespace simple
 } // end namespace itk
-
-#endif // __sitkelastiximagefilter_cxx_

--- a/Code/ElastixTransformixWrappers/src/sitkElastixImageFilterImpl.cxx
+++ b/Code/ElastixTransformixWrappers/src/sitkElastixImageFilterImpl.cxx
@@ -1,6 +1,3 @@
-#ifndef __sitkelastiximagefilterimpl_cxx_
-#define __sitkelastiximagefilterimpl_cxx_
-
 #include "sitkElastixImageFilter.h"
 #include "sitkElastixImageFilterImpl.h"
 #include "sitkCastImageFilter.h"
@@ -1077,5 +1074,3 @@ ElastixImageFilter::ElastixImageFilterImpl
 
 } // end namespace simple
 } // end namespace itk
-
-#endif // __sitkelastiximagefilterimpl_cxx_

--- a/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilter.cxx
+++ b/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilter.cxx
@@ -1,6 +1,3 @@
-#ifndef __sitktransformiximagefilter_cxx_
-#define __sitktransformiximagefilter_cxx_
-
 #include "sitkTransformixImageFilter.h"
 #include "sitkTransformixImageFilterImpl.h"
 
@@ -476,5 +473,3 @@ Transformix( const Image& movingImage, const TransformixImageFilter::ParameterMa
 
 } // end namespace simple
 } // end namespace itk
-
-#endif // __sitktransformiximagefilter_cxx_

--- a/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilterImpl.cxx
+++ b/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilterImpl.cxx
@@ -1,6 +1,3 @@
-#ifndef __sitktransformiximagefilterimpl_cxx_
-#define __sitktransformiximagefilterimpl_cxx_
-
 #include "sitkTransformixImageFilter.h"
 #include "sitkTransformixImageFilterImpl.h"
 #include "sitkCastImageFilter.h"
@@ -705,5 +702,3 @@ TransformixImageFilter::TransformixImageFilterImpl
 
 } // end namespace simple
 } // end namespace itk
-
-#endif // __sitktransformiximagefilterimpl_cxx_

--- a/Code/IO/src/sitkImageIOUtilities.cxx
+++ b/Code/IO/src/sitkImageIOUtilities.cxx
@@ -16,9 +16,6 @@
 *
 *=========================================================================*/
 
-#ifndef sitkImageIOUtilities_h
-#define sitkImageIOUtilities_h
-
 #include "sitkMacro.h"
 #include "sitkExceptionObject.h"
 #include "itkImageIOBase.h"
@@ -103,5 +100,3 @@ itk::SmartPointer<ImageIOBase> CreateImageIOByName(const std::string & ioname)
 }
 }
 }
-
-#endif


### PR DESCRIPTION
Include guards are only meant to be used in header files (h and hxx files), as they aim to prevent compile errors when the very same header file is `#include`d multiple times.