### PR TITLE
Avoid exception GetParameter(key) if Elastix Filter has 1 parameter map

### DIFF
--- a/Code/ElastixTransformixWrappers/include/sitkElastixImageFilter.h
+++ b/Code/ElastixTransformixWrappers/include/sitkElastixImageFilter.h
@@ -266,7 +266,7 @@ public:
   /** \brief Adds a parameter specified by \p key, with the specified values to the parameter map at the specified (zero-based) \p index. */
   SITK_RETURN_SELF_TYPE_HEADER AddParameter( const unsigned int index, const std::string key, const std::vector< std::string > value );
 
-  /** \brief Intended to retrieve the values of the parameter specified by \p key, when there is only one parameter map. */
+  /** \brief Retrieves the values of the parameter specified by \p key, when there is only one parameter map. */
   std::vector< std::string > GetParameter( const std::string key );
 
   /** \brief Retrieves the values of the parameter specified by \p key, from the parameter map at the specified (zero-based) \p index. */

--- a/Code/ElastixTransformixWrappers/src/sitkElastixImageFilterImpl.cxx
+++ b/Code/ElastixTransformixWrappers/src/sitkElastixImageFilterImpl.cxx
@@ -928,7 +928,7 @@ ElastixImageFilter::ElastixImageFilterImpl::ParameterValueVectorType
 ElastixImageFilter::ElastixImageFilterImpl
 ::GetParameter( const ParameterKeyType key )
 {
-  if( this->m_ParameterMapVector.size() > 0 )
+  if( this->m_ParameterMapVector.size() > 1 )
   {
     sitkExceptionMacro( "An index is needed when more than one parameter map is present. Please specify the parameter map number as the first argument." );
   }

--- a/Testing/Unit/sitkElastixImageFilterTests.cxx
+++ b/Testing/Unit/sitkElastixImageFilterTests.cxx
@@ -350,5 +350,19 @@ TEST( ElastixImageFilter, SetNumberOfThreads )
   EXPECT_NO_THROW( silx.Execute() );
 }
 
+
+// Tests GetParameter(key) when exactly one parameter map is present.
+TEST(ElastixImageFilter, GetParameterWhenOneParameterMapIsPresent)
+{
+    const ElastixImageFilter::ParameterKeyType key = "key";
+    const ElastixImageFilter::ParameterValueVectorType values{ "1", "2", "3" };
+    const ElastixImageFilter::ParameterMapType parameterMap{ {key, values} };
+
+    ElastixImageFilter silx;
+    silx.SetParameterMap(parameterMap);
+
+    EXPECT_EQ(silx.GetParameter(key), values);
+}
+
 } // namespace simple
 } // namesapce itk


### PR DESCRIPTION
Before this commit, `ElastixImageFilter::GetParameter(key)` would erroneously throw an exception saying "An index is needed when more than one parameter map is present", even when the filter would have exactly one parameter map.