### PR TITLE
Typo in DicomSeriesFromArray example

### DIFF
--- a/Examples/DicomSeriesFromArray/DicomSeriesFromArray.R
+++ b/Examples/DicomSeriesFromArray/DicomSeriesFromArray.R
@@ -38,7 +38,7 @@ writeSlices <- function(series_tag_values, new_img, out_dir, i) {
 
     # (0020, 0032) image position patient determines the 3D spacing between slices.
     image_slice$SetMetaData("0020|0032", paste(new_img$TransformIndexToPhysicalPoint(c(0,0,i)), collapse='\\')) # Image Position (Patient)
-    image_slice$SetMetaData("0020,0013", i-1) # Instance Number
+    image_slice$SetMetaData("0020|0013", i-1) # Instance Number
 
     # Write to the output directory and add the extension dcm, to force writing in DICOM format.
     writer$SetFileName(file.path(out_dir, paste(i-1, '.dcm', sep="")))

--- a/Examples/DicomSeriesFromArray/DicomSeriesFromArray.py
+++ b/Examples/DicomSeriesFromArray/DicomSeriesFromArray.py
@@ -57,7 +57,7 @@ def writeSlices(series_tag_values, new_img, out_dir, i):
         "\\".join(map(str, new_img.TransformIndexToPhysicalPoint((0, 0, i)))),
     )
     #   Instance Number
-    image_slice.SetMetaData("0020,0013", str(i))
+    image_slice.SetMetaData("0020|0013", str(i))
 
     # Write to the output directory and add the extension dcm, to force
     # writing in DICOM format.


### PR DESCRIPTION
Currently, the DicomSeriesFromArray  example says to set the DICOM metadata key "0020,0013" for the instance number. This does not work with the SetMetaData function, and should instead be "0020|0013". I hope this is useful, but no worries if it's not.