### PR TITLE
Pin spell checker to v0.1

### DIFF
--- a/.github/workflows/PythonLintAndSpell.yml
+++ b/.github/workflows/PythonLintAndSpell.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install git+https://github.com/SimpleITK/SimpleITKSpellChecking
+        python -m pip install git+https://github.com/SimpleITK/SimpleITKSpellChecking@v0.1
 
     - name: Do spell checking
       run: |


### PR DESCRIPTION
There are some error using the current master of the spell checker. Pin to an older version to ensure consistent behavior.