### PR TITLE
Fix error with itk::LabelOverlapMeasuresImageFilter::SetInput

### DIFF
--- a/Code/BasicFilters/json/LabelOverlapMeasuresImageFilter.json
+++ b/Code/BasicFilters/json/LabelOverlapMeasuresImageFilter.json
@@ -2,11 +2,22 @@
   "name" : "LabelOverlapMeasuresImageFilter",
   "template_code_filename" : "ImageFilter",
   "template_test_filename" : "ImageFilter",
-  "number_of_inputs" : 2,
+  "number_of_inputs" : 0,
   "pixel_types" : "IntegerPixelIDTypeList",
   "filter_type" : "itk::LabelOverlapMeasuresImageFilter<InputImageType>",
   "no_procedure" : true,
   "no_return_image" : true,
+  "inputs" : [
+    {
+      "name" : "SourceImage",
+      "type" : "Image"
+    },
+    {
+      "name" : "TargetImage",
+      "type" : "Image",
+      "custom_itk_cast" : "filter->SetTargetImage( this->CastImageToITK<typename FilterType::LabelImageType>(*inTargetImage) );"
+    }
+  ],
   "members" : [],
   "measurements" : [
     {


### PR DESCRIPTION
The ITK refactoring of this class included a change of base class,
removing the SetInput method used in SimpleITK. The JSON is updated to
use named inputs.