### PR TITLE
Add self-hosted-x64

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -99,7 +99,7 @@ jobs:
     - name: Install Monarch self-hosted build dependencies
       if: matrix.os == 'self-hosted-x64'
       run: |
-        apt install -y \
+        apt-get install -y \
           mono-devel \
           r-base \
           r-base-dev \

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -30,6 +30,15 @@ jobs:
       max-parallel: 4
       matrix:
         include:
+          - os: self-hosted-x64
+            cmake-build-type: "Release"
+            cmake-generator: "Ninja"
+            ctest-cache: |
+              WRAP_PYTHON:BOOL=ON
+              WRAP_JAVA:BOOL=ON
+              WRAP_CSHARP:BOOL=ON
+              WRAP_R:BOOL=ON
+              SimpleITK_USE_ELASTIX:BOOL=ON
           - os: self-hosted-arm
             cmake-build-type: "Release"
             cmake-generator: "Ninja"
@@ -53,7 +62,6 @@ jobs:
               WRAP_PYTHON:BOOL=ON
               WRAP_JAVA:BOOL=ON
               WRAP_CSHARP:BOOL=ON
-
     steps:
     - uses: actions/checkout@v3
       with:
@@ -88,6 +96,15 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install ninja scikit-ci-addons cmake~=3.18.0
+    - name: Install Monarch self-hosted build dependencies
+      if: matrix.os == 'self-hosted-x64'
+      run: |
+        apt install -y \
+          mono-devel \
+          r-base \
+          r-base-dev \
+          ruby-dev \
+          ruby-full
     - name: Build and Test
       shell: bash
       env:


### PR DESCRIPTION
This PR adds Monarch self-hosted Github runners on x64 architecture.