### PR TITLE
Update to macos-12 for GHA

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -15,11 +15,11 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        os: [macos-10.15, ubuntu-18.04]
+        os: [macos-12, ubuntu-18.04]
         include:
           - os: ubuntu-18.04
             cmake-build-type: "Release"
-          - os: macos-10.15
+          - os: macos-12
             cmake-build-type: "Release"
 
     steps:


### PR DESCRIPTION
GHA is now scheduling brownout for the older operating system.

https://github.com/actions/virtual-environments/issues/5583