### PR TITLE
AZP update macosx version for CI and package builds

### DIFF
--- a/Testing/CI/Azure/azure-pipelines.yml
+++ b/Testing/CI/Azure/azure-pipelines.yml
@@ -65,8 +65,8 @@ jobs:
   - job: macOS
     timeoutInMinutes: 0
     variables:
-      imageName: 'macos-10.15'
-      xcodeVersion: 10.3
+      imageName: 'macos-11'
+      xcodeVersion: 12.4
     pool:
       vmImage: $(imageName)
 

--- a/Testing/CI/Azure/templates/package-mac-job.yml
+++ b/Testing/CI/Azure/templates/package-mac-job.yml
@@ -10,7 +10,7 @@ jobs:
       DASHBOARD_BRANCH_DIRECTORY: $(Agent.BuildDirectory)/SimpleITK-dashboard
       DASHBOARD_GIT_BRANCH: $[ dependencies.Configure.outputs['configure.BuildHash'] ]
     pool:
-      vmImage: 'macos-10.15'
+      vmImage: 'macos-11'
     steps:
       - template: ./git-download-steps.yml
       - task: UsePythonVersion@0


### PR DESCRIPTION
macos-10.15 is being deprecated.