### PR TITLE
Sphinx version and en lang

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 sphinx-tabs
 cmake
 sphinx_rtd_theme
-sphinx==3.0.0
+sphinx~=5.3.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -64,7 +64,9 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+# Setting default to English to avoid warning.
+#language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
Modified sphinx version in requirements.txt to ~5.3.0 and ran "make html"
Also changed "language" in conf.py from None to "en" to fix warning.