### PR TITLE
Use pip to install SimpleITK

### DIFF
--- a/Wrapping/Python/LegacyPackaging.cmake
+++ b/Wrapping/Python/LegacyPackaging.cmake
@@ -93,7 +93,7 @@ if (SimpleITK_PYTHON_USE_VIRTUALENV)
   add_custom_command( OUTPUT "${VIRTUAL_PYTHON_EXECUTABLE}"
     COMMAND "${PYTHON_EXECUTABLE}" "-m" "venv" "--clear" "${PythonVirtualenvHome}"
     COMMAND "${VIRTUAL_PYTHON_EXECUTABLE}" "-m" "pip" "install" "--upgrade" "pip"
-    COMMAND "${VIRTUAL_PYTHON_EXECUTABLE}" "setup.py" install
+    COMMAND "${VIRTUAL_PYTHON_EXECUTABLE}" "-m" "pip" "install" "."
     WORKING_DIRECTORY "${SimpleITK_Python_BINARY_DIR}"
     DEPENDS
     "${SWIG_MODULE_SimpleITKPython_TARGET_NAME}"

--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -278,8 +278,7 @@ To install a built python package into the system Python, as root run:
 
 .. code-block :: bash
 
- cd SimpleITK-build/Wrapping/Python
- python setup.py install
+ python -m pip install SimpleITK-build/Wrapping/Python
 
 Preferably, a Python virtual environment is created and the
 distribution installed there.


### PR DESCRIPTION
Direct usage of setup.py is being depricated:

SetuptoolsDeprecationWarning: setup.py install is deprecated. Use
build and pip and other standards-based tools.