### PR TITLE
Batch build timeout

### DIFF
--- a/.github/workflows/BatchBuild.yml
+++ b/.github/workflows/BatchBuild.yml
@@ -25,10 +25,10 @@ jobs:
       max-parallel: 4
       matrix:
         include:
-          - os: windows-2019
+          - os: windows-2022
             cmake-build-type: "MinSizeRel"
-            cmake-generator: "Visual Studio 16 2019"
-            cmake-generator-toolset: v141,host=x64
+            cmake-generator: "Visual Studio 17 2022"
+            cmake-generator-toolset: v143,host=x64
             cmake-generator-platform: x64
             ctest-cache: |
               SimpleITK_USE_ELASTIX:BOOL=ON


### PR DESCRIPTION
Change windows image and visual studio compiler to address a build time out/disk space issue in a batch build.