### PR TITLE
Update RtD configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,8 +12,11 @@ formats: all
 sphinx:
   configuration: docs/source/conf.py
 
+build:
+  tools:
+    python: "3.10"
+
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.10
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
python.version is depricated and replaced by build.tools.python