### PR TITLE
Update to CSharp DotNet version 4

### DIFF
--- a/CMake/FindDotNetFrameworkSdk.cmake
+++ b/CMake/FindDotNetFrameworkSdk.cmake
@@ -76,9 +76,9 @@ if( CSHARP_DOTNET_FOUND )
 
   # Set the compiler version
   # Do not force, so that the user can manually select their own version if they wish
-  if ( DEFINED CSHARP_DOTNET_COMPILER_v2.0.50727 )
-    # If available, select .NET v2.0.50727 (this is the minimal version as it supports generics, and allows use of VS2008)
-    set( CSHARP_DOTNET_VERSION "v2.0.50727" CACHE STRING "C# .NET compiler version" )
+  if ( DEFINED CSHARP_DOTNET_COMPILER_v4.0.30319 )
+    # If available, select .NET v4.0.30319 (this is the minimal version that works with the SWIG 4.1.1 output )
+    set( CSHARP_DOTNET_VERSION "v4.0.30319" CACHE STRING "C# .NET compiler version" )
   else( )
     # Select the highest version (first in reverse sorted list)
     list( GET CSHARP_DOTNET_VERSIONS 0 csharp_dotnet_version_temp )

--- a/Testing/CI/Azure/azure-pipelines.yml
+++ b/Testing/CI/Azure/azure-pipelines.yml
@@ -192,3 +192,10 @@ jobs:
           call  "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"  ${{ variables.VCVAR_OPTIONS }} -vcvars_ver=14.0
           bash $(Build.SourcesDirectory)/Testing/CI/Azure/scripts/win_build_python.sh
         displayName: Build Python 38
+      - script: |
+          call  "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"  ${{ variables.VCVAR_OPTIONS }} -vcvars_ver=14.0
+          bash $(Build.SourcesDirectory)/Testing/CI/Azure/scripts/win_build_csharp.sh
+        displayName: Build CSharp
+        continueOnError: true
+        env:
+          CSHARP_PLATFORM: '${{ variables.PYTHON_ARCH }}'

--- a/Testing/CI/Azure/templates/package-linux-job.yml
+++ b/Testing/CI/Azure/templates/package-linux-job.yml
@@ -1,6 +1,6 @@
 parameters:
   DOCKERFILE: Dockerfile-2014-x86_64
-  PYTHON_VERSIONS: "cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310"
+  PYTHON_VERSIONS: "cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311"
   BUILD_CSHARP: 0
 
 jobs:

--- a/Testing/CI/Azure/templates/package-mac-job.yml
+++ b/Testing/CI/Azure/templates/package-mac-job.yml
@@ -94,6 +94,14 @@ jobs:
       - task: UsePythonVersion@0
         displayName: Enable Python
         inputs:
+          versionSpec: '3.11'
+          architecture: 'x64'
+      - bash: ${BUILD_SOURCESDIRECTORY}/Testing/CI/Azure/scripts/mac_build_python.sh
+        displayName: Build Python 310
+        continueOnError: true
+      - task: UsePythonVersion@0
+        displayName: Enable Python
+        inputs:
           versionSpec: '3.10'
           architecture: 'x64'
       - bash: ${BUILD_SOURCESDIRECTORY}/Testing/CI/Azure/scripts/mac_build_python.sh

--- a/Testing/CI/Azure/templates/package-win-job.yml
+++ b/Testing/CI/Azure/templates/package-win-job.yml
@@ -70,6 +70,16 @@ jobs:
       - task: UsePythonVersion@0
         displayName: Enable Python
         inputs:
+          versionSpec: '3.11'
+          architecture: '${{ parameters.PYTHON_ARCH }}'
+      - script: |
+          call  "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"  ${{ parameters.VCVAR_OPTIONS }} -vcvars_ver=14.0
+          bash $(Build.SourcesDirectory)/Testing/CI/Azure/scripts/win_build_python.sh
+        displayName: Build Python 311
+        continueOnError: true
+      - task: UsePythonVersion@0
+        displayName: Enable Python
+        inputs:
           versionSpec: '3.10'
           architecture: '${{ parameters.PYTHON_ARCH }}'
       - script: |


### PR DESCRIPTION
The should address errors such as the following:
Command.cs(91,7): error CS0246: The type or namespace name 'var' could not be found (are you missing a using directive or an assembly reference?)

which occour after the update to SWIG