### PR TITLE
Fix types defined in MaskedImageTypeLists and reduce MaskImageFilter support for types.

### DIFF
--- a/Code/BasicFilters/json/MaskImageFilter.json
+++ b/Code/BasicFilters/json/MaskImageFilter.json
@@ -8,7 +8,8 @@
     "sitkToPixelType.hxx"
   ],
   "pixel_types" : "NonLabelPixelIDTypeList",
-  "pixel_types2" : "IntegerPixelIDTypeList",
+
+  "pixel_types2" : "MaskedPixelIDTypeList",
   "inputs" : [
     {
       "name" : "Image",

--- a/Code/BasicFilters/json/MaskNegatedImageFilter.json
+++ b/Code/BasicFilters/json/MaskNegatedImageFilter.json
@@ -6,7 +6,6 @@
   "doc" : "Some global documentation",
   "pixel_types" : "BasicPixelIDTypeList",
   "pixel_types2" : "MaskedPixelIDTypeList",
-  "custom_register" : "this->m_DualMemberFactory->RegisterMemberFunctions< PixelIDTypeList, 3 > ();\n  this->m_DualMemberFactory->RegisterMemberFunctions< PixelIDTypeList, 2 > ();\n  this->m_DualMemberFactory->RegisterMemberFunctions< PixelIDTypeList, PixelIDTypeList2, 3 > ();\n  this->m_DualMemberFactory->RegisterMemberFunctions< PixelIDTypeList, PixelIDTypeList2, 2 > (); ",
   "include_files" : [
     "sitkToPixelType.hxx"
   ],

--- a/Code/Common/include/sitkPixelIDTypeLists.h
+++ b/Code/Common/include/sitkPixelIDTypeLists.h
@@ -90,7 +90,7 @@ using UnsignedIntegerPixelIDTypeList = typelist2::typelist<BasicPixelID<uint8_t>
                                                            >;
 
 /** The conventional type used for a mask image as a list */
-using MaskedPixelIDTypeList = typelist2::typelist<uint8_t>;
+using MaskedPixelIDTypeList = typelist2::typelist<BasicPixelID<uint8_t>>;
 
 
 /** List of pixel ids which are real types for the itk::Image class.


### PR DESCRIPTION
The MaskedPixelIDTypeList had been incorrectly defined. Per the SimpleITK common conventions mask images are uint8. This change makes the MaskImageFilter and MaskNegatedImageFilter support only the types in the MaskedPixelIDTypeList ( uint8 ).

The may result in some broken code which used some of the other instantiated combination, but it reduces the binary size of MaskImageFilter.o from 13M to 3.9M 