### PR TITLE
ENH: Dependency between GetGDCMSeriesIDs and GetGDCMSeriesFileNames.

### DIFF
--- a/Code/IO/include/sitkImageSeriesReader.h
+++ b/Code/IO/include/sitkImageSeriesReader.h
@@ -99,7 +99,10 @@ namespace itk {
        * \param seriesID          Set the name that identifies a
        * particular series. Default value is an empty string which
        * will return the file names associated with the first series
-       * found in the directory.
+       * found in the directory. If the parameter value was obtained
+       * from a call to GDCMSeriesIDs, the value of the
+       * useSeriesDetails parameter must be the same here and in the
+       * call to GDCMSeriesIDs.
        * \param useSeriesDetails  Use additional series information
        * such as ProtocolName and SeriesName to identify when a single
        * SeriesUID contains multiple 3D volumes - as can occur with
@@ -117,9 +120,15 @@ namespace itk {
       /** \brief Get all the seriesIDs from a DICOM data set
        *
        * \param directory  The directory that contains the DICOM data set
+       * \param useSeriesDetails  Use additional series information
+       * such as ProtocolName and SeriesName to identify when a single
+       * SeriesUID contains multiple 3D volumes - as can occur with
+       * perfusion and DTI imaging. The parameter value must match the
+       * value used in the call to GDCMSeriesFileNames.
        * \sa itk::GDCMSeriesFileNames
        **/
-      static std::vector<std::string> GetGDCMSeriesIDs( const std::string &directory );
+      static std::vector<std::string> GetGDCMSeriesIDs( const std::string &directory,
+                                                        bool useSeriesDetails = false );
 
       SITK_RETURN_SELF_TYPE_HEADER SetFileNames ( const std::vector<std::string> &fileNames );
       const std::vector<std::string> &GetFileNames() const;

--- a/Code/IO/src/sitkImageSeriesReader.cxx
+++ b/Code/IO/src/sitkImageSeriesReader.cxx
@@ -63,11 +63,13 @@ namespace itk {
     return gdcmSeries->GetFileNames(seriesID);
     }
 
-  std::vector<std::string> ImageSeriesReader::GetGDCMSeriesIDs( const std::string &directory )
+  std::vector<std::string> ImageSeriesReader::GetGDCMSeriesIDs( const std::string &directory,
+                                                                bool useSeriesDetails )
     {
     GDCMSeriesFileNames::Pointer gdcmSeries = GDCMSeriesFileNames::New();
 
     gdcmSeries->SetInputDirectory( directory );
+    gdcmSeries->SetUseSeriesDetails( useSeriesDetails );
     return gdcmSeries->GetSeriesUIDs();
     }
 

--- a/Testing/Unit/sitkImageIOTests.cxx
+++ b/Testing/Unit/sitkImageIOTests.cxx
@@ -465,6 +465,20 @@ TEST(IO, DicomSeriesReader) {
   fileNames = reader.GetGDCMSeriesFileNames( dicomDir, "1.2.840.113619.2.133.1762890640.1886.1055165015.999" );
   EXPECT_EQ( 3u, fileNames.size() );
 
+  // Use the original seriesIDs, first series, and attempt to list the
+  // series files using the "decorated" series information
+  // (useSeriesDetails). They should not match and will result in an
+  // empty vector.
+  bool useSeriesDetails = true;
+  fileNames = reader.GetGDCMSeriesFileNames( dicomDir, seriesIDs[0], useSeriesDetails );
+  EXPECT_EQ( 0u, fileNames.size() );
+
+  //Now, get the "decorated" series information and it will match what
+  //is used in the GetGDCMSeriesFileNames method.
+  seriesIDs = reader.GetGDCMSeriesIDs( dicomDir, useSeriesDetails );
+  fileNames = reader.GetGDCMSeriesFileNames( dicomDir, seriesIDs[0], useSeriesDetails );
+  EXPECT_EQ( 3u, fileNames.size() );
+
   // When reading a series each slice has its own meta-data dictionary
   // so the user has to decide on how to combine them, our image will
   // return an empty dictionary.


### PR DESCRIPTION
The GetGDCMSeriesFileNames supports a useSeriesDetails flag which appends tag based information to the seriesUID. This "decorated" seriesUID is then used to identify files as belonging to the series. The GetGDCMSeriesIDs did not support the useSeriesDetails flag, so always returned the non-decorated seriesUID which in combination with the decorated seriesUID used by
GetGDCMSeriesFileNames returns no matching files. This commit adds the flag to the GetGDCMSeriesIDs so that returns "decorated" seriesUIDs when it is set to true and will work as expected with GetGDCMSeriesFileNames when that is called with the flag set to true too.