### PR TITLE
Fix GHA trigger for Package workflows

### DIFF
--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -2,7 +2,12 @@ name: Package
 
 on:
   push:
-    tag: [ 'latest', 'v*' ]
+    tags:
+      - 'latest'
+      - 'v*'
+    branches-ignore:
+      - '**'
+
 
 
 jobs:


### PR DESCRIPTION
GHA Package workflow was being triggered in forked repos due to branch push. This explicitly disables the workflow for all branches.