### PR TITLE
Exclude problematic numpy versions

### DIFF
--- a/Testing/Unit/Python/sitkGetArrayViewFromImageTest.py
+++ b/Testing/Unit/Python/sitkGetArrayViewFromImageTest.py
@@ -119,11 +119,16 @@ class TestNumpySimpleITKMemoryviewInterface(unittest.TestCase):
         self.assertEqual(h, sitk.Hash(img2))
 
     def test_arrayview_writable(self):
-        """Test correct behavior of writablity to the returned array view."""
+        """Test correct behavior of non-writablity to the returned array view."""
 
-        img = sitk.Image((9, 10), sitk.sitkFloat32, 1)
+        img = sitk.Image((3, 4), sitk.sitkFloat32, 1)
 
         a = sitk.GetArrayViewFromImage(img)
+
+        self.assertFalse(a.flags['WRITEABLE'])
+
+        with self.assertRaises(ValueError):
+            a[1, 2] = 1
 
         with self.assertRaises(ValueError):
             a.fill(0)

--- a/Wrapping/Python/LegacyPackaging.cmake
+++ b/Wrapping/Python/LegacyPackaging.cmake
@@ -86,7 +86,7 @@ if (SimpleITK_PYTHON_USE_VIRTUALENV)
   add_custom_command( OUTPUT "${VIRTUAL_PYTHON_EXECUTABLE}"
     COMMAND "${PYTHON_EXECUTABLE}" "-m" "venv" "--clear" "${PythonVirtualenvHome}"
     COMMAND "${VIRTUAL_PYTHON_EXECUTABLE}" "-m" "pip" "install" "--upgrade" "pip"
-    COMMAND "${VIRTUAL_PYTHON_EXECUTABLE}" "-m" "pip" "install" "wheel" "numpy" "."
+    COMMAND "${VIRTUAL_PYTHON_EXECUTABLE}" "-m" "pip" "install" "wheel" "numpy!=1.24.1,!=1.24.0" "."
     WORKING_DIRECTORY "${SimpleITK_Python_BINARY_DIR}"
     DEPENDS
     "${SWIG_MODULE_SimpleITKPython_TARGET_NAME}"


### PR DESCRIPTION
See SimpleITK#1805 for details.

Explude version of numpy which cause Python.Test.ArrayView to fail.