### PR TITLE
Use unique_ptr for Pimple Transform

### DIFF
--- a/Code/Common/include/sitkAffineTransform.h
+++ b/Code/Common/include/sitkAffineTransform.h
@@ -80,7 +80,7 @@ public:
 
 protected:
 
-  void SetPimpleTransform( PimpleTransformBase *pimpleTransform ) override;
+  void SetPimpleTransform(std::unique_ptr<PimpleTransformBase> && pimpleTransform ) override;
 
 private:
 

--- a/Code/Common/include/sitkBSplineTransform.h
+++ b/Code/Common/include/sitkBSplineTransform.h
@@ -90,7 +90,7 @@ public:
 
 protected:
 
-  void SetPimpleTransform( PimpleTransformBase *pimpleTransform ) override;
+  void SetPimpleTransform(std::unique_ptr<PimpleTransformBase> && pimpleTransform ) override;
 
 private:
 

--- a/Code/Common/include/sitkComposeScaleSkewVersor3DTransform.h
+++ b/Code/Common/include/sitkComposeScaleSkewVersor3DTransform.h
@@ -96,7 +96,7 @@ public:
 
 protected:
 
-  void SetPimpleTransform( PimpleTransformBase *pimpleTransform ) override;
+  void SetPimpleTransform(std::unique_ptr<PimpleTransformBase> && pimpleTransform ) override;
 
 private:
 

--- a/Code/Common/include/sitkCompositeTransform.h
+++ b/Code/Common/include/sitkCompositeTransform.h
@@ -149,7 +149,7 @@ public:
 
 protected:
 
-  void SetPimpleTransform( PimpleTransformBase * ) override;
+  void SetPimpleTransform(std::unique_ptr<PimpleTransformBase> &&) override;
 
 private:
 

--- a/Code/Common/include/sitkDisplacementFieldTransform.h
+++ b/Code/Common/include/sitkDisplacementFieldTransform.h
@@ -108,7 +108,7 @@ public:
 
 protected:
 
-  void SetPimpleTransform( PimpleTransformBase *pimpleTransform ) override;
+  void SetPimpleTransform(std::unique_ptr<PimpleTransformBase> && pimpleTransform ) override;
 
 private:
 

--- a/Code/Common/include/sitkEuler2DTransform.h
+++ b/Code/Common/include/sitkEuler2DTransform.h
@@ -74,7 +74,7 @@ public:
 
 protected:
 
-  void SetPimpleTransform( PimpleTransformBase *pimpleTransform ) override;
+  void SetPimpleTransform(std::unique_ptr<PimpleTransformBase> && pimpleTransform ) override;
 
 private:
 

--- a/Code/Common/include/sitkEuler3DTransform.h
+++ b/Code/Common/include/sitkEuler3DTransform.h
@@ -85,7 +85,7 @@ SITK_RETURN_SELF_TYPE_HEADER ComputeZYXOff () {return this->SetComputeZYX(false)
 
 protected:
 
-void SetPimpleTransform( PimpleTransformBase *pimpleTransform ) override;
+void SetPimpleTransform(std::unique_ptr<PimpleTransformBase> && pimpleTransform ) override;
 
 private:
 

--- a/Code/Common/include/sitkScaleSkewVersor3DTransform.h
+++ b/Code/Common/include/sitkScaleSkewVersor3DTransform.h
@@ -91,7 +91,7 @@ public:
 
 protected:
 
-  void SetPimpleTransform( PimpleTransformBase *pimpleTransform ) override;
+  void SetPimpleTransform(std::unique_ptr<PimpleTransformBase> && pimpleTransform ) override;
 
 private:
 

--- a/Code/Common/include/sitkScaleTransform.h
+++ b/Code/Common/include/sitkScaleTransform.h
@@ -66,7 +66,7 @@ public:
 
 protected:
 
-  void SetPimpleTransform( PimpleTransformBase *pimpleTransform ) override;
+  void SetPimpleTransform(std::unique_ptr<PimpleTransformBase> && pimpleTransform ) override;
 
 private:
 

--- a/Code/Common/include/sitkScaleVersor3DTransform.h
+++ b/Code/Common/include/sitkScaleVersor3DTransform.h
@@ -87,7 +87,7 @@ public:
 
 protected:
 
-  void SetPimpleTransform( PimpleTransformBase *pimpleTransform ) override;
+  void SetPimpleTransform(std::unique_ptr<PimpleTransformBase> && pimpleTransform ) override;
 
 private:
 

--- a/Code/Common/include/sitkSimilarity2DTransform.h
+++ b/Code/Common/include/sitkSimilarity2DTransform.h
@@ -78,7 +78,7 @@ public:
 
 protected:
 
-  void SetPimpleTransform( PimpleTransformBase *pimpleTransform ) override;
+  void SetPimpleTransform(std::unique_ptr<PimpleTransformBase> && pimpleTransform ) override;
 
 private:
 

--- a/Code/Common/include/sitkSimilarity3DTransform.h
+++ b/Code/Common/include/sitkSimilarity3DTransform.h
@@ -85,7 +85,7 @@ SITK_RETURN_SELF_TYPE_HEADER SetMatrix(const std::vector<double> &matrix, double
 
 protected:
 
-void SetPimpleTransform( PimpleTransformBase *pimpleTransform ) override;
+void SetPimpleTransform(std::unique_ptr<PimpleTransformBase> && pimpleTransform ) override;
 
 private:
 

--- a/Code/Common/include/sitkTransform.h
+++ b/Code/Common/include/sitkTransform.h
@@ -255,9 +255,9 @@ protected:
   explicit Transform( PimpleTransformBase *pimpleTransform );
 
   // this method is called to set the private pimpleTransform outside
-  // of the constructor, derived classes can override it of update the
+  // the constructor, derived classes can override it of update the
   // state.
-  virtual void SetPimpleTransform( PimpleTransformBase *pimpleTransform );
+  virtual void SetPimpleTransform(std::unique_ptr<PimpleTransformBase> && pimpleTransform );
 
 private:
 

--- a/Code/Common/include/sitkTranslationTransform.h
+++ b/Code/Common/include/sitkTranslationTransform.h
@@ -58,7 +58,7 @@ std::vector<double> GetOffset( ) const;
 
 protected:
 
-void SetPimpleTransform( PimpleTransformBase *pimpleTransform ) override;
+void SetPimpleTransform(std::unique_ptr<PimpleTransformBase> && pimpleTransform ) override;
 
 private:
 

--- a/Code/Common/include/sitkVersorRigid3DTransform.h
+++ b/Code/Common/include/sitkVersorRigid3DTransform.h
@@ -82,7 +82,7 @@ public:
 
 protected:
 
-  void SetPimpleTransform( PimpleTransformBase *pimpleTransform ) override;
+  void SetPimpleTransform(std::unique_ptr<PimpleTransformBase> && pimpleTransform ) override;
 
 private:
 

--- a/Code/Common/include/sitkVersorTransform.h
+++ b/Code/Common/include/sitkVersorTransform.h
@@ -78,7 +78,7 @@ public:
 
 protected:
 
-  void SetPimpleTransform( PimpleTransformBase *pimpleTransform ) override;
+  void SetPimpleTransform(std::unique_ptr<PimpleTransformBase> && pimpleTransform ) override;
 
 private:
 

--- a/Code/Common/src/sitkAffineTransform.cxx
+++ b/Code/Common/src/sitkAffineTransform.cxx
@@ -139,9 +139,9 @@ AffineTransform::Self &AffineTransform::Rotate(int axis1, int axis2, double angl
   return *this;
 }
 
-void AffineTransform::SetPimpleTransform( PimpleTransformBase *pimpleTransform )
+void AffineTransform::SetPimpleTransform(std::unique_ptr<PimpleTransformBase> && pimpleTransform )
 {
-  Superclass::SetPimpleTransform(pimpleTransform);
+  Superclass::SetPimpleTransform(std::move(pimpleTransform));
   Self::InternalInitialization(this->GetITKBase());
 }
 

--- a/Code/Common/src/sitkBSplineTransform.cxx
+++ b/Code/Common/src/sitkBSplineTransform.cxx
@@ -207,9 +207,9 @@ unsigned int BSplineTransform::GetOrder() const
 }
 
 
-void BSplineTransform::SetPimpleTransform( PimpleTransformBase *pimpleTransform )
+void BSplineTransform::SetPimpleTransform(std::unique_ptr<PimpleTransformBase> && pimpleTransform )
 {
-  Superclass::SetPimpleTransform(pimpleTransform);
+  Superclass::SetPimpleTransform(std::move(pimpleTransform));
   Self::InternalInitialization(this->GetITKBase());
 }
 

--- a/Code/Common/src/sitkComposeScaleSkewVersor3DTransform.cxx
+++ b/Code/Common/src/sitkComposeScaleSkewVersor3DTransform.cxx
@@ -167,9 +167,9 @@ std::vector<double> ComposeScaleSkewVersor3DTransform::GetMatrix( ) const
   return this->m_pfGetMatrix();
 }
 
-void ComposeScaleSkewVersor3DTransform::SetPimpleTransform( PimpleTransformBase *pimpleTransform )
+void ComposeScaleSkewVersor3DTransform::SetPimpleTransform(std::unique_ptr<PimpleTransformBase> && pimpleTransform )
 {
-  Superclass::SetPimpleTransform(pimpleTransform);
+  Superclass::SetPimpleTransform(std::move(pimpleTransform));
   Self::InternalInitialization(this->GetITKBase());
 }
 

--- a/Code/Common/src/sitkCompositeTransform.cxx
+++ b/Code/Common/src/sitkCompositeTransform.cxx
@@ -66,9 +66,9 @@ CompositeTransform &CompositeTransform::operator=( const CompositeTransform &arg
   return *this;
 }
 
-void CompositeTransform::SetPimpleTransform( PimpleTransformBase *pimpleTransform )
+void CompositeTransform::SetPimpleTransform(std::unique_ptr<PimpleTransformBase> && pimpleTransform )
 {
-  Superclass::SetPimpleTransform(pimpleTransform);
+  Superclass::SetPimpleTransform(std::move(pimpleTransform));
   Self::InternalInitialization(this->GetITKBase());
 }
 
@@ -214,7 +214,7 @@ void CompositeTransform::InternalInitialization(itk::Transform<double, NDimensio
   ctx->AddTransform(tx);
 
   // Call InternalInitialization again with a CompositeTransform the second time.
-  Self::SetPimpleTransform(new PimpleTransform<CompositeTransformType >(ctx));
+  Self::SetPimpleTransform(std::make_unique<PimpleTransform<CompositeTransformType >>(ctx));
 }
 
 

--- a/Code/Common/src/sitkDisplacementFieldTransform.cxx
+++ b/Code/Common/src/sitkDisplacementFieldTransform.cxx
@@ -236,9 +236,9 @@ DisplacementFieldTransform::SetSmoothingBSplineOnUpdate( const std::vector<unsig
 }
 
 
-void DisplacementFieldTransform::SetPimpleTransform( PimpleTransformBase *pimpleTransform )
+void DisplacementFieldTransform::SetPimpleTransform(std::unique_ptr<PimpleTransformBase> && pimpleTransform )
 {
-  Superclass::SetPimpleTransform(pimpleTransform);
+  Superclass::SetPimpleTransform(std::move(pimpleTransform));
   Self::InternalInitialization(this->GetITKBase());
 }
 
@@ -363,7 +363,7 @@ void DisplacementFieldTransform::InternalSetSmoothingOff( TDisplacementFieldTran
     itkNewDisplacement->SetInterpolator( itkDisplacement->GetModifiableInterpolator() );
     itkNewDisplacement->SetInverseInterpolator( itkDisplacement->GetModifiableInverseInterpolator() );
 
-    this->SetPimpleTransform( new PimpleTransform<NewTransformType>(itkNewDisplacement));
+    this->SetPimpleTransform( std::make_unique<PimpleTransform<NewTransformType>>(itkNewDisplacement));
     }
 }
 
@@ -390,7 +390,7 @@ void DisplacementFieldTransform::InternalSetSmoothingGaussianOnUpdate( TDisplace
     itkNewDisplacement->SetInterpolator( itkDisplacement->GetModifiableInterpolator() );
     itkNewDisplacement->SetInverseInterpolator( itkDisplacement->GetModifiableInverseInterpolator() );
 
-    this->SetPimpleTransform( new PimpleTransform<NewTransformType>(itkNewDisplacement));
+    this->SetPimpleTransform( std::make_unique<PimpleTransform<NewTransformType>>(itkNewDisplacement));
     }
   else
     {
@@ -428,7 +428,7 @@ void DisplacementFieldTransform::InternalSetSmoothingBSplineOnUpdate( TDisplacem
     itkNewDisplacement->SetInterpolator( itkDisplacement->GetModifiableInterpolator() );
     itkNewDisplacement->SetInverseInterpolator( itkDisplacement->GetModifiableInverseInterpolator() );
 
-    this->SetPimpleTransform( new PimpleTransform<NewTransformType>(itkNewDisplacement));
+    this->SetPimpleTransform( std::make_unique<PimpleTransform<NewTransformType>>(itkNewDisplacement));
     }
   else
     {

--- a/Code/Common/src/sitkEuler2DTransform.cxx
+++ b/Code/Common/src/sitkEuler2DTransform.cxx
@@ -119,9 +119,9 @@ Euler2DTransform::Self &Euler2DTransform::SetMatrix(const std::vector<double> &p
   return *this;
 }
 
-void Euler2DTransform::SetPimpleTransform( PimpleTransformBase *pimpleTransform )
+void Euler2DTransform::SetPimpleTransform(std::unique_ptr<PimpleTransformBase> && pimpleTransform )
 {
-  Superclass::SetPimpleTransform(pimpleTransform);
+  Superclass::SetPimpleTransform(std::move(pimpleTransform));
   Self::InternalInitialization(this->GetITKBase());
 }
 

--- a/Code/Common/src/sitkEuler3DTransform.cxx
+++ b/Code/Common/src/sitkEuler3DTransform.cxx
@@ -140,9 +140,9 @@ Euler3DTransform::Self &Euler3DTransform::SetMatrix(const std::vector<double> &p
   return *this;
 }
 
-void Euler3DTransform::SetPimpleTransform( PimpleTransformBase *pimpleTransform )
+void Euler3DTransform::SetPimpleTransform(std::unique_ptr<PimpleTransformBase> && pimpleTransform )
 {
-  Superclass::SetPimpleTransform(pimpleTransform);
+  Superclass::SetPimpleTransform(std::move(pimpleTransform));
   Self::InternalInitialization(this->GetITKBase());
 }
 

--- a/Code/Common/src/sitkPimpleTransform.hxx
+++ b/Code/Common/src/sitkPimpleTransform.hxx
@@ -136,8 +136,8 @@ public:
     }
 
 
-  virtual PimpleTransformBase *ShallowCopy( ) const = 0;
-  virtual PimpleTransformBase *DeepCopy( ) const = 0;
+  virtual std::unique_ptr<PimpleTransformBase> ShallowCopy( ) const = 0;
+  virtual std::unique_ptr<PimpleTransformBase> DeepCopy( ) const = 0;
 
   virtual int GetReferenceCount( ) const = 0;
 
@@ -221,15 +221,14 @@ public:
   unsigned int GetOutputDimension( ) const override { return OutputDimension; }
 
 
-  PimpleTransformBase *ShallowCopy( ) const override
+  std::unique_ptr<PimpleTransformBase> ShallowCopy( ) const override
     {
-      return new Self( this->m_Transform.GetPointer() );
+      return std::make_unique<Self>( this->m_Transform.GetPointer() );
     }
 
-  PimpleTransformBase *DeepCopy( ) const override
+  std::unique_ptr<PimpleTransformBase> DeepCopy( ) const override
     {
-      PimpleTransformBase *copy( new Self( this->m_Transform->Clone() ) );
-      return copy;
+      return std::make_unique<Self>( this->m_Transform->Clone() );
     }
 
   int GetReferenceCount( ) const override

--- a/Code/Common/src/sitkScaleSkewVersor3DTransform.cxx
+++ b/Code/Common/src/sitkScaleSkewVersor3DTransform.cxx
@@ -167,9 +167,9 @@ std::vector<double> ScaleSkewVersor3DTransform::GetMatrix( ) const
   return this->m_pfGetMatrix();
 }
 
-void ScaleSkewVersor3DTransform::SetPimpleTransform( PimpleTransformBase *pimpleTransform )
+void ScaleSkewVersor3DTransform::SetPimpleTransform(std::unique_ptr<PimpleTransformBase> && pimpleTransform )
 {
-  Superclass::SetPimpleTransform(pimpleTransform);
+  Superclass::SetPimpleTransform(std::move(pimpleTransform));
   Self::InternalInitialization(this->GetITKBase());
 }
 

--- a/Code/Common/src/sitkScaleTransform.cxx
+++ b/Code/Common/src/sitkScaleTransform.cxx
@@ -88,9 +88,9 @@ std::vector<double> ScaleTransform::GetMatrix( ) const
   return this->m_pfGetMatrix();
 }
 
-void ScaleTransform::SetPimpleTransform( PimpleTransformBase *pimpleTransform )
+void ScaleTransform::SetPimpleTransform(std::unique_ptr<PimpleTransformBase> && pimpleTransform )
 {
-  Superclass::SetPimpleTransform(pimpleTransform);
+  Superclass::SetPimpleTransform(std::move(pimpleTransform));
   Self::InternalInitialization(this->GetITKBase());
 }
 

--- a/Code/Common/src/sitkScaleVersor3DTransform.cxx
+++ b/Code/Common/src/sitkScaleVersor3DTransform.cxx
@@ -151,9 +151,9 @@ std::vector<double> ScaleVersor3DTransform::GetMatrix( ) const
   return this->m_pfGetMatrix();
 }
 
-void ScaleVersor3DTransform::SetPimpleTransform( PimpleTransformBase *pimpleTransform )
+void ScaleVersor3DTransform::SetPimpleTransform(std::unique_ptr<PimpleTransformBase> && pimpleTransform )
 {
-  Superclass::SetPimpleTransform(pimpleTransform);
+  Superclass::SetPimpleTransform(std::move(pimpleTransform));
   Self::InternalInitialization(this->GetITKBase());
 }
 

--- a/Code/Common/src/sitkSimilarity2DTransform.cxx
+++ b/Code/Common/src/sitkSimilarity2DTransform.cxx
@@ -132,9 +132,9 @@ Similarity2DTransform::Self &Similarity2DTransform::SetMatrix(const std::vector<
   return *this;
 }
 
-void Similarity2DTransform::SetPimpleTransform( PimpleTransformBase *pimpleTransform )
+void Similarity2DTransform::SetPimpleTransform(std::unique_ptr<PimpleTransformBase> && pimpleTransform )
 {
-  Superclass::SetPimpleTransform(pimpleTransform);
+  Superclass::SetPimpleTransform(std::move(pimpleTransform));
   Self::InternalInitialization(this->GetITKBase());
 }
 

--- a/Code/Common/src/sitkSimilarity3DTransform.cxx
+++ b/Code/Common/src/sitkSimilarity3DTransform.cxx
@@ -157,9 +157,9 @@ Similarity3DTransform::Self &Similarity3DTransform::SetMatrix(const std::vector<
   return *this;
 }
 
-void Similarity3DTransform::SetPimpleTransform( PimpleTransformBase *pimpleTransform )
+void Similarity3DTransform::SetPimpleTransform(std::unique_ptr<PimpleTransformBase> && pimpleTransform )
 {
-  Superclass::SetPimpleTransform(pimpleTransform);
+  Superclass::SetPimpleTransform(std::move(pimpleTransform));
   Self::InternalInitialization(this->GetITKBase());
 }
 

--- a/Code/Common/src/sitkTranslationTransform.cxx
+++ b/Code/Common/src/sitkTranslationTransform.cxx
@@ -71,9 +71,9 @@ std::vector<double> TranslationTransform::GetOffset( ) const
 {
   return this->m_pfGetOffset();
 }
-void TranslationTransform::SetPimpleTransform( PimpleTransformBase *pimpleTransform )
+void TranslationTransform::SetPimpleTransform(std::unique_ptr<PimpleTransformBase> && pimpleTransform )
 {
-  Superclass::SetPimpleTransform(pimpleTransform);
+  Superclass::SetPimpleTransform(std::move(pimpleTransform));
   Self::InternalInitialization(this->GetITKBase());
 }
 

--- a/Code/Common/src/sitkVersorRigid3DTransform.cxx
+++ b/Code/Common/src/sitkVersorRigid3DTransform.cxx
@@ -141,9 +141,9 @@ VersorRigid3DTransform::Self &VersorRigid3DTransform::SetMatrix(const std::vecto
   return *this;
 }
 
-void VersorRigid3DTransform::SetPimpleTransform( PimpleTransformBase *pimpleTransform )
+void VersorRigid3DTransform::SetPimpleTransform(std::unique_ptr<PimpleTransformBase> && pimpleTransform )
 {
-  Superclass::SetPimpleTransform(pimpleTransform);
+  Superclass::SetPimpleTransform(std::move(pimpleTransform));
   Self::InternalInitialization(this->GetITKBase());
 }
 

--- a/Code/Common/src/sitkVersorTransform.cxx
+++ b/Code/Common/src/sitkVersorTransform.cxx
@@ -119,9 +119,9 @@ VersorTransform::Self &VersorTransform::SetMatrix(const std::vector<double> &par
   return *this;
 }
 
-void VersorTransform::SetPimpleTransform( PimpleTransformBase *pimpleTransform )
+void VersorTransform::SetPimpleTransform(std::unique_ptr<PimpleTransformBase> && pimpleTransform )
 {
-  Superclass::SetPimpleTransform(pimpleTransform);
+  Superclass::SetPimpleTransform(std::move(pimpleTransform));
   Self::InternalInitialization(this->GetITKBase());
 }
 


### PR DESCRIPTION
Remove raw pointer usage for the pimple transform with unique_ptr which enforces the logic of ownership to the heap allocated object.