### PR TITLE
Fixed spelling bugs in .hxx files

### DIFF
--- a/.github/workflows/PythonLintAndSpell.yml
+++ b/.github/workflows/PythonLintAndSpell.yml
@@ -54,4 +54,5 @@ jobs:
 
     - name: Do spell checking
       run: |
-        codespell . --miss --suffix ".py" --suffix ".cxx" --dict .github/workflows/additional_dictionary.txt
+        codespell . --miss --suffix ".py" --suffix ".cxx" --suffix ".md" --suffix ".rst" \
+          --suffix ".hxx" --dict .github/workflows/additional_dictionary.txt

--- a/.github/workflows/additional_dictionary.txt
+++ b/.github/workflows/additional_dictionary.txt
@@ -1921,6 +1921,7 @@ specialised
 sphinxexample
 sphinxext
 spie
+splined
 splitlines
 splitter
 splweb

--- a/.github/workflows/additional_dictionary.txt
+++ b/.github/workflows/additional_dictionary.txt
@@ -1308,6 +1308,7 @@ ggplot
 gh
 gimble
 gipl
+github
 gitlab
 globals
 gmail
@@ -1666,6 +1667,7 @@ num
 numarray
 numfocus
 numpy
+nrrd
 objectness
 oct
 octree
@@ -1929,6 +1931,7 @@ springgreen
 sprintf
 sqr
 sqrt
+src
 srcRegion
 ss
 sse
@@ -1981,6 +1984,7 @@ supersampling
 superset
 sv
 svd
+svg
 swapaxes
 sweepline
 switch
@@ -2053,6 +2057,7 @@ typelist
 typelists
 typename
 tz
+ubuntu
 ubyte
 uchar
 uchars
@@ -2178,6 +2183,7 @@ xyz
 xz
 ymax
 ymin
+yml
 yn
 yy
 yyy

--- a/Code/BasicFilters/src/sitkImageToKernel.hxx
+++ b/Code/BasicFilters/src/sitkImageToKernel.hxx
@@ -26,10 +26,10 @@ namespace itk {
 namespace simple {
 namespace {
 
-/** \brief Convert an itk Image to an itk ImageKernalOperator
+/** \brief Convert an itk Image to an itk ImageKernelOperator
  *
  * This method will internally pad the image with the
- * ConstantPadImageFilter, and then convert to an ImageKernalOperator
+ * ConstantPadImageFilter, and then convert to an ImageKernelOperator
  * via a deep copy.
  *
  */

--- a/Code/BasicFilters/src/sitkPermuteAxis_Static.hxx
+++ b/Code/BasicFilters/src/sitkPermuteAxis_Static.hxx
@@ -21,7 +21,7 @@
 #include "sitkPermuteAxesImageFilter.h"
 
 // This file is intended to contain the definition of static
-// membervariables needed by JSON Expand templated image filters.
+// member variables needed by JSON Expand templated image filters.
 // It may also contain other member declarations, or other useful
 // items that could be specified here, as opposed to the JSON.
 

--- a/Code/Common/include/sitkImageConvert.hxx
+++ b/Code/Common/include/sitkImageConvert.hxx
@@ -86,7 +86,7 @@ GetVectorImageFromImage( itk::Image< itk::Vector< TPixelType, NLength >, NImageD
   typename VectorImageType::InternalPixelType* buffer = reinterpret_cast<typename VectorImageType::InternalPixelType*>( img->GetPixelContainer()->GetBufferPointer() );
 
   // Unlike an image of Vectors a VectorImage's container is a
-  // container of TPixelType, whos size is the image's number of
+  // container of TPixelType, whose size is the image's number of
   // pixels * number of pixels per component
   numberOfElements *= NLength;
 
@@ -131,7 +131,7 @@ GetVectorImageFromImage( itk::Image< itk::CovariantVector< TPixelType, NLength>,
   typename VectorImageType::InternalPixelType* buffer = reinterpret_cast<typename VectorImageType::InternalPixelType*>( img->GetPixelContainer()->GetBufferPointer() );
 
   // Unlike an image of Vectors a VectorImage's container is a
-  // container of TPixelType, whos size is the image's number of
+  // container of TPixelType, whose size is the image's number of
   // pixels * number of pixels per component
   numberOfElements *= NLength;
 
@@ -189,7 +189,7 @@ GetVectorImageFromImage( itk::Image< itk::Offset< NLength >, NImageDimension> *i
   typename VectorImageType::InternalPixelType* buffer = reinterpret_cast<typename VectorImageType::InternalPixelType*>( img->GetPixelContainer()->GetBufferPointer() );
 
   // Unlike an image of Vectors a VectorImage's container is a
-  // container of TPixelType, whos size is the image's number of
+  // container of TPixelType, whose size is the image's number of
   // pixels * number of pixels per component
   numberOfElements *= NLength;
 

--- a/Code/Common/src/sitkPimpleTransform.hxx
+++ b/Code/Common/src/sitkPimpleTransform.hxx
@@ -52,10 +52,10 @@ namespace itk
 namespace simple
 {
 
-// This is a base class of the private implementatino of the transform
+// This is a base class of the private implementation of the transform
 // class.
 //
-// The interface provide virutal method and other generic methods to
+// The interface provide virtual method and other generic methods to
 // the concrete ITK transform type, there by provide encapsulation and
 // a uniform interface
 class SITKCommon_HIDDEN PimpleTransformBase
@@ -146,7 +146,7 @@ public:
   // Tries to construct an inverse of the transform, if true is returned
   // the inverse was successful, and outputTransform is modified to
   // the new class and ownership it passed to the caller.  Otherwise
-  // outputTranform is not changed.
+  // outputTransform is not changed.
   virtual bool GetInverse( PimpleTransformBase * &outputTransform ) const = 0;
 
   virtual bool IsLinear() const


### PR DESCRIPTION
Also, the Github Action now checks ".md", ".rst" and ".hxx" files automatically.