### PR TITLE
If GTest::Main is already defined reuse

### DIFF
--- a/CMake/sitkUseGTest.cmake
+++ b/CMake/sitkUseGTest.cmake
@@ -18,7 +18,7 @@ include(GoogleTest)
 
 if (TARGET GTest::Main AND TARGET GTest::GTest)
     message(STATUS "GTest targets already defined.")
-#    return()
+    return()
 endif()
 
 set(GTEST_ROOT "" CACHE PATH "Path to the root of a binary gtest \


### PR DESCRIPTION
When other projects use GTest, its targets may already be available in CMake. When this occours SimpleITK will use the other defined targets. The occours when SimpleITK is configured to use ITK from its build tree.