### PR TITLE
Restore functions for static members like ImageSeriesReader_GetGDCMSe…

### DIFF
--- a/Code/Common/src/sitkPixelIDValues.cxx
+++ b/Code/Common/src/sitkPixelIDValues.cxx
@@ -153,8 +153,6 @@ PixelIDValueType GetPixelIDValueFromString(const std::string &enumString )
 
   if ( enumString == "sitkUnknown" )
     {
-    // Unknown must be first because other enums may be -1 if they are
-    // not instantiated
       return sitkUnknown;
     }
   else if ( enumString == "sitkUInt8" )

--- a/Testing/Unit/Python/CMakeLists.txt
+++ b/Testing/Unit/Python/CMakeLists.txt
@@ -22,6 +22,10 @@ sitk_add_python_test( Test.ExternalViewer
   "${CMAKE_CURRENT_SOURCE_DIR}/sitkExternalViewerTest.py"
   )
 
+sitk_add_python_test( Test.FlatStaticMethod
+   "${CMAKE_CURRENT_SOURCE_DIR}/sitkFlatStaticMethod.py"
+   )
+
 # Numpy test.
 sitk_add_python_test( Test.Numpy
   "${CMAKE_CURRENT_SOURCE_DIR}/sitkNumpyArrayConversionTest.py"

--- a/Testing/Unit/Python/sitkFlatStaticMethod.py
+++ b/Testing/Unit/Python/sitkFlatStaticMethod.py
@@ -1,0 +1,73 @@
+# ==========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ==========================================================================
+import unittest
+import tempfile
+import shutil
+import SimpleITK as sitk
+from pathlib import Path
+
+
+class FlatStatic(unittest.TestCase):
+
+    def setUp(self):
+        # Create a temporary directory for output files
+        self.test_dir = Path(tempfile.mkdtemp())
+
+        img = sitk.Image([10, 10], sitk.sitkInt16)
+        self.test_dcm_file = self.test_dir / "test.dcm"
+        sitk.WriteImage(img, self.test_dcm_file)
+
+    def tearDown(self):
+        # Delete the temporary directory and files contained within. Perhaps if tests fail then the output should  stick
+        # around to debug the problem
+        shutil.rmtree(self.test_dir)
+
+    def test_ProcessObject(self):
+        sitk.ProcessObject_GlobalDefaultDebugOff()
+        sitk.ProcessObject_GlobalDefaultDebugOn()
+        assert (sitk.ProcessObject_GetGlobalDefaultDebug())
+        sitk.ProcessObject_SetGlobalDefaultDebug(False)
+        assert (not sitk.ProcessObject_GetGlobalDefaultDebug())
+
+        sitk.ProcessObject_GlobalWarningDisplayOff()
+        sitk.ProcessObject_GlobalWarningDisplayOn()
+        assert (sitk.ProcessObject_GetGlobalWarningDisplay())
+        sitk.ProcessObject_SetGlobalWarningDisplay(False)
+        assert (not sitk.ProcessObject_GetGlobalWarningDisplay())
+
+        sitk.ProcessObject_SetGlobalDefaultCoordinateTolerance(2.0e-6)
+        self.assertEqual(sitk.ProcessObject_GetGlobalDefaultCoordinateTolerance(), 2.0e-6)
+
+        sitk.ProcessObject_SetGlobalDefaultDirectionTolerance(2.2e-6)
+        self.assertEqual(sitk.ProcessObject_GetGlobalDefaultDirectionTolerance(), 2.2e-6)
+
+        sitk.ProcessObject_SetGlobalDefaultNumberOfThreads(2)
+        self.assertEqual(sitk.ProcessObject_GetGlobalDefaultNumberOfThreads(), 2)
+
+    def test_IO(self):
+        sitk.ImageSeriesReader_GetGDCMSeriesIDs(str(self.test_dir))
+
+        sitk.ImageReaderBase_GetImageIOFromFileName(str(self.test_dcm_file))
+
+    def test_Version(self):
+        # Just test one method here
+        sitk.Version_VersionString()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Testing/Unit/Python/sitkProcessObjectTest.py
+++ b/Testing/Unit/Python/sitkProcessObjectTest.py
@@ -44,6 +44,11 @@ class ProcessObjectTest(unittest.TestCase):
         self.assertTrue(issubclass(sitk.GaussianImageSource,sitk.ProcessObject))
         self.assertTrue(issubclass(sitk.JoinSeriesImageFilter,sitk.ProcessObject))
 
+    def test_ProcessObject_static(self):
+        """Test wrapping of static methods"""
+
+        sitk.ProcessObject.SetGlobalDefaultThreader("PLATFORM")
+
 
     def test_ProcessObject_lambda_Command(self):
         """Check that the lambda Command on event works"""

--- a/Wrapping/Python/CMakeLists.txt
+++ b/Wrapping/Python/CMakeLists.txt
@@ -17,6 +17,8 @@ include_directories ( ${SimpleITK_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR} )
 #
 # Options
 #
+option ( SimpleITK_PYTHON_FLATSTATICMETHOD "Enable object_method functions for static class members. \
+This feature will be removed in the future. To disable requires SWIG>=4.1.0" ON )
 option ( SimpleITK_PYTHON_THREADS "Enable threaded python usage by unlocking the GIL." ON )
 mark_as_advanced( SimpleITK_PYTHON_THREADS )
 option ( SimpleITK_PYTHON_EGG "Add building of python eggs to the dist target." OFF )
@@ -31,6 +33,9 @@ set_source_files_properties ( SimpleITK.i PROPERTIES CPLUSPLUS ON )
 set(CMAKE_SWIG_FLAGS ${CMAKE_SWIG_GLOBAL_FLAGS} -features autodoc=1 -keyword )
 if( SimpleITK_PYTHON_THREADS )
   set(CMAKE_SWIG_FLAGS ${CMAKE_SWIG_FLAGS} -threads)
+endif()
+if (SimpleITK_PYTHON_FLATSTATICMETHOD AND SWIG_VERSION VERSION_GREATER_EQUAL "4.1.0")
+  set(CMAKE_SWIG_FLAGS ${CMAKE_SWIG_FLAGS} -flatstaticmethod )
 endif()
 set(CMAKE_SWIG_OUTDIR ${CMAKE_CURRENT_BINARY_DIR}/SimpleITK)
 set(SWIG_MODULE_SimpleITK_EXTRA_DEPS ${SWIG_EXTRA_DEPS}


### PR DESCRIPTION
…riesIDs

SWIG 4.1.0 change behavior to removing flattened static methods for objects. The compatible behavior can be restored by adding `-flatstaticmethod` argument to SWIG. The
SimpleITK_PYTHON_FLATSTATICMETHOD CMake variable has been added to control the usage of this flag. It is currently enabled by default and is planned to default to OFF in future releases.