### PR TITLE
Disable elastix in the AZP CI pipelines

### DIFF
--- a/Testing/CI/Azure/azure-pipelines.yml
+++ b/Testing/CI/Azure/azure-pipelines.yml
@@ -54,7 +54,7 @@ jobs:
             BUILD_EXAMPLES:BOOL=ON
             BUILD_SHARED_LIBS:BOOL=OFF
             BUILD_TESTING:BOOL=ON
-            SimpleITK_USE_ELASTIX:BOOL=ON
+            SimpleITK_USE_ELASTIX:BOOL=OFF
             WRAP_DEFAULT:BOOL=OFF
             WRAP_R:BOOL=OFF
             WRAP_PYTHON:BOOL=ON
@@ -113,7 +113,7 @@ jobs:
             BUILD_EXAMPLES:BOOL=ON
             BUILD_SHARED_LIBS:BOOL=OFF
             BUILD_TESTING:BOOL=ON
-            SimpleITK_USE_ELASTIX:BOOL=ON
+            SimpleITK_USE_ELASTIX:BOOL=OFF
             WRAP_DEFAULT:BOOL=OFF
             WRAP_PYTHON:BOOL=ON
             WRAP_JAVA:BOOL=ON
@@ -172,7 +172,7 @@ jobs:
             BUILD_EXAMPLES:BOOL=ON
             BUILD_SHARED_LIBS:BOOL=OFF
             BUILD_TESTING:BOOL=ON
-            SimpleITK_USE_ELASTIX:BOOL=ON
+            SimpleITK_USE_ELASTIX:BOOL=OFF
             WRAP_DEFAULT:BOOL=OFF
         workingDirectory: $(Agent.BuildDirectory)
       - script: |


### PR DESCRIPTION
The windows build was running out of disk space. This change will reduce disk usages and improve performance.

Elastix building is enable in the GitHub Actions builds.