### PR TITLE
Teach Python masked assign to support vector images

### DIFF
--- a/Code/BasicFilters/json/MaskImageFilter.json
+++ b/Code/BasicFilters/json/MaskImageFilter.json
@@ -3,7 +3,7 @@
   "template_code_filename" : "DualImageFilter",
   "template_test_filename" : "ImageFilter",
   "number_of_inputs" : 0,
-  "doc" : "Some global documentation\n\\todo MaskImageFilter will support VectorImages shortly",
+  "doc" : "Some global documentation\n",
   "include_files" : [
     "sitkToPixelType.hxx"
   ],

--- a/Code/BasicFilters/json/MaskedAssignImageFilter.json
+++ b/Code/BasicFilters/json/MaskedAssignImageFilter.json
@@ -1,15 +1,14 @@
 {
   "name" : "MaskedAssignImageFilter",
-  "template_code_filename" : "DualImageFilter",
+  "template_code_filename" : "ImageFilter",
   "template_test_filename" : "ImageFilter",
-  "filter_type" : "itk::MaskedAssignImageFilter<InputImageType, InputImageType2, OutputImageType>",
+  "filter_type" : "itk::MaskedAssignImageFilter<InputImageType, itk::Image<std::uint8_t, InputImageType::ImageDimension>, OutputImageType>",
   "number_of_inputs" : 0,
   "doc" : "",
   "include_files" : [
     "sitkToPixelType.hxx"
   ],
   "pixel_types" : "NonLabelPixelIDTypeList",
-  "pixel_types2" : "MaskedPixelIDTypeList",
   "inputs" : [
     {
       "name" : "Image",
@@ -21,10 +20,22 @@
     },
     {
       "name" : "AssignImage",
-      "type" : "Image"
+      "type" : "Image",
+      "optional" : true
     }
   ],
-  "members" : [],
+  "members" : [
+    {
+      "name" : "AssignConstant",
+      "type" : "double",
+      "default" : 0,
+      "custom_itk_cast" : "if (inAssignImage == nullptr) {typename OutputImageType::PixelType v;  NumericTraits<typename OutputImageType::PixelType>::SetLength( v, image1->GetNumberOfComponentsPerPixel() );  ToPixelType( this->m_AssignConstant, v ); filter->SetAssignConstant( v );}",
+      "briefdescriptionSet" : "",
+      "detaileddescriptionSet" : "Method to explicitly set the outside value of the mask when AssignImage is undefined. Defaults to 0",
+      "briefdescriptionGet" : "",
+      "detaileddescriptionGet" : ""
+    }
+  ],
   "tests" : [
     {
       "tag" : "2d",
@@ -42,7 +53,7 @@
       "tag" : "cthead1",
       "description" : "cthead with different types",
       "settings" : [],
-        "md5hash" : "815662daa2000a9d93ca0d025319809a",
+      "md5hash" : "815662daa2000a9d93ca0d025319809a",
       "inputs" : [
         "Input/cthead1-Float.mha",
         "Input/cthead1-mask.png",
@@ -50,15 +61,46 @@
       ]
     },
     {
+      "tag" : "cthead1_constant",
+      "description" : "cthead with different types and constant assign",
+      "settings" : [
+        {
+          "parameter" : "AssignConstant",
+          "type" : "double",
+          "value" : "0.0"
+        }
+      ],
+        "md5hash" : "69e26fb7cc642621f4c6eaa037e9259a",
+      "inputs" : [
+        "Input/cthead1-Float.mha",
+        "Input/cthead1-mask.png"
+      ]
+    },
+    {
       "tag" : "rgb",
       "description" : "rgb",
-      "settings" : [
-      ],
-        "md5hash" : "25219307a68bebbe202040ea61c7687d",
+      "settings" : [],
+      "md5hash" : "25219307a68bebbe202040ea61c7687d",
       "inputs" : [
         "Input/VM1111Shrink-RGB.png",
         "Input/VM1111Shrink-mask.png",
         "Input/VM1111Shrink-RGB.png"
+      ]
+    },
+    {
+      "tag" : "rgb_constant",
+      "description" : "assign constant to rgb",
+      "settings" : [
+        {
+          "parameter" : "AssignConstant",
+          "type" : "double",
+          "value" : "0.0"
+        }
+      ],
+      "md5hash" : "e641fb5503d0ec3b6023fc80b9848500",
+      "inputs" : [
+        "Input/VM1111Shrink-RGB.png",
+        "Input/VM1111Shrink-mask.png"
       ]
     }
   ],

--- a/Testing/Unit/Python/sitkImageTests.py
+++ b/Testing/Unit/Python/sitkImageTests.py
@@ -458,7 +458,7 @@ class ImageTests(unittest.TestCase):
                            sitk.sitkUInt8, sitk.sitkInt8,
                            sitk.sitkUInt16, sitk.sitkInt16,
                            sitk.sitkUInt32, sitk.sitkInt32,
-                           sitk.sitkUInt64, sitk.sitkInt64):
+                           sitk.sitkUInt64, sitk.sitkInt64, ):
             image = sitk.Image([2, 2], pixel_type)
 
             image[mask_image] = 2
@@ -466,6 +466,21 @@ class ImageTests(unittest.TestCase):
             self.assertEqual(image[1,0], 2)
             self.assertEqual(image[0,1], 2)
             self.assertEqual(image[1,1], 0)
+
+
+        for pixel_type in (sitk.sitkVectorFloat32, sitk.sitkVectorFloat64,
+                           sitk.sitkVectorUInt8, sitk.sitkVectorInt8,
+                           sitk.sitkVectorUInt16, sitk.sitkVectorInt16,
+                           sitk.sitkVectorUInt32, sitk.sitkVectorInt32,
+                           sitk.sitkVectorUInt64, sitk.sitkVectorInt64, ):
+            image = sitk.Image([2, 2], pixel_type)
+
+            image[mask_image] = 2
+            self.assertTrue(all(i == 0 for i in image[0,0]))
+            self.assertTrue(all(i == 2 for i in image[1,0]), image[1,0])
+            self.assertTrue(all(i == 2 for i in image[0,1]))
+            self.assertTrue(all(i == 0 for i in image[1,1]))
+
 
     def test_legacy(self):
         """ This is old testing cruft before unittest"""

--- a/Wrapping/Python/sitkImage.i
+++ b/Wrapping/Python/sitkImage.i
@@ -195,10 +195,9 @@
         }
         Image __imasked_assign(const Image &mask,  double constant)
         {
-          itk::simple::MaskNegatedImageFilter mn;
-          mn.SetMaskingValue(0);
-          mn.SetOutsideValue(constant);
-          return (*$self) = mn.Execute(std::move(*$self), mask);
+          itk::simple::MaskedAssignImageFilter ma;
+          ma.SetAssignConstant(constant);
+          return (*$self) = ma.Execute(std::move(*$self), mask);
         }
 
 


### PR DESCRIPTION
Updated MaskedAssignImageFilter to have an optional AssignImage, and support constant assignments. This  duplicates the functionality of the MaskNegatedImageFilter, but support vector images.