### PR TITLE
ENH: Make Elastix and Transformix `GetName()` members const-correct

### DIFF
--- a/Code/ElastixTransformixWrappers/include/sitkElastixImageFilter.h
+++ b/Code/ElastixTransformixWrappers/include/sitkElastixImageFilter.h
@@ -52,7 +52,7 @@ public:
   typedef ParameterMapType::iterator                              ParameterMapIterator;
   typedef ParameterMapType::const_iterator                        ParameterMapConstIterator;
 
-  const std::string GetName();
+  std::string GetName() const;
 
   /** \brief Sets a fixed image.
    *

--- a/Code/ElastixTransformixWrappers/include/sitkTransformixImageFilter.h
+++ b/Code/ElastixTransformixWrappers/include/sitkTransformixImageFilter.h
@@ -47,7 +47,7 @@ public:
   typedef ParameterMapType::iterator                              ParameterMapIterator;
   typedef ParameterMapType::const_iterator                        ParameterMapConstIterator;
 
-  const std::string GetName();
+  std::string GetName() const;
 
   SITK_RETURN_SELF_TYPE_HEADER SetMovingImage( const Image& movingImage );
   Image& GetMovingImage();

--- a/Code/ElastixTransformixWrappers/src/sitkElastixImageFilter.cxx
+++ b/Code/ElastixTransformixWrappers/src/sitkElastixImageFilter.cxx
@@ -19,9 +19,9 @@ ElastixImageFilter
   m_Pimple = NULL;
 }
 
-const std::string
+std::string
 ElastixImageFilter
-::GetName()
+::GetName() const
 {
   return this->m_Pimple->GetName();
 }

--- a/Code/ElastixTransformixWrappers/src/sitkElastixImageFilterImpl.cxx
+++ b/Code/ElastixTransformixWrappers/src/sitkElastixImageFilterImpl.cxx
@@ -263,9 +263,9 @@ ElastixImageFilter::ElastixImageFilterImpl
   return this->m_ResultImage;
 }
 
-const std::string
+std::string
 ElastixImageFilter::ElastixImageFilterImpl
-::GetName( void )
+::GetName( void ) const
 {
   const std::string name = "ElastixImageFilter";
   return name;

--- a/Code/ElastixTransformixWrappers/src/sitkElastixImageFilterImpl.h
+++ b/Code/ElastixTransformixWrappers/src/sitkElastixImageFilterImpl.h
@@ -35,7 +35,7 @@ public:
   typedef elastix::ParameterObject                    ParameterObjectType;
   typedef elastix::ParameterObject::Pointer           ParameterObjectPointer;
 
-  const std::string GetName( void );
+  std::string GetName( void ) const;
 
   void SetFixedImage( const Image& fixedImage );
   void SetFixedImage( const VectorOfImage& fixedImages );

--- a/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilter.cxx
+++ b/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilter.cxx
@@ -19,9 +19,9 @@ TransformixImageFilter
   m_Pimple = NULL;
 }
 
-const std::string
+std::string
 TransformixImageFilter
-::GetName()
+::GetName() const
 {
   return this->m_Pimple->GetName();
 }

--- a/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilterImpl.cxx
+++ b/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilterImpl.cxx
@@ -226,9 +226,9 @@ TransformixImageFilter::TransformixImageFilterImpl
   return this->m_ResultImage;
 }
 
-const std::string
+std::string
 TransformixImageFilter::TransformixImageFilterImpl
-::GetName()
+::GetName() const
 {
   const std::string name = std::string( "TransformixImageFilter" );
   return name;

--- a/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilterImpl.h
+++ b/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilterImpl.h
@@ -32,7 +32,7 @@ public:
   typedef ParameterObjectType::ParameterValueType        ParameterValueType;
   typedef ParameterObjectType::ParameterValueVectorType  ParameterValueVectorType;
 
-  const std::string GetName();
+  std::string GetName() const;
 
   void SetMovingImage( const Image& movingImage );
   Image& GetMovingImage();


### PR DESCRIPTION
Fixed the location of the `const` keyword of `GetName()` member function declarations, allowing to retrieve the name from a `const` ElastixImageFilter or TransformixImageFilter object.