### PR TITLE
Use a proxy image for inplace operations

### DIFF
--- a/Code/BasicFilters/include/sitkImageOperators.h
+++ b/Code/BasicFilters/include/sitkImageOperators.h
@@ -93,22 +93,22 @@ inline Image operator^( Image &&img, int s ) { return Xor(std::move(img), s ); }
 inline Image operator^( int s, const Image &img ) { return Xor(s, img ); }
 
 
-inline Image &operator+=( Image &img1, const Image &img2 ) { return img1 = Add(std::move(img1), img2 ); }
-inline Image &operator+=( Image &img1, double s ) { return img1 = Add(std::move(img1), s ); }
-inline Image &operator-=( Image &img1, const Image &img2 ) { return img1 = Subtract(std::move(img1), img2 ); }
-inline Image &operator-=( Image &img1, double s ) { return img1 = Subtract(std::move(img1), s ); }
-inline Image &operator*=( Image &img1, const Image &img2 ) { return img1 = Multiply(std::move(img1), img2 ); }
-inline Image &operator*=( Image &img1, double s ) { return img1 = Multiply(std::move(img1), s ); }
-inline Image &operator/=( Image &img1, const Image &img2 ) { return img1 = Divide(std::move(img1), img2 ); }
-inline Image &operator/=( Image &img1, double s ) { return img1 = Divide(std::move(img1), s ); }
-inline Image &operator%=( Image &img1, const Image &img2 ) { return img1 = Modulus(std::move(img1), img2 ); }
-inline Image &operator%=( Image &img1, uint32_t s ) { return img1 = Modulus(std::move(img1), s ); }
-inline Image &operator&=( Image &img1, const Image &img2 ) { return img1 = And(std::move(img1), img2 ); }
-inline Image &operator&=( Image &img1, int s ) { return img1 = And(std::move(img1), s ); }
-inline Image &operator|=( Image &img1, const Image &img2 ) { return img1 = Or(std::move(img1), img2 ); }
-inline Image &operator|=( Image &img1, int s ) { return img1 = Or(std::move(img1), s ); }
-inline Image &operator^=( Image &img1, const Image &img2 ) { return img1 = Xor(std::move(img1), img2 ); }
-inline Image &operator^=( Image &img1, int s ) { return img1 = Xor(std::move(img1), s ); }
+inline Image &operator+=( Image &img1, const Image &img2 ) { Add(img1.ProxyForInPlaceOperation(), img2 ); return img1;}
+inline Image &operator+=( Image &img1, double s ) { Add(img1.ProxyForInPlaceOperation(), s ); return img1;}
+inline Image &operator-=( Image &img1, const Image &img2 ) { Subtract(img1.ProxyForInPlaceOperation(), img2 ); return img1;}
+inline Image &operator-=( Image &img1, double s ) { Subtract(img1.ProxyForInPlaceOperation(), s ); return img1;}
+inline Image &operator*=( Image &img1, const Image &img2 ) { Multiply(img1.ProxyForInPlaceOperation(), img2 ); return img1;}
+inline Image &operator*=( Image &img1, double s ) { Multiply(img1.ProxyForInPlaceOperation(), s ); return img1;}
+inline Image &operator/=( Image &img1, const Image &img2 ) { Divide(img1.ProxyForInPlaceOperation(), img2 ); return img1;}
+inline Image &operator/=( Image &img1, double s ) { Divide(img1.ProxyForInPlaceOperation(), s ); return img1;}
+inline Image &operator%=( Image &img1, const Image &img2 ) { Modulus(img1.ProxyForInPlaceOperation(), img2 ); return img1;}
+inline Image &operator%=( Image &img1, uint32_t s ) { Modulus(img1.ProxyForInPlaceOperation(), s ); return img1;}
+inline Image &operator&=( Image &img1, const Image &img2 ) { And(img1.ProxyForInPlaceOperation(), img2 ); return img1;}
+inline Image &operator&=( Image &img1, int s ) { And(img1.ProxyForInPlaceOperation(), s ); return img1;}
+inline Image &operator|=( Image &img1, const Image &img2 ) { Or(img1.ProxyForInPlaceOperation(), img2 ); return img1;}
+inline Image &operator|=( Image &img1, int s ) { Or(img1.ProxyForInPlaceOperation(), s ); return img1;}
+inline Image &operator^=( Image &img1, const Image &img2 ) { Xor(img1.ProxyForInPlaceOperation(), img2 ); return img1;}
+inline Image &operator^=( Image &img1, int s ) { Xor(img1.ProxyForInPlaceOperation(), s ); return img1;}
 /**@} */
 }
 }

--- a/Code/Common/include/sitkImage.h
+++ b/Code/Common/include/sitkImage.h
@@ -115,7 +115,7 @@ namespace simple
      * filter.Execute( img.ProxyForInPlaceOperation() );
      * \endcode
      *
-     * The meta-data dictionary is not copies to the returned proxy image.
+     * The meta-data dictionary is not copied to the returned proxy image.
      */
     Image ProxyForInPlaceOperation();
 #endif
@@ -549,8 +549,6 @@ namespace simple
     AllocateInternal ( const std::vector<unsigned int > &size, unsigned int numberOfComponents );
     /**@}*/
 
-    Image(std::unique_ptr<PimpleImageBase> &&pimpleImage );
-
   private:
 
    /** Method called by certain constructors to convert ITK images
@@ -562,6 +560,10 @@ namespace simple
      * chosen carefully to flexibly enable this.
      */
     void InternalInitialization( PixelIDValueType type, unsigned  int dimension, itk::DataObject *image );
+
+
+    Image( std::unique_ptr<PimpleImageBase> pimpleImage );
+
 
     template <typename TImageType>
     PimpleImageBase * DispatchedInternalInitialization(itk::DataObject *image);

--- a/Code/Common/include/sitkImage.h
+++ b/Code/Common/include/sitkImage.h
@@ -97,6 +97,27 @@ namespace simple
      */
     Image( Image &&img ) noexcept;
     Image& operator=( Image &&img ) noexcept;
+
+    /** \brief Advanced method not commonly needed
+     *
+     * This method is designed to support implementations "in-place" object behavior for methods which operate on
+     * r-value references. The returned image is a new image which has a low level pointer to this object's image
+     * buffer, without the SimpleITK or ITK reference counting. This is implemented by setting the new ITK Image's
+     * buffer to the same as this objects without ownership.
+     *
+     * \warning This method bypasses the SimpleITK reference counting, and the reference needs to be manually maintained
+     *  in the scope. The resulting object is designed only to be a temporary.
+     *
+     * In the following example this method is used instead of an `std::move` call when the filter's first argument
+     * takes an r-value reference. The `img` object will container the results of the filter execution, and the `img`
+     * image buffer will be preserved in case of exceptions, and the meta-data will remain in the img object.
+     * \code
+     * filter.Execute( img.ProxyForInPlaceOperation() );
+     * \endcode
+     *
+     * The meta-data dictionary is not copies to the returned proxy image.
+     */
+    Image ProxyForInPlaceOperation();
 #endif
 
 
@@ -528,6 +549,7 @@ namespace simple
     AllocateInternal ( const std::vector<unsigned int > &size, unsigned int numberOfComponents );
     /**@}*/
 
+    Image(std::unique_ptr<PimpleImageBase> &&pimpleImage );
 
   private:
 

--- a/Code/Common/src/sitkImage.cxx
+++ b/Code/Common/src/sitkImage.cxx
@@ -40,7 +40,7 @@ namespace itk
     Allocate ( {0, 0}, sitkUInt8, 1 );
   }
 
-  Image::Image( std::unique_ptr<PimpleImageBase> &&pimpleImage )
+  Image::Image( std::unique_ptr<PimpleImageBase> pimpleImage )
   : m_PimpleImage( std::move(pimpleImage) )
   {
       if (!this->m_PimpleImage)

--- a/Code/Common/src/sitkImage.cxx
+++ b/Code/Common/src/sitkImage.cxx
@@ -40,6 +40,15 @@ namespace itk
     Allocate ( {0, 0}, sitkUInt8, 1 );
   }
 
+  Image::Image( std::unique_ptr<PimpleImageBase> &&pimpleImage )
+  : m_PimpleImage( std::move(pimpleImage) )
+  {
+      if (!this->m_PimpleImage)
+      {
+          sitkExceptionMacro("Invalid nullptr pimpleImage.");
+      }
+  }
+
   Image::Image( const Image &img )
   : m_PimpleImage( img.m_PimpleImage->ShallowCopy())
   {
@@ -77,6 +86,18 @@ namespace itk
     Image::Image( const std::vector< unsigned int > &size, PixelIDValueEnum ValueEnum, unsigned int numberOfComponents )
     {
       Allocate( size, ValueEnum, numberOfComponents );
+    }
+
+
+    Image Image::ProxyForInPlaceOperation()
+    {
+        if ( m_PimpleImage ) {
+            this->MakeUnique();
+            auto proxy =m_PimpleImage->ProxyCopy();
+            assert(proxy);
+            return Image(std::move(proxy));
+        }
+        return Image();
     }
 
     itk::DataObject* Image::GetITKBase( )

--- a/Code/Common/src/sitkPimpleImageBase.h
+++ b/Code/Common/src/sitkPimpleImageBase.h
@@ -43,6 +43,8 @@ namespace itk
 
     virtual ~PimpleImageBase( ) = default;
 
+    virtual std::unique_ptr<PimpleImageBase> ProxyCopy() = 0;
+
     virtual PixelIDValueEnum GetPixelID() const = 0;
     virtual unsigned int GetDimension( ) const  = 0;
     virtual uint64_t GetNumberOfPixels( ) const = 0;

--- a/Testing/Unit/Python/sitkImageIndexingTest.py
+++ b/Testing/Unit/Python/sitkImageIndexingTest.py
@@ -50,6 +50,7 @@ class TestImageIndexingInterface(unittest.TestCase):
         nda = np.linspace(0, 14, 15 ).reshape(3,5)
 
         img = sitk.GetImageFromArray( nda )
+        img["test"] = "value"
 
         self.assertEqual( img.GetSize(), (5,3) )
 
@@ -59,11 +60,13 @@ class TestImageIndexingInterface(unittest.TestCase):
         self.assertEqual( img[[2,0]], 2.0 )
         self.assertEqual( img[1,2], 11.0 )
         self.assertEqual( img[-1,-2], 9.0 )
+        self.assertEqual(img["test"], "value")
 
         # check default slice indexing
         self.assertImageNDArrayEquals(img[:,:],nda)
         self.assertImageNDArrayEquals(img[:],nda)
         self.assertImageNDArrayEquals(img[::-1,::-1],nda[::-1,::-1])
+        self.assertEqual(img["test"], "value")
 
         # out of bounds cases and empty
         self.assertEqual(len(img[:,5:6]), 0)
@@ -71,6 +74,7 @@ class TestImageIndexingInterface(unittest.TestCase):
         self.assertEqual(len(img[-6:0,:]), 0)
         self.assertEqual(len(img[0:0,:]), 0)
         self.assertEqual(len(img[-4:-1:-2,-2:-1:1]), 0)
+        self.assertEqual(img["test"], "value")
 
 
 
@@ -82,6 +86,7 @@ class TestImageIndexingInterface(unittest.TestCase):
         self.assertImageNDArrayEquals(img[1:4:2,0:2:2],nda[0:2:2,1:4:2])
         self.assertImageNDArrayEquals(img[1::2,0::2],nda[0::2,1::2])
         self.assertImageNDArrayEquals(img[:3:2,:2:2],nda[:2:2,:3:2])
+        self.assertEqual(img["test"], "value")
 
         # check step size indexing
         self.assertImageNDArrayEquals(img[::2,:],nda[:,::2])
@@ -92,6 +97,7 @@ class TestImageIndexingInterface(unittest.TestCase):
         self.assertImageNDArrayEquals(img[::3,::3],nda[::3,::3])
         self.assertImageNDArrayEquals(img[::2,::3],nda[::3,::2])
         self.assertImageNDArrayEquals(img[::3,::2],nda[::2,::3])
+        self.assertEqual(img["test"], "value")
 
 
 
@@ -115,6 +121,7 @@ class TestImageIndexingInterface(unittest.TestCase):
         self.assertImageNDArrayEquals(img[...], nda[...])
         self.assertImageNDArrayEquals(img[...,1:3], nda[1:3,...])
         self.assertImageNDArrayEquals(img[-2:0,...], nda[...,-2:0])
+        self.assertEqual(img["test"], "value")
 
     def test_setitem(self):
         """ testing __setitem__ with pasting to roi"""
@@ -122,6 +129,7 @@ class TestImageIndexingInterface(unittest.TestCase):
         nda = np.linspace(0, 59, 60).reshape(3, 4, 5)
 
         img = sitk.GetImageFromArray(nda)
+        img["test"] = "value"
 
         img[1:3, 2:4, 0:2] = sitk.Image([2, 2, 2], sitk.sitkFloat64) + 1
         self.assertTrue(all([px == 1 for px in img[1:3, 2:4, 0:2]]))
@@ -133,6 +141,7 @@ class TestImageIndexingInterface(unittest.TestCase):
         self.assertTrue(all([px == 4 for px in img[0:2, 0:1, 0:3]]))
         img[0:2, 0:3, 0:1] = sitk.Image([2, 3], sitk.sitkFloat64) + 5
         self.assertTrue(all([px == 5 for px in img[0:2, 0:3, 0:1]]))
+        self.assertEqual(img["test"], "value")
 
         img[-1, 0:1, 0:3] = sitk.Image([1, 3], sitk.sitkFloat64) + 6
         self.assertTrue(all([px == 6 for px in img[-1, 0:1, 0:3]]))
@@ -140,6 +149,7 @@ class TestImageIndexingInterface(unittest.TestCase):
         self.assertTrue(all([px == 7 for px in img[1:2, 1, 0:3]]))
         img[2:3, 0:3, 1] = sitk.Image([1, 3], sitk.sitkFloat64) + 8
         self.assertTrue(all([px == 8 for px in img[2:3, 0:3, 1]]))
+        self.assertEqual(img["test"], "value")
 
         img[..., 2:4, 2:3] = sitk.Image([5, 2, 1], sitk.sitkFloat64) + 9
         self.assertTrue(all([px == 9 for px in img[:, 2:4, 2:3]]))
@@ -149,18 +159,23 @@ class TestImageIndexingInterface(unittest.TestCase):
         self.assertTrue(all([px == 11 for px in img]))
         img[2, 3:4, 1:2, ...] = sitk.Image([1, 1], sitk.sitkFloat64) + 12
         self.assertTrue(all([px == 12 for px in img[2, 3:4, 1:2]]))
+        self.assertEqual(img["test"], "value")
 
         with self.assertRaises(IndexError):
             img[1:3, 2:4] = sitk.Image([2, 2, 2], sitk.sitkFloat64)
+        self.assertEqual(img["test"], "value")
 
         self.assertRaises(IndexError,
                           lambda: self.doImageAssign(img, (slice(0, 2),) * 3, sitk.Image([2, 2], sitk.sitkFloat64)))
+        self.assertEqual(img["test"], "value")
         self.assertRaises(IndexError,
                           lambda: self.doImageAssign(img, (slice(0, 2),) * 3, sitk.Image([2, 2, 1], sitk.sitkFloat64)))
         self.assertRaises(IndexError,
                           lambda: self.doImageAssign(img, (slice(0, 2),) * 3, sitk.Image([2, 1, 2], sitk.sitkFloat64)))
         self.assertRaises(IndexError,
                           lambda: self.doImageAssign(img, (slice(0, 2),) * 3, sitk.Image([1, 2, 2], sitk.sitkFloat64)))
+
+        self.assertEqual(img["test"], "value")
 
     def test_5d_setitem(self):
         """ testing __setitem__ with pasting to 5D roi"""
@@ -173,21 +188,26 @@ class TestImageIndexingInterface(unittest.TestCase):
 
         size = [19, 17, 13, 2, 3]
         img = sitk.Image(size, sitk.sitkFloat64)
+        img["test"] = "value"
 
         img[0, 0, 0, 0, 0] = 1
         self.assertEqual(1, img.GetPixel([0, 0, 0, 0, 0]))
+        self.assertEqual(img["test"], "value")
 
         img[-19, -17, -13, -2, -3] = 2
         self.assertEqual(2, img.GetPixel([0, 0, 0, 0, 0]))
+        self.assertEqual(img["test"], "value")
 
         img[:, :, :, 0, 0] = sitk.Image(size[:3], sitk.sitkFloat64) + 3
         self.assertEqual(3, img.GetPixel([0, 0, 0, 0, 0]))
         self.assertTrue(all([px == 3 for px in img[:, :, :, 0, 0]]))
+        self.assertEqual(img["test"], "value")
 
         img[:, 1, 1, :, 2] = sitk.Image((size[0], size[3]), sitk.sitkFloat64) + 4
         self.assertEqual(4, img.GetPixel([0, 1, 1, 0, 2]))
         self.assertEqual(4, img[0, 1, 1, 0, 2])
         self.assertTrue(all([px == 4 for px in img[:, 1, 1, :, 2]]))
+        self.assertEqual(img["test"], "value")
 
         img = sitk.Image(size, sitk.sitkUInt8)
         img[..., 0] = 1

--- a/Testing/Unit/Python/sitkImageTests.py
+++ b/Testing/Unit/Python/sitkImageTests.py
@@ -244,102 +244,133 @@ class ImageTests(unittest.TestCase):
 
         image1 = sitk.Image([2, 2], sitk.sitkFloat64)
         image2 = image1 + 1.0
+        image1["test"] = "value"
 
         self.assertEqual(image1[1, 1], 0.0)
         self.assertEqual(image2[1, 1], 1.0)
+        self.assertEqual(image1["test"], "value")
 
         image1 += image2
         self.assertEqual(image1[1, 1], 1.0)
+        self.assertEqual(image1["test"], "value")
 
         image1 *= image2+5.5
         self.assertEqual(image1[0, 0], 6.5)
+        self.assertEqual(image1["test"], "value")
 
         image1 -= image2
         self.assertEqual(image1[0, 0], 5.5)
+        self.assertEqual(image1["test"], "value")
 
         image1 /= image2*2.0
         self.assertEqual(image1[0, 0], 2.75)
+        self.assertEqual(image1["test"], "value")
 
         image1 //= image2*2.0
         self.assertEqual(image1[0, 0], 1.0)
+        self.assertEqual(image1["test"], "value")
 
         image1 **= image2
         self.assertEqual(image1[0, 0], 1.0)
+        self.assertEqual(image1["test"], "value")
 
         image1 = sitk.Image([3, 3], sitk.sitkUInt32)
         image2 = sitk.Image([3,3], sitk.sitkUInt32)
+        image1["test"] = "value"
 
         image1 += (image2 + 0b10001110101)
         self.assertEqual(image1[1, 1], 1141)
+        self.assertEqual(image1["test"], "value")
 
         image1 &= (image2 + 0b11111111011)
         self.assertEqual(image1[1, 1], 1137)
+        self.assertEqual(image1["test"], "value")
 
         image1 |= (image2 + 0b00000000111)
         self.assertEqual(image1[1, 1], 1143)
+        self.assertEqual(image1["test"], "value")
 
         image1 ^= (image2 + 0b00000001101)
         self.assertEqual(image1[1, 1], 1146)
+        self.assertEqual(image1["test"], "value")
 
         image1 %= (image2 + 4)
         self.assertEqual(image1[1, 1], 2)
+        self.assertEqual(image1["test"], "value")
 
     def test_inplace_operators_exception(self):
         """ Test exception generated during inplace operation"""
 
-        img = sitk.Image([1,1], sitk.sitkUInt32)
+        size = [1, 1]
+        img = sitk.Image(size, sitk.sitkUInt32)
+        img["test"] = "1"
         try:
             img += sitk.Cast(img, sitk.sitkFloat32)
         except RuntimeError:
             pass
         else:
-            assert(False) # Failed to throw exception
-        # img was C++ moved then an exception occurred, this is the state afterwards.
-        # This check ensure the image is still valid, the value does not matter.
-        self.assertEqual( img.GetSize(), (0,0))
+            assert False  # Failed to throw exception
 
+        # Check the image and meta-data dictionary are the sane.
+        self.assertEqual( img.GetSize(), tuple(size))
+        self.assertTrue( "test" in img )
+        self.assertEqual( img["test"], "1")
 
     def test_inplace_operators_constants(self):
         """ Test in place operators with numeric constants"""
 
         image = sitk.Image([2, 2], sitk.sitkFloat64)
+        image["test"] = "value"
 
         self.assertEqual(image[0, 0], 0.0)
+        self.assertEqual(image["test"], "value")
 
         image += 3.125
         self.assertEqual(image[0, 0], 3.125)
+        self.assertEqual(image["test"], "value")
 
         image *= 2.0
         self.assertEqual(image[0, 0], 6.25)
+        self.assertEqual(image["test"], "value")
 
         image -= 4.0
         self.assertEqual(image[0, 0], 2.25)
+        self.assertEqual(image["test"], "value")
 
         image /= 0.25
         self.assertEqual(image[0, 0], 9.0)
+        self.assertEqual(image["test"], "value")
 
         image //= 2.2
         self.assertEqual(image[0, 0], 4.0)
+        self.assertEqual(image["test"], "value")
 
         image **= 2.0
         self.assertEqual(image[0, 0], 16.0)
+        self.assertEqual(image["test"], "value")
 
         image = sitk.Image([3, 3], sitk.sitkUInt32)
+        image["test"] = "value"
 
         image += 0b10001110101
         self.assertEqual(image[1, 1], 1141)
+        self.assertEqual(image["test"], "value")
 
         image &= 0b11111111011
         self.assertEqual(image[1, 1], 1137)
+        self.assertEqual(image["test"], "value")
 
         image |= 0b00000000111
         self.assertEqual(image[1, 1], 1143)
+        self.assertEqual(image["test"], "value")
 
         image ^= 0b00000001101
         self.assertEqual(image[1, 1], 1146)
+        self.assertEqual(image["test"], "value")
 
         image %= 4
         self.assertEqual(image[1, 1], 2)
+        self.assertEqual(image["test"], "value")
 
     def test_evaluate_at_continuous_index(self):
         """Test for EvaluateAtContinuousIndex"""
@@ -412,6 +443,8 @@ class ImageTests(unittest.TestCase):
                            sitk.sitkUInt32, sitk.sitkInt32,
                            sitk.sitkUInt64, sitk.sitkInt64):
             image = sitk.Image([2, 2], pixel_type)
+            image["test"] = "value"
+
             image2 = sitk.Image([2, 2], pixel_type)
             image2 += 2
 
@@ -420,10 +453,13 @@ class ImageTests(unittest.TestCase):
             self.assertEqual(image[1,0], 2)
             self.assertEqual(image[0,1], 2)
             self.assertEqual(image[1,1], 0)
+            self.assertEqual(image["test"], "value")
 
         for pixel_type in (sitk.sitkComplexFloat32,
                            sitk.sitkComplexFloat64):
             image = sitk.Image([2, 2], pixel_type)
+            image["test"] = "value"
+
             image2 = sitk.Image([2, 2], pixel_type)
             image2 -= 1
             image[mask_image] = image2
@@ -432,6 +468,7 @@ class ImageTests(unittest.TestCase):
             self.assertEqual(image[1,0], complex(-1,0))
             self.assertEqual(image[0,1], complex(-1,0))
             self.assertEqual(image[1,1], 0)
+            self.assertEqual(image["test"], "value")
 
         for pixel_type in (sitk.sitkVectorFloat32, sitk.sitkVectorFloat64,
                            sitk.sitkVectorUInt8, sitk.sitkVectorInt8,
@@ -439,6 +476,8 @@ class ImageTests(unittest.TestCase):
                            sitk.sitkVectorUInt32, sitk.sitkVectorInt32,
                            sitk.sitkVectorUInt64, sitk.sitkVectorInt64):
             image = sitk.Image([2, 2], pixel_type, 4)
+            image["test"] = "value"
+
             image2 = sitk.Image([2, 2], pixel_type, 4)
             image2 += 2
 
@@ -448,6 +487,7 @@ class ImageTests(unittest.TestCase):
             self.assertTrue(all(i == 2 for i in image[1,0]), image[1,0])
             self.assertTrue(all(i == 2 for i in image[0,1]))
             self.assertTrue(all(i == 0 for i in image[1,1]))
+            self.assertEqual(image["test"], "value")
 
     def test_masked_assign_constant(self):
 
@@ -460,12 +500,14 @@ class ImageTests(unittest.TestCase):
                            sitk.sitkUInt32, sitk.sitkInt32,
                            sitk.sitkUInt64, sitk.sitkInt64, ):
             image = sitk.Image([2, 2], pixel_type)
+            image["test"] = "value"
 
             image[mask_image] = 2
             self.assertEqual(image[0,0], 0)
             self.assertEqual(image[1,0], 2)
             self.assertEqual(image[0,1], 2)
             self.assertEqual(image[1,1], 0)
+            self.assertEqual(image["test"], "value")
 
 
         for pixel_type in (sitk.sitkVectorFloat32, sitk.sitkVectorFloat64,
@@ -474,12 +516,14 @@ class ImageTests(unittest.TestCase):
                            sitk.sitkVectorUInt32, sitk.sitkVectorInt32,
                            sitk.sitkVectorUInt64, sitk.sitkVectorInt64, ):
             image = sitk.Image([2, 2], pixel_type)
+            image["test"] = "value"
 
             image[mask_image] = 2
             self.assertTrue(all(i == 0 for i in image[0,0]))
             self.assertTrue(all(i == 2 for i in image[1,0]), image[1,0])
             self.assertTrue(all(i == 2 for i in image[0,1]))
             self.assertTrue(all(i == 0 for i in image[1,1]))
+            self.assertEqual(image["test"], "value")
 
 
     def test_legacy(self):

--- a/Testing/Unit/sitkImageTests.cxx
+++ b/Testing/Unit/sitkImageTests.cxx
@@ -1724,6 +1724,36 @@ TEST_F(Image,MetaDataDictionary)
 
 }
 
+TEST_F(Image, ProxyForInPlaceOperation)
+{
+    sitk::Image img{ 10,10, sitk::sitkFloat32 };
+
+    img.SetPixelAsFloat({0,0}, 1.0f);
+
+    auto proxyImage = img.ProxyForInPlaceOperation();
+    EXPECT_EQ(proxyImage.GetPixelAsFloat({0,0}), 1.0f);
+    EXPECT_TRUE(proxyImage.IsUnique());
+    EXPECT_TRUE(img.IsUnique());
+
+    proxyImage.SetPixelAsFloat({0,1}, 2.0f);
+    EXPECT_EQ(proxyImage.GetPixelAsFloat({0,1}), 2.0f);
+    EXPECT_EQ(img.GetPixelAsFloat({0,1}), 2.0f);
+
+    sitk::Image img2{ {10,10}, sitk::sitkVectorUInt8, 3};
+
+    img2.SetPixelAsVectorUInt8({0,0}, {1,1,1});
+
+    proxyImage = img2.ProxyForInPlaceOperation();
+    ASSERT_EQ(proxyImage.GetPixelID(), sitk::sitkVectorUInt8);
+    EXPECT_EQ(proxyImage.GetPixelAsVectorUInt8({0,0}), std::vector<uint8_t>({1,1,1}));
+    EXPECT_TRUE(proxyImage.IsUnique());
+    EXPECT_TRUE(img2.IsUnique());
+
+    proxyImage.SetPixelAsVectorUInt8({0,1}, {3,2,1});
+    EXPECT_EQ(proxyImage.GetPixelAsVectorUInt8({0,1}), std::vector<uint8_t>({3,2,1}));
+    EXPECT_EQ(img2.GetPixelAsVectorUInt8({0,1}), std::vector<uint8_t>({3,2,1}));
+}
+
 TEST_F(Image, MoveOperations)
 {
   sitk::Image img;

--- a/Testing/Unit/sitkOperatorTests.cxx
+++ b/Testing/Unit/sitkOperatorTests.cxx
@@ -96,10 +96,12 @@ TEST(OperatorTests,BinaryLogic)
 
 TEST(OperatorTests, InPlaceException)
 {
-
+    const std::string img1_hash = "ed4a77d1b56a118938788fc53037759b6c501e3d";
     sitk::Image img1 ( 10, 10, sitk::sitkInt8 );
+    img1.SetMetaData("test", "value");
     sitk::Image img2 ( 10, 10, sitk::sitkInt32 );
 
+    EXPECT_EQ( img1_hash, sitk::Hash( img1));
     auto itkBasePtr1 = img1.GetITKBase();
     auto itkBasePtr2 = img2.GetITKBase();
 
@@ -107,8 +109,9 @@ TEST(OperatorTests, InPlaceException)
 
 
     EXPECT_EQ(static_cast<const sitk::Image&>(img2).GetITKBase(), itkBasePtr2);
-    EXPECT_NE(static_cast<const sitk::Image&>(img1).GetITKBase(), nullptr);
-    EXPECT_NE(static_cast<const sitk::Image&>(img1).GetITKBase(), itkBasePtr1);
+    EXPECT_EQ(static_cast<const sitk::Image&>(img1).GetITKBase(), itkBasePtr1);
+    EXPECT_EQ( img1_hash, sitk::Hash( img1));
+    EXPECT_EQ( "value", img1.GetMetaData("test"));
 }
 
 

--- a/Wrapping/Python/sitkImage.i
+++ b/Wrapping/Python/sitkImage.i
@@ -76,90 +76,96 @@
 
         Image __iadd__ ( const Image &i )
         {
-          return (*$self) += i;
+          return *$self += i;
         }
         Image __iadd__ ( double c )
         {
-          return (*$self) += c;
+          return *$self += c;
         }
         Image __isub__ ( const Image &i )
         {
-          return (*$self) -= i;
+          return *$self -= i;
         }
         Image __isub__ ( double c )
         {
-          return (*$self) -= c;
+          return *$self -= c;
         }
         Image __imul__ ( const Image &i )
         {
-          return (*$self) *=  i;
+          return *$self *=  i;
         }
         Image __imul__ ( double c )
         {
-          return (*$self) *=  c;
+          return *$self *=  c;
         }
         Image __imod__ ( const Image &i )
         {
-          return (*$self) %=  i;
+          return *$self %=  i;
         }
         Image __imod__ ( int c )
         {
-          return (*$self) %=  c;
+          return *$self %=  c;
         }
 
 
 
         Image __ifloordiv__ ( const Image &i )
         {
-          return ((*$self) = DivideFloor(std::move(*$self), i));
+          DivideFloor($self->ProxyForInPlaceOperation(), i);
+          return *$self;
         }
         Image __ifloordiv__ ( double c )
         {
-          return ((*$self) = DivideFloor(std::move(*$self), c));
+          DivideFloor($self->ProxyForInPlaceOperation(), c);
+          return *$self;
         }
         Image __itruediv__ ( const Image &i )
         {
-          return ((*$self) = DivideReal(std::move(*$self), i));
+          DivideReal($self->ProxyForInPlaceOperation(), i);
+          return *$self;
         }
         Image __itruediv__ ( double c )
         {
-          return ((*$self) = DivideReal(std::move(*$self), c));
+          DivideReal($self->ProxyForInPlaceOperation(), c);
+          return *$self;
         }
 
 
         Image __ipow__ ( const Image &i )
         {
-          return ((*$self) = Pow(std::move(*$self), i));
+          Pow($self->ProxyForInPlaceOperation(), i);
+          return *$self;
         }
         Image __ipow__ ( double c)
         {
-          return ((*$self) = Pow(std::move(*$self), c));
+          Pow($self->ProxyForInPlaceOperation(), c);
+          return *$self;
         }
 
 
         Image __ior__ ( const Image &i )
         {
-          return (*$self) |=  i;
+          return *$self |=  i;
         }
         Image __ior__ ( int c )
         {
-          return (*$self) |=  c;
+          return *$self |=  c;
         }
         Image __ixor__ ( const Image &i )
         {
-          return (*$self) ^=  i;
+          return *$self ^=  i;
         }
         Image __ixor__ ( int c )
         {
-          return (*$self) ^=  c;
+          return *$self ^=  c;
         }
         Image __iand__ ( const Image &i )
         {
-          return (*$self) &=  i;
+          return *$self &=  i;
         }
         Image __iand__ ( int c )
         {
-          return (*$self) &=  c;
+          return *$self &=  c;
         }
         // A wrapper for performing the paste operation in place
         Image __ipaste(const Image & sourceImage,
@@ -173,7 +179,8 @@
         paster.SetSourceIndex(std::move(sourceIndex));
         paster.SetDestinationIndex(std::move(destinationIndex));
         paster.SetDestinationSkipAxes(std::move(destinationSkipAxes));
-        return (*$self) = paster.Execute(std::move(*$self), sourceImage);
+        paster.Execute($self->ProxyForInPlaceOperation(), sourceImage);
+        return *$self;
         }
         Image __ipaste(double constant,
                    std::vector< unsigned int > sourceSize,
@@ -186,18 +193,21 @@
         paster.SetSourceIndex(std::move(sourceIndex));
         paster.SetDestinationIndex(std::move(destinationIndex));
         paster.SetDestinationSkipAxes(std::move(destinationSkipAxes));
-        return (*$self) = paster.Execute(std::move(*$self), constant);
+        paster.Execute($self->ProxyForInPlaceOperation(), constant);
+        return *$self;
         }
         Image __imasked_assign(const Image &mask,  const Image &assign)
         {
           itk::simple::MaskedAssignImageFilter ma;
-          return (*$self) = ma.Execute(std::move(*$self), mask, assign);
+          ma.Execute($self->ProxyForInPlaceOperation(), mask, assign);
+          return *$self;
         }
         Image __imasked_assign(const Image &mask,  double constant)
         {
           itk::simple::MaskedAssignImageFilter ma;
           ma.SetAssignConstant(constant);
-          return (*$self) = ma.Execute(std::move(*$self), mask);
+          ma.Execute($self->ProxyForInPlaceOperation(), mask);
+          return *$self;
         }
 
 


### PR DESCRIPTION
A proxy image is an image which holds a reference to the original image's buffer. This solves two problems:
 - If an exception occours then the original image will not be cleared, as it was not the image move.
 - The meta-data dictionary is preserved. Although the expese of copying the dictionary is incurred.

Addresses #1911
This is also a follow up to #1726
