### PR TITLE
Add 4D support to cast filter when elastix is enabled

### DIFF
--- a/Code/BasicFilters/include/sitkCastImageFilter.h
+++ b/Code/BasicFilters/include/sitkCastImageFilter.h
@@ -167,6 +167,7 @@ private:
   void RegisterMemberFactory3();
   void RegisterMemberFactory3v();
   void RegisterMemberFactory3l();
+  void RegisterMemberFactory4();
   /** @} */
 
   typedef Image (Self::*MemberFunctionType)( const Image& );

--- a/Code/BasicFilters/src/CMakeLists.txt
+++ b/Code/BasicFilters/src/CMakeLists.txt
@@ -98,6 +98,7 @@ cache_list_append( SimpleITKBasicFiltersGeneratedSource_ITKCommon
   sitkCastImageFilter-3.cxx
   sitkCastImageFilter-3l.cxx
   sitkCastImageFilter-3v.cxx
+  sitkCastImageFilter-4.cxx
   sitkCastImageFilter.cxx
   sitkExtractImageFilter.cxx
   sitkHashImageFilter.cxx )

--- a/Code/BasicFilters/src/sitkCastImageFilter-4.cxx
+++ b/Code/BasicFilters/src/sitkCastImageFilter-4.cxx
@@ -1,0 +1,42 @@
+/*=========================================================================
+*
+*  Copyright NumFOCUS
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*         http://www.apache.org/licenses/LICENSE-2.0.txt
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*=========================================================================*/
+
+#include "sitkCastImageFilter.hxx"
+
+
+namespace itk
+{
+namespace simple
+{
+
+
+void CastImageFilter::RegisterMemberFactory4()
+{
+#if SITK_MAX_DIMENSION >= 4 && defined(SITK_USE_ELASTIX)
+    m_DualMemberFactory->RegisterMemberFunctions<ComplexPixelIDTypeList, ComplexPixelIDTypeList, 4, CastAddressor<MemberFunctionType> > ();
+    m_DualMemberFactory->RegisterMemberFunctions<BasicPixelIDTypeList, ComplexPixelIDTypeList, 4, CastAddressor<MemberFunctionType> > ();
+    m_DualMemberFactory->RegisterMemberFunctions<BasicPixelIDTypeList, BasicPixelIDTypeList, 4, CastAddressor<MemberFunctionType> > ();
+    m_DualMemberFactory->RegisterMemberFunctions<IntegerPixelIDTypeList, LabelPixelIDTypeList, 4, ToLabelAddressor<MemberFunctionType> > ();
+    m_DualMemberFactory->RegisterMemberFunctions<LabelPixelIDTypeList, IntegerPixelIDTypeList, 4, LabelToAddressor<MemberFunctionType> > ();
+    m_DualMemberFactory->RegisterMemberFunctions<VectorPixelIDTypeList, VectorPixelIDTypeList, 4, CastAddressor<MemberFunctionType> > ();
+    m_DualMemberFactory->RegisterMemberFunctions<BasicPixelIDTypeList, VectorPixelIDTypeList, 4, ToVectorAddressor<MemberFunctionType> > ();
+#endif
+}
+
+} // end namespace simple
+} // end namespace itk

--- a/Code/BasicFilters/src/sitkCastImageFilter.cxx
+++ b/Code/BasicFilters/src/sitkCastImageFilter.cxx
@@ -45,6 +45,7 @@ CastImageFilter::CastImageFilter()
   this->RegisterMemberFactory3v();
   this->RegisterMemberFactory3l();
 
+  this->RegisterMemberFactory4();
 
 }
 


### PR DESCRIPTION
Supporting these additional adds about 4MB to the size of the binary so support for 4D is only enabled if elastix is configured.

closes #1891