### PR TITLE
Fix numpy character dtype conversion warning

### DIFF
--- a/Wrapping/Python/SimpleITK/extra.py
+++ b/Wrapping/Python/SimpleITK/extra.py
@@ -180,8 +180,7 @@ def _get_sitk_pixelid(numpy_array_type: Type["numpy.ndarray"]) -> int:
     np = numpy
 
     # This is a Mapping from numpy dtypes to sitks pixel types.
-    _np_sitk = {np.dtype(np.character): sitkUInt8,
-                np.dtype(np.uint8): sitkUInt8,
+    _np_sitk = {np.dtype(np.uint8): sitkUInt8,
                 np.dtype(np.uint16): sitkUInt16,
                 np.dtype(np.uint32): sitkUInt32,
                 np.dtype(np.uint64): sitkUInt64,
@@ -209,8 +208,7 @@ def _get_sitk_vector_pixelid(numpy_array_type: Type["numpy.ndarray"]) -> int:
     np = numpy
 
     # This is a Mapping from numpy dtypes to sitks pixel types.
-    _np_sitk = {np.dtype(np.character): sitkVectorUInt8,
-                np.dtype(np.uint8): sitkVectorUInt8,
+    _np_sitk = {np.dtype(np.uint8): sitkVectorUInt8,
                 np.dtype(np.uint16): sitkVectorUInt16,
                 np.dtype(np.uint32): sitkVectorUInt32,
                 np.dtype(np.uint64): sitkVectorUInt64,


### PR DESCRIPTION
Remove np.character as SimpleITK only handles numbers and not characters of different widths.