### PR TITLE
Reduce output verbosity for spell checking

### DIFF
--- a/.github/workflows/PythonLintAndSpell.yml
+++ b/.github/workflows/PythonLintAndSpell.yml
@@ -54,4 +54,4 @@ jobs:
 
     - name: Do spell checking
       run: |
-        codespell . --suffix ".py" --suffix ".cxx" --dict .github/workflows/additional_dictionary.txt
+        codespell . --miss --suffix ".py" --suffix ".cxx" --dict .github/workflows/additional_dictionary.txt


### PR DESCRIPTION
Only print out the spelling errors found.