### PR TITLE
Adding Image::ToVector and Image::ToScalar

### DIFF
--- a/Code/Common/include/sitkImage.h
+++ b/Code/Common/include/sitkImage.h
@@ -371,6 +371,38 @@ namespace simple
 
     std::string ToString( ) const;
 
+    /** \brief Convert the first dimension to the components for image with vector pixel type.
+     *
+     * This method will convert a scalar image to a vector image with
+     * the number of components equal to the size of the first
+     * dimension. If the image is already a vector image then the
+     * image is returned.
+     *
+     * An exception is thrown if the image is 2D or if the pixel type is a label or complex pixel type.
+     *
+     * \param inPlace If true then the image is made unique and converted in place updating this image,
+     * otherwise a copy of the image is made and returned.
+     *
+     * \sa ToScalarImage
+     */
+    Image ToVectorImage(bool inPlace = true);
+
+    /** \brief Convert a image of vector pixel type to a scalar image with N+1 dimensions.
+     *
+     * This method will convert a vector image to a scalar image with
+     * the size of the first dimension equal to the number of
+     * components. If the image is already a scalar image then the
+     * image is returned.
+     *
+     * An exception is thrown if the image is has SITK_MAX_DIMENSION dimensions or if the pixel type is a label or complex pixel type.
+     *
+     * \param inPlace If true then the image is made unique and converted in place updating this image,
+     * otherwise a copy of the image is made and returned.
+     *
+     * \sa ToVectorImage
+     */
+    Image ToScalarImage(bool inPlace = true);
+
     /** \brief Get the value of a pixel
      *
      * Returns the value of a pixel for the given index. The index
@@ -549,6 +581,26 @@ namespace simple
     AllocateInternal ( const std::vector<unsigned int > &size, unsigned int numberOfComponents );
     /**@}*/
 
+    /** \brief Internal methods for converting images between vectors and scalars
+     *  @{
+     */
+    template<class TImageType>
+    std::enable_if_t<IsVector<TImageType>::Value, Image>
+    ToVectorInternal(bool inPlace);
+
+    template<class TImageType>
+    std::enable_if_t<IsBasic<TImageType>::Value, Image>
+    ToVectorInternal(bool inPlace);
+
+    template<class TImageType>
+    std::enable_if_t<IsVector<TImageType>::Value, Image>
+    ToScalarInternal(bool inPlace);
+
+    template<class TImageType>
+    std::enable_if_t<IsBasic<TImageType>::Value, Image>
+    ToScalarInternal(bool inPlace);
+    /**@}*/
+
   private:
 
    /** Method called by certain constructors to convert ITK images
@@ -571,6 +623,8 @@ namespace simple
 
     friend struct DispatchedInternalInitialiationAddressor;
     friend struct AllocateMemberFunctionAddressor;
+    friend struct ToVectorAddressor;
+    friend struct ToScalarAddressor;
 
 
     std::unique_ptr<PimpleImageBase> m_PimpleImage;

--- a/Code/Common/include/sitkImage.h
+++ b/Code/Common/include/sitkImage.h
@@ -378,6 +378,9 @@ namespace simple
      * dimension. If the image is already a vector image then the
      * image is returned.
      *
+     * The components of the direction cosine matrix for the first dimension must be the identity matrix, or else an
+     * exception is thrown.
+     *
      * An exception is thrown if the image is 2D or if the pixel type is a label or complex pixel type.
      *
      * \param inPlace If true then the image is made unique and converted in place updating this image,
@@ -394,7 +397,11 @@ namespace simple
      * components. If the image is already a scalar image then the
      * image is returned.
      *
-     * An exception is thrown if the image is has SITK_MAX_DIMENSION dimensions or if the pixel type is a label or complex pixel type.
+     * For the additional dimension the origin is set to zero, the spacing to one, and the new components of the
+     * direction cosine to the identity matrix.
+     *
+     * An exception is thrown if the image is has SITK_MAX_DIMENSION dimensions or if the pixel type is a label or
+     * complex pixel type.
      *
      * \param inPlace If true then the image is made unique and converted in place updating this image,
      * otherwise a copy of the image is made and returned.

--- a/Code/Common/include/sitkImageConvert.h
+++ b/Code/Common/include/sitkImageConvert.h
@@ -31,14 +31,27 @@ namespace simple
 {
 
 
-/** \brief A utility method to help convert between itk image types efficiently.
+/** \brief Utility methods to  convert between itk image types efficiently by
+ * sharing the buffer between the input and output.
  *
+ * @{
  */
 template< typename TPixelType, unsigned int ImageDimension >
 SITKCommon_HIDDEN
 typename itk::Image< itk::Vector< TPixelType, ImageDimension >, ImageDimension>::Pointer
 GetImageFromVectorImage( itk::VectorImage< TPixelType, ImageDimension > *img, bool transferOwnership = false );
 
+
+template< typename TPixelType, unsigned int ImageDimension >
+SITKCommon_HIDDEN
+typename itk::Image< TPixelType, ImageDimension+1>::Pointer
+GetScalarImageFromVectorImage( itk::VectorImage< TPixelType, ImageDimension > *img);
+
+// method to convert a scalar image to a VectorImage changing the first dimension to the vector components
+template< typename TPixelType, unsigned int ImageDimension >
+SITKCommon_HIDDEN
+typename itk::VectorImage< TPixelType, ImageDimension-1>::Pointer
+GetVectorImageFromScalarImage( itk::Image< TPixelType, ImageDimension > *img);
 
 template< class TPixelType, unsigned int NImageDimension, unsigned int NLength >
 SITKCommon_HIDDEN
@@ -58,8 +71,7 @@ typename itk::VectorImage<
     int64_t,
     int32_t>::type, NImageDimension >::Pointer
 GetVectorImageFromImage( itk::Image< itk::Offset< NLength >, NImageDimension> *img, bool transferOwnership = false );
-
-
+/**@}*/
 
 }
 }

--- a/Code/Common/src/sitkImage.cxx
+++ b/Code/Common/src/sitkImage.cxx
@@ -222,6 +222,7 @@ namespace itk
       return this->m_PimpleImage->ToString();
     }
 
+
     std::vector< unsigned int > Image::GetSize( ) const
     {
       assert( m_PimpleImage );

--- a/Code/Common/src/sitkImage.hxx
+++ b/Code/Common/src/sitkImage.hxx
@@ -135,6 +135,7 @@ namespace itk
   std::enable_if_t<IsBasic<TImageType>::Value, Image>
   Image::ToVectorInternal(bool inPlace)
   {
+    static_assert(TImageType::ImageDimension > 2, "Image dimension must be greater than 2");
 
     typename TImageType::Pointer itkImage;
 
@@ -152,6 +153,20 @@ namespace itk
     if (itkImage.GetPointer() == nullptr)
     {
       sitkExceptionMacro(<< "Unexpected template dispatch error");
+    }
+
+
+    auto direction = itkImage->GetDirection();
+    for (unsigned int i = 1; i < TImageType::ImageDimension; ++i)
+    {
+      if (direction[i][0] != 0.0 || direction[0][i] != 0.0)
+      {
+        sitkExceptionMacro(<< "Cannot convert image with non-identity direction in first dimension to a vector image");
+      }
+    }
+    if (direction[0][0] != 1.0)
+    {
+      sitkExceptionMacro(<< "Cannot convert image with non-identity direction in first dimension to a vector image");
     }
 
     auto itkVectorImage = GetVectorImageFromScalarImage(itkImage.GetPointer());

--- a/Code/Common/src/sitkImage.hxx
+++ b/Code/Common/src/sitkImage.hxx
@@ -28,6 +28,8 @@
 #include "sitkExceptionObject.h"
 #include "sitkPimpleImageBase.hxx"
 #include "sitkPixelIDTypeLists.h"
+#include "sitkImageConvert.hxx"
+
 
 
 namespace itk
@@ -122,7 +124,104 @@ namespace itk
     m_PimpleImage.reset( new PimpleImage<TImageType>( image ) );
   }
 
+  template <typename TImageType>
+  std::enable_if_t<IsVector<TImageType>::Value, Image>
+  Image::ToVectorInternal(bool)
+  {
+    return *this;
   }
-}
+
+  template <typename TImageType>
+  std::enable_if_t<IsBasic<TImageType>::Value, Image>
+  Image::ToVectorInternal(bool inPlace)
+  {
+
+    typename TImageType::Pointer itkImage;
+
+    if (inPlace)
+    {
+      this->MakeUnique();
+      itkImage = dynamic_cast<TImageType *>(this->m_PimpleImage->GetDataBase());
+    }
+    else
+    {
+      auto copy = this->m_PimpleImage->DeepCopy();
+      itkImage = dynamic_cast<TImageType *>(copy->GetDataBase());
+    }
+
+    if (itkImage.GetPointer() == nullptr)
+    {
+      sitkExceptionMacro(<< "Unexpected template dispatch error");
+    }
+
+    auto itkVectorImage = GetVectorImageFromScalarImage(itkImage.GetPointer());
+
+    itkImage = nullptr;
+    using VectorImageType = typename decltype(itkVectorImage)::ObjectType;
+
+    if (inPlace)
+    {
+      // The pimpleImage does not allow construction when the Image's PixelContainer has more than one reference. So
+      // The pre-existing image must be destroyed before the new one is created.
+      this->m_PimpleImage.reset();
+      this->m_PimpleImage = std::make_unique<PimpleImage<VectorImageType>>(itkVectorImage);
+      return *this;
+    }
+    else
+    {
+      return Image(std::make_unique<PimpleImage<VectorImageType>>(itkVectorImage));
+    }
+  }
+
+
+  template <typename TImageType>
+  std::enable_if_t<IsBasic<TImageType>::Value, Image>
+  Image::ToScalarInternal(bool)
+  {
+    return *this;
+  }
+
+  template <typename TImageType>
+  std::enable_if_t<IsVector<TImageType>::Value, Image>
+  Image::ToScalarInternal(bool inPlace)
+  {
+
+    typename TImageType::Pointer itkImage;
+
+    if (inPlace)
+    {
+      this->MakeUnique();
+      itkImage = dynamic_cast<TImageType *>(this->m_PimpleImage->GetDataBase());
+    }
+    else
+    {
+      auto copy = this->m_PimpleImage->DeepCopy();
+      itkImage = dynamic_cast<TImageType *>(copy->GetDataBase());
+    }
+
+    if (itkImage.GetPointer() == nullptr)
+    {
+      sitkExceptionMacro(<< "Unexpected template dispatch error");
+    }
+
+    auto itkScalarImage = GetScalarImageFromVectorImage(itkImage.GetPointer());
+    itkImage = nullptr;
+    using ScalarImageType = typename decltype(itkScalarImage)::ObjectType;
+
+    if (inPlace)
+    {
+      this->m_PimpleImage.reset();
+      this->m_PimpleImage = std::make_unique<PimpleImage<ScalarImageType>>(itkScalarImage);
+      return *this;
+    }
+    else
+    {
+      return Image(std::make_unique<PimpleImage<ScalarImageType>>(itkScalarImage));
+    }
+  }
+
+
+  } // namespace simple
+} // namespace itk
 
 #endif // sitkImage_h

--- a/Code/Common/src/sitkPimpleImageBase.hxx
+++ b/Code/Common/src/sitkPimpleImageBase.hxx
@@ -22,6 +22,7 @@
 #include "sitkMemberFunctionFactory.h"
 #include "sitkConditional.h"
 #include "sitkCreateInterpolator.hxx"
+#include "sitkImageConvert.hxx"
 
 #include "itkImage.h"
 #include "itkVectorImage.h"
@@ -152,7 +153,6 @@ namespace itk
 
     itk::DataObject* GetDataBase( ) override { return this->m_Image.GetPointer(); }
     const itk::DataObject* GetDataBase( ) const override { return this->m_Image.GetPointer(); }
-
 
     PixelIDValueEnum GetPixelID() const noexcept override
       {
@@ -326,7 +326,8 @@ namespace itk
         return out.str();
       }
 
-    int GetReferenceCountOfImage() const override
+      int
+      GetReferenceCountOfImage() const override
       {
         return this->m_Image->GetReferenceCount();
       }

--- a/Testing/Unit/sitkImageTests.cxx
+++ b/Testing/Unit/sitkImageTests.cxx
@@ -2025,6 +2025,9 @@ TEST_F(Image, ToVector)
     sitk::Image img = sitk::Image(3, 10, 10, pixelType);
     img.SetSpacing({ 1.0, 2.0, 3.0 });
     img.SetOrigin({ 1.0, 2.0, 3.0 });
+    img.SetDirection({1.0, 0.0, 0.0,
+      0.0, 0.0, 1.0,
+      0.0, 1.0, 0.0 });
 
     const std::string hash = sitk::Hash(img);
 
@@ -2034,7 +2037,7 @@ TEST_F(Image, ToVector)
     EXPECT_EQ(converted.GetNumberOfComponentsPerPixel(), 3);
     EXPECT_EQ(converted.GetSpacing(), std::vector<double>({ 2.0, 3.0 }));
     EXPECT_EQ(converted.GetOrigin(), std::vector<double>({ 2.0, 3.0 }));
-    EXPECT_EQ(converted.GetDirection(), std::vector<double>({ 1.0, 0.0, 0.0, 1.0 }));
+    EXPECT_EQ(converted.GetDirection(), std::vector<double>({ 0.0, 1.0, 1.0, 0.0 }));
     EXPECT_TRUE(converted.IsUnique());
     EXPECT_TRUE(img.IsUnique());
 
@@ -2046,7 +2049,7 @@ TEST_F(Image, ToVector)
     EXPECT_EQ(img.GetNumberOfComponentsPerPixel(), 3);
     EXPECT_EQ(img.GetSpacing(), std::vector<double>({ 2.0, 3.0 }));
     EXPECT_EQ(img.GetOrigin(), std::vector<double>({ 2.0, 3.0 }));
-    EXPECT_EQ(img.GetDirection(), std::vector<double>({ 1.0, 0.0, 0.0, 1.0 }));
+    EXPECT_EQ(img.GetDirection(), std::vector<double>({ 0.0, 1.0, 1.0, 0.0 }));
     EXPECT_TRUE(img.IsUnique());
 
     img = sitk::Image( std::vector<unsigned int>(SITK_MAX_DIMENSION, 5), pixelType);
@@ -2054,6 +2057,23 @@ TEST_F(Image, ToVector)
 
     img = sitk::Image( std::vector<unsigned int>(2, 5), pixelType);
     EXPECT_ANY_THROW(img.ToVectorImage(false));
+
+    sitk::Image img2 = sitk::Image( 5, 16, 16, pixelType);
+
+    img2.SetDirection({-1.0, 0.0, 0.0,
+      0.0, 0.0, 1.0,
+      0.0, 1.0, 0.0 });
+    EXPECT_ANY_THROW(img2.ToVectorImage(false));
+
+    img2.SetDirection({0.0, 1.0, 0.0,
+      0.0, 0.0, 1.0,
+      1.0, 0.0, 0.0 });
+    EXPECT_ANY_THROW(img2.ToVectorImage(false));
+
+    img2.SetDirection({0.0, 0.0, 1.0,
+      1.0, 0.0, 0.0,
+      0.0, 1.0, 0.0 });
+    EXPECT_ANY_THROW(img2.ToVectorImage(false));
 
   }
 

--- a/Testing/Unit/sitkImageTests.cxx
+++ b/Testing/Unit/sitkImageTests.cxx
@@ -123,6 +123,21 @@ public:
   std::vector<double> directionI2D{1.0, 0.0, 0.0, 1.0 };
   std::vector<double> directionI3D{1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0 };
 
+
+  const std::list<sitk::PixelIDValueEnum> labelTypes = {
+    sitk::sitkLabelUInt8, sitk::sitkLabelUInt16, sitk::sitkLabelUInt32, sitk::sitkLabelUInt64
+  };
+  const std::list<sitk::PixelIDValueEnum> basicTypes = { sitk::sitkUInt8,  sitk::sitkUInt16, sitk::sitkUInt32,
+                                                        sitk::sitkUInt64, sitk::sitkInt8,   sitk::sitkInt16,
+                                                        sitk::sitkInt32,  sitk::sitkInt64,  sitk::sitkFloat32,
+                                                        sitk::sitkFloat64 };
+  const std::list<sitk::PixelIDValueEnum> complexTypes = { sitk::sitkComplexFloat32, sitk::sitkComplexFloat64 };
+  const std::list<sitk::PixelIDValueEnum> vectorTypes = { sitk::sitkVectorUInt8,   sitk::sitkVectorUInt16,
+                                                          sitk::sitkVectorUInt32,  sitk::sitkVectorUInt64,
+                                                          sitk::sitkVectorInt8,    sitk::sitkVectorInt16,
+                                                          sitk::sitkVectorInt32,   sitk::sitkVectorInt64,
+                                                          sitk::sitkVectorFloat32, sitk::sitkVectorFloat64 };
+
 };
 
 
@@ -433,9 +448,6 @@ TEST_F(Image,Properties) {
   ASSERT_ANY_THROW( shortImage->SetDirection( std::vector<double>( adir, adir + 4 ) ) );
   ASSERT_ANY_THROW( shortImage->SetDirection( std::vector<double>( adir, adir + 8 ) ) );
 }
-
-namespace sitk = itk::simple;
-
 
 TEST_F(Image, CopyInformation)
 {
@@ -2003,5 +2015,186 @@ TEST_F(Image, Evaluate_boundary) {
 
     EXPECT_ANY_THROW(img.EvaluateAtPhysicalPoint({-5.1, 0}));
     EXPECT_ANY_THROW(img.EvaluateAtPhysicalPoint({95.01, 9.5}));
+  }
+}
+
+TEST_F(Image, ToVector)
+{
+  for (auto pixelType : basicTypes)
+  {
+    sitk::Image img = sitk::Image(3, 10, 10, pixelType);
+    img.SetSpacing({ 1.0, 2.0, 3.0 });
+    img.SetOrigin({ 1.0, 2.0, 3.0 });
+
+    const std::string hash = sitk::Hash(img);
+
+    sitk::Image converted = img.ToVectorImage(false);
+    EXPECT_EQ(converted.GetDimension(), 2u);
+    EXPECT_EQ(converted.GetSize(), std::vector<unsigned int>({ 10, 10 }));
+    EXPECT_EQ(converted.GetNumberOfComponentsPerPixel(), 3);
+    EXPECT_EQ(converted.GetSpacing(), std::vector<double>({ 2.0, 3.0 }));
+    EXPECT_EQ(converted.GetOrigin(), std::vector<double>({ 2.0, 3.0 }));
+    EXPECT_EQ(converted.GetDirection(), std::vector<double>({ 1.0, 0.0, 0.0, 1.0 }));
+    EXPECT_TRUE(converted.IsUnique());
+    EXPECT_TRUE(img.IsUnique());
+
+    EXPECT_EQ(sitk::Hash(converted), hash);
+
+    img.ToVectorImage(true);
+    EXPECT_EQ(img.GetDimension(), 2u);
+    EXPECT_EQ(img.GetSize(), std::vector<unsigned int>({ 10, 10 }));
+    EXPECT_EQ(img.GetNumberOfComponentsPerPixel(), 3);
+    EXPECT_EQ(img.GetSpacing(), std::vector<double>({ 2.0, 3.0 }));
+    EXPECT_EQ(img.GetOrigin(), std::vector<double>({ 2.0, 3.0 }));
+    EXPECT_EQ(img.GetDirection(), std::vector<double>({ 1.0, 0.0, 0.0, 1.0 }));
+    EXPECT_TRUE(img.IsUnique());
+
+    img = sitk::Image( std::vector<unsigned int>(SITK_MAX_DIMENSION, 5), pixelType);
+    EXPECT_NO_THROW(img.ToVectorImage(false));
+
+    img = sitk::Image( std::vector<unsigned int>(2, 5), pixelType);
+    EXPECT_ANY_THROW(img.ToVectorImage(false));
+
+  }
+
+  for (auto pixelType : vectorTypes)
+  {
+    sitk::Image img = sitk::Image({ 10u, 10u }, pixelType, 3);
+
+    sitk::Image converted;
+    EXPECT_NO_THROW(converted = img.ToVectorImage(false));
+    EXPECT_EQ(converted.GetDimension(), 2u);
+    EXPECT_EQ(converted.GetSize(), std::vector<unsigned int>({ 10, 10 }));
+    EXPECT_EQ(converted.GetNumberOfComponentsPerPixel(), 3);
+    EXPECT_EQ(converted.GetPixelID(), pixelType);
+    EXPECT_FALSE(converted.IsUnique());
+    EXPECT_FALSE(img.IsUnique());
+
+    EXPECT_NO_THROW(converted = img.ToVectorImage(true));
+    EXPECT_EQ(img.GetDimension(), 2u);
+    EXPECT_EQ(img.GetSize(), std::vector<unsigned int>({ 10, 10 }));
+    EXPECT_EQ(img.GetNumberOfComponentsPerPixel(), 3);
+    EXPECT_FALSE(img.IsUnique());
+    EXPECT_FALSE(img.IsUnique());
+
+    img = sitk::Image(std::vector<unsigned int>(SITK_MAX_DIMENSION, 5u), pixelType, 3);
+
+
+    EXPECT_NO_THROW(converted = img.ToVectorImage(false));
+    EXPECT_EQ(converted.GetDimension(), SITK_MAX_DIMENSION);
+    EXPECT_EQ(converted.GetNumberOfComponentsPerPixel(), 3);
+
+    EXPECT_NO_THROW(converted = img.ToVectorImage(true));
+
+  }
+
+  for (auto pixelType : labelTypes)
+  {
+
+    for (unsigned int d = 2; d <= SITK_MAX_DIMENSION; ++d)
+    {
+      sitk::Image img = sitk::Image(std::vector<unsigned int>(d, 5), pixelType);
+
+      EXPECT_ANY_THROW(img.ToVectorImage(false));
+      EXPECT_ANY_THROW(img.ToVectorImage(true));
+    }
+  }
+
+  for (auto pixelType : complexTypes)
+  {
+    for (unsigned int d = 2; d <= SITK_MAX_DIMENSION; ++d)
+    {
+      sitk::Image img = sitk::Image(std::vector<unsigned int>(d, 5), pixelType);
+
+      EXPECT_ANY_THROW(img.ToVectorImage(false));
+      EXPECT_ANY_THROW(img.ToVectorImage(true));
+    }
+  }
+}
+
+TEST_F(Image, ToScalar)
+{
+  for( auto pixelType: vectorTypes)
+  {
+    sitk::Image img({10u, 10u}, pixelType, 3);
+    img.SetOrigin({1.0, 2.0});
+    img.SetSpacing({3.0, 4.0});
+    img.SetDirection({0.0, 1.0, 1.0, 0.0});
+
+
+    sitk::Image converted = img.ToScalarImage(false);
+    EXPECT_EQ(converted.GetDimension(), 3u);
+    EXPECT_EQ(converted.GetSize(), std::vector<unsigned int>({3, 10, 10}));
+    EXPECT_EQ(converted.GetNumberOfComponentsPerPixel(), 1u);
+    EXPECT_EQ(converted.GetSpacing(), std::vector<double>({1.0, 3.0, 4.0}));
+    EXPECT_EQ(converted.GetOrigin(), std::vector<double>({0.0, 1.0, 2.0}));
+    EXPECT_EQ(converted.GetDirection(), std::vector<double>({1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0}));
+    EXPECT_TRUE(converted.IsUnique());
+    EXPECT_TRUE(img.IsUnique());
+
+    converted = img.ToScalarImage(true);
+    EXPECT_EQ(img.GetDimension(), 3u);
+    EXPECT_EQ(img.GetSize(), std::vector<unsigned int>({3, 10, 10}));
+    EXPECT_EQ(img.GetNumberOfComponentsPerPixel(), 1u);
+    EXPECT_FALSE(img.IsUnique());
+    EXPECT_FALSE(converted.IsUnique());
+
+    img = sitk::Image(std::vector<unsigned int>(SITK_MAX_DIMENSION, 5u), pixelType, 3);
+    EXPECT_ANY_THROW(img.ToScalarImage(false));
+
+    img = sitk::Image(std::vector<unsigned int>(2, 5u), pixelType, 3);
+    EXPECT_NO_THROW(img.ToScalarImage(false));
+  }
+
+  for( auto pixelType: basicTypes)
+  {
+    sitk::Image img({ 10u, 10u }, pixelType);
+
+    sitk::Image converted = img.ToScalarImage(false);
+    EXPECT_EQ(converted.GetDimension(), 2u);
+    EXPECT_EQ(converted.GetSize(), std::vector<unsigned int>({ 10, 10 }));
+    EXPECT_EQ(converted.GetNumberOfComponentsPerPixel(), 1u);
+    EXPECT_EQ(converted.GetPixelID(), pixelType);
+    EXPECT_FALSE(converted.IsUnique());
+    EXPECT_FALSE(img.IsUnique());
+
+    converted = img.ToScalarImage(true);
+    EXPECT_EQ(img.GetDimension(), 2u);
+    EXPECT_EQ(img.GetSize(), std::vector<unsigned int>({ 10, 10 }));
+    EXPECT_EQ(img.GetNumberOfComponentsPerPixel(), 1u);
+    EXPECT_EQ(img.GetPixelID(), pixelType);
+    EXPECT_FALSE(img.IsUnique());
+    EXPECT_FALSE(converted.IsUnique());
+
+    img = sitk::Image(std::vector<unsigned int>(SITK_MAX_DIMENSION, 5u), pixelType);
+    EXPECT_NO_THROW(img.ToScalarImage(false));
+
+    img = sitk::Image(std::vector<unsigned int>(2, 5u), pixelType);
+    EXPECT_NO_THROW(img.ToScalarImage(false));
+
+  }
+
+
+  for (auto pixelType : labelTypes)
+  {
+
+    for (unsigned int d = 2; d <= SITK_MAX_DIMENSION; ++d)
+    {
+      sitk::Image img = sitk::Image(std::vector<unsigned int>(d, 5), pixelType);
+
+      EXPECT_ANY_THROW(img.ToScalarImage(false));
+      EXPECT_ANY_THROW(img.ToScalarImage(true));
+    }
+  }
+
+  for (auto pixelType : complexTypes)
+  {
+    for (unsigned int d = 2; d <= SITK_MAX_DIMENSION; ++d)
+    {
+      sitk::Image img = sitk::Image(std::vector<unsigned int>(d, 5), pixelType);
+
+      EXPECT_ANY_THROW(img.ToScalarImage(false));
+      EXPECT_ANY_THROW(img.ToScalarImage(true));
+    }
   }
 }


### PR DESCRIPTION
Add new method to efficiently convert between scalar and vector images, where the vector component is converted to a image dimension. This enable conversion of images when the fastest axis is no used for channels and other operations dones on a per-channel basis.