### PR TITLE
Update Java.i to set endian type to native before exposing typed buffers

### DIFF
--- a/Wrapping/Java/Java.i
+++ b/Wrapping/Java/Java.i
@@ -75,7 +75,8 @@
    */
   public java.nio.Buffer getBufferAsBuffer()
     {
-      java.nio.ByteBuffer b = getBufferAsByteBuffer();
+      java.nio.ByteBuffer b = getBufferAsByteBuffer().order(java.nio.ByteOrder.nativeOrder());
+      
       if (getPixelID() == PixelIDValueEnum.sitkInt16 ||
           getPixelID() == PixelIDValueEnum.sitkVectorInt16)
         {

--- a/Wrapping/Java/Java.i
+++ b/Wrapping/Java/Java.i
@@ -76,7 +76,7 @@
   public java.nio.Buffer getBufferAsBuffer()
     {
       java.nio.ByteBuffer b = getBufferAsByteBuffer().order(java.nio.ByteOrder.nativeOrder());
-      
+
       if (getPixelID() == PixelIDValueEnum.sitkInt16 ||
           getPixelID() == PixelIDValueEnum.sitkVectorInt16)
         {


### PR DESCRIPTION
I recently had an issue when trying to write into the FloatBuffer from a Tensorflow JVM Tensor FloatBuffer, the issue was caused by the endianess not matching the default OS's endianess. 

I propose we cast into the native OS's endian order before returning these typed buffers, as we can't change the endianess from these typed buffers directly, instead needing to manually perform the added steps. 