### PR TITLE
Restore and depricate MaskImageFilter support for mask input types

### DIFF
--- a/Code/BasicFilters/json/MaskImageFilter.json
+++ b/Code/BasicFilters/json/MaskImageFilter.json
@@ -5,10 +5,12 @@
   "number_of_inputs" : 0,
   "doc" : "Some global documentation\n",
   "include_files" : [
-    "sitkToPixelType.hxx"
+    "sitkToPixelType.hxx",
+    "sitkNotEqualImageFilter.h"
   ],
   "pixel_types" : "NonLabelPixelIDTypeList",
   "pixel_types2" : "MaskedPixelIDTypeList",
+  "custom_type2" : "PixelIDValueEnum type2 = maskImage.GetPixelID();\n  if (!this->m_DualMemberFactory->HasMemberFunction( type1, type2, dimension ) && TypeListHasPixelIDValue<IntegerPixelIDTypeList>(type2)) { type2 = sitkUInt8; }",
   "inputs" : [
     {
       "name" : "Image",
@@ -16,7 +18,10 @@
     },
     {
       "name" : "MaskImage",
-      "type" : "Image"
+      "type" : "Image",
+      "custom_itk_cast" : "auto maskingValue = this->m_MaskingValue;\n  typename FilterType::MaskImageType::ConstPointer image2;\n  if (inMaskImage->GetPixelID() != sitkUInt8) {\n   sitkWarningMacro( \"Support for pixel type \" << GetPixelIDValueAsString(inMaskImage->GetPixelID()) << \" for the MaskImage input has been deprecated and will be removed in future versions. Implicitly casting input to support \\'sitkUInt8\\' type. \" );   Image temp = NotEqual(*inMaskImage, this->m_MaskingValue);image2 = this->CastImageToITK<typename FilterType::MaskImageType>( temp );\n  } else {\n   image2 = this->CastImageToITK<typename FilterType::MaskImageType>( *inMaskImage );\n}\n  filter->SetMaskImage( image2 );"
+
+
     }
   ],
   "members" : [
@@ -37,7 +42,8 @@
       "briefdescriptionSet" : "",
       "detaileddescriptionSet" : "Method to explicitly set the masking value of the mask. Defaults to 0",
       "briefdescriptionGet" : "",
-      "detaileddescriptionGet" : "Method to get the masking value of the mask."
+      "detaileddescriptionGet" : "Method to get the masking value of the mask.",
+      "custom_itk_cast" : "filter->SetMaskingValue(maskingValue);"
     }
   ],
   "tests" : [

--- a/Code/BasicFilters/src/CMakeLists.txt
+++ b/Code/BasicFilters/src/CMakeLists.txt
@@ -167,6 +167,9 @@ add_filter_library(SimpleITKBasicFilters1 SimpleITKBasicFilters1Source no_itk_de
 target_link_libraries ( SimpleITKBasicFilters1
   PRIVATE ${PREV_SimpleITK_LIBRARIES} )
 
+# Manual dependecy needed for to run the Cast filter
+target_link_libraries ( SimpleITK_ITKImageIntensity PRIVATE SimpleITK_ITKImageFilterBase )
+
 sitk_target_use_itk_factory( SimpleITK_ITKFFT FFTImageFilterInit )
 sitk_target_use_itk_factory( SimpleITK_ITKConvolution FFTImageFilterInit )
 sitk_target_use_itk_factory( SimpleITK_ITKDeconvolution FFTImageFilterInit )

--- a/Code/BasicFilters/templates/sitkDualImageFilterTemplate.cxx.in
+++ b/Code/BasicFilters/templates/sitkDualImageFilterTemplate.cxx.in
@@ -119,7 +119,7 @@ if inputs then
   end
 end
 
-if number_of_inputs >= 2 or (inputs and (#inputs >= 2)) then
+if not custom_type2 and (number_of_inputs >= 2 or (inputs and (#inputs >= 2))) then
   OUT=OUT..[[
   const PixelIDValueType type2 = ]]..inputName2..[[.GetPixelIDValue();]]
 else

--- a/Code/Common/include/sitkPixelIDValues.h
+++ b/Code/Common/include/sitkPixelIDValues.h
@@ -118,7 +118,6 @@ enum PixelIDValueEnum {
   sitkLabelUInt64 = PixelIDToPixelIDValue< LabelPixelID<uint64_t> >::value, ///< RLE label of unsigned 64 bit integers
 };
 
-
 const std::string SITKCommon_EXPORT GetPixelIDValueAsString( PixelIDValueType type );
 const std::string SITKCommon_EXPORT GetPixelIDValueAsString( PixelIDValueEnum type );
 
@@ -139,6 +138,37 @@ const std::string SITKCommon_EXPORT GetPixelIDValueAsString( PixelIDValueEnum ty
 PixelIDValueType SITKCommon_EXPORT GetPixelIDValueFromString(const std::string &enumString );
 
 #ifndef SWIG
+
+namespace detail
+{
+template <typename PixelIDTypeList>
+struct TypeListHasPixelIDValue;
+template <typename... Ts>
+struct TypeListHasPixelIDValue<typelist2::typelist<Ts...>>
+{
+  static bool
+  op(PixelIDValueEnum match)
+  {
+    if (match == sitkUnknown)
+      return false;
+
+    bool result = false;
+    ((void)[&match, &result]() { result = result || (PixelIDToPixelIDValue<Ts>::value == match); }(), ...);
+    return result;
+  }
+};
+}
+
+
+/** \brief Check if the runtime PixelID is contained in a template parameter typelist
+ */
+template <typename TPixelIDTypeList = InstantiatedPixelIDTypeList>
+bool
+TypeListHasPixelIDValue(PixelIDValueEnum match)
+{
+  return detail::TypeListHasPixelIDValue<TPixelIDTypeList>::op(match);
+}
+
 SITKCommon_EXPORT std::ostream& operator<<(std::ostream& os, const PixelIDValueEnum id);
 #endif
 

--- a/Testing/Unit/TestBase/SimpleITKTestHarness.h
+++ b/Testing/Unit/TestBase/SimpleITKTestHarness.h
@@ -45,6 +45,7 @@ inline std::ostream& operator<< (std::ostream& os, const std::vector<T>& v)
 
 #include "sitkImage.h"
 #include "sitkCommand.h"
+#include "sitkLogger.h"
 
 // Class to help us find test data
 //
@@ -92,6 +93,39 @@ protected:
 extern DataFinder dataFinder;
 
 
+// A mockup of a logger which saves messages to strings.
+class MockLogger
+  :public itk::simple::LoggerBase {
+public:
+
+  MockLogger() = default;
+
+  ~MockLogger() override = default;
+
+  void DisplayText(const char * t) override {m_DisplayText << t;}
+
+  void DisplayErrorText(const char * t) override {m_DisplayErrorText << t;}
+
+  void DisplayWarningText(const char * t) override {m_DisplayWarningText << t;}
+
+  void DisplayGenericOutputText(const char * t) override {m_DisplayGenericOutputText << t;}
+
+  void DisplayDebugText(const char * t) override {m_DisplayDebugText << t;}
+
+  void Clear() {
+    m_DisplayText.str("");
+    m_DisplayErrorText.str("");
+    m_DisplayWarningText.str("");
+    m_DisplayGenericOutputText.str("");
+    m_DisplayDebugText.str("");
+  }
+
+  std::stringstream m_DisplayText;
+  std::stringstream m_DisplayErrorText;
+  std::stringstream m_DisplayWarningText;
+  std::stringstream m_DisplayGenericOutputText;
+  std::stringstream m_DisplayDebugText;
+};
 
 /** Base Command Class which holds onto a process object
  */

--- a/Testing/Unit/sitkBasicFiltersTests.cxx
+++ b/Testing/Unit/sitkBasicFiltersTests.cxx
@@ -227,7 +227,8 @@ TEST(BasicFilters,MaskImageFilter_deprecated_1)
 
   namespace sitk = itk::simple;
 
-  testing::internal::CaptureStderr();
+  MockLogger logger;
+  logger.SetAsGlobalITKLogger();
 
   EXPECT_TRUE(sitk::TypeListHasPixelIDValue<sitk::IntegerPixelIDTypeList>(sitk::sitkUInt32));
 
@@ -243,36 +244,19 @@ TEST(BasicFilters,MaskImageFilter_deprecated_1)
   EXPECT_EQ(out.GetPixelAsFloat({ 0, 1 }), 0);
   EXPECT_EQ(out.GetPixelAsFloat({ 1, 1 }), 99);
 
-  EXPECT_TRUE( testing::internal::GetCapturedStderr().find("has been deprecated") != std::string::npos );
+  EXPECT_TRUE(logger.m_DisplayWarningText.str().find("has been deprecated") != std::string::npos );
 
-
-}
-
-
-TEST(BasicFilters,MaskImageFilter_deprecated_2)
-{
-  // test deprecated support for pixel types in the mask image filter
-
-  namespace sitk = itk::simple;
-
-  testing::internal::CaptureStderr();
-
-
-  sitk::Image img({ 100, 100 }, sitk::sitkFloat32);
-  img.SetPixelAsFloat({ 0, 0 }, 99);
-  img.SetPixelAsFloat({ 1, 1 }, 99);
-  sitk::Image mask({ 100, 100 }, sitk::sitkUInt32);
-  mask.SetPixelAsUInt32({ 1, 1 }, 1);
+  logger.Clear();
 
 
   mask.SetPixelAsUInt32({ 1, 1 }, 255);
-  auto out = sitk::Mask(img, mask);
+  out = sitk::Mask(img, mask);
   EXPECT_EQ(out.GetPixelID(), sitk::sitkFloat32);
   EXPECT_EQ(out.GetPixelAsFloat({ 0, 0 }), 0);
   EXPECT_EQ(out.GetPixelAsFloat({ 0, 1 }), 0);
   EXPECT_EQ(out.GetPixelAsFloat({ 1, 1 }), 99);
 
-  EXPECT_TRUE( testing::internal::GetCapturedStderr().find("has been deprecated") != std::string::npos );
+    EXPECT_TRUE(logger.m_DisplayWarningText.str().find("has been deprecated") != std::string::npos );
 
 }
 

--- a/Testing/Unit/sitkBasicFiltersTests.cxx
+++ b/Testing/Unit/sitkBasicFiltersTests.cxx
@@ -57,6 +57,8 @@
 #include <sitkDICOMOrientImageFilter.h>
 #include <sitkPasteImageFilter.h>
 #include <sitkN4BiasFieldCorrectionImageFilter.h>
+#include <sitkMaskImageFilter.h>
+#include <sitkLogger.h>
 
 #include "itkVectorImage.h"
 #include "itkVector.h"
@@ -218,6 +220,63 @@ TEST(BasicFilters,ConnectedThreshold_ENUMCHECK) {
   EXPECT_EQ( (int) ITKType::ConnectivityEnum::FaceConnectivity, (int) itk::simple::ConnectedThresholdImageFilter::FaceConnectivity );
   EXPECT_EQ( (int) ITKType::ConnectivityEnum::FullConnectivity, (int) itk::simple::ConnectedThresholdImageFilter::FullConnectivity );
 }
+
+TEST(BasicFilters,MaskImageFilter_deprecated_1)
+{
+  // test deprecated support for pixel types in the mask image filter
+
+  namespace sitk = itk::simple;
+
+  testing::internal::CaptureStderr();
+
+  EXPECT_TRUE(sitk::TypeListHasPixelIDValue<sitk::IntegerPixelIDTypeList>(sitk::sitkUInt32));
+
+  sitk::Image img({ 100, 100 }, sitk::sitkFloat32);
+  img.SetPixelAsFloat({ 0, 0 }, 99);
+  img.SetPixelAsFloat({ 1, 1 }, 99);
+  sitk::Image mask({ 100, 100 }, sitk::sitkUInt32);
+  mask.SetPixelAsUInt32({ 1, 1 }, 1);
+
+  auto out = sitk::Mask(img, mask);
+  EXPECT_EQ(out.GetPixelID(), sitk::sitkFloat32);
+  EXPECT_EQ(out.GetPixelAsFloat({ 0, 0 }), 0);
+  EXPECT_EQ(out.GetPixelAsFloat({ 0, 1 }), 0);
+  EXPECT_EQ(out.GetPixelAsFloat({ 1, 1 }), 99);
+
+  EXPECT_TRUE( testing::internal::GetCapturedStderr().find("has been deprecated") != std::string::npos );
+
+
+}
+
+
+TEST(BasicFilters,MaskImageFilter_deprecated_2)
+{
+  // test deprecated support for pixel types in the mask image filter
+
+  namespace sitk = itk::simple;
+
+  testing::internal::CaptureStderr();
+
+
+  sitk::Image img({ 100, 100 }, sitk::sitkFloat32);
+  img.SetPixelAsFloat({ 0, 0 }, 99);
+  img.SetPixelAsFloat({ 1, 1 }, 99);
+  sitk::Image mask({ 100, 100 }, sitk::sitkUInt32);
+  mask.SetPixelAsUInt32({ 1, 1 }, 1);
+
+
+  mask.SetPixelAsUInt32({ 1, 1 }, 255);
+  auto out = sitk::Mask(img, mask);
+  EXPECT_EQ(out.GetPixelID(), sitk::sitkFloat32);
+  EXPECT_EQ(out.GetPixelAsFloat({ 0, 0 }), 0);
+  EXPECT_EQ(out.GetPixelAsFloat({ 0, 1 }), 0);
+  EXPECT_EQ(out.GetPixelAsFloat({ 1, 1 }), 99);
+
+  EXPECT_TRUE( testing::internal::GetCapturedStderr().find("has been deprecated") != std::string::npos );
+
+}
+
+
 
 TEST(BasicFilter,GradientAnisotropicDiffusion_EstimateOptimalTimeStep) {
   // This test is to check the correctness of the

--- a/Testing/Unit/sitkCommonTests.cxx
+++ b/Testing/Unit/sitkCommonTests.cxx
@@ -927,3 +927,22 @@ TEST(PixelID, FromString)
 
   FROM_STRING_CHECK(sitkUnknown);
 }
+
+
+TEST(PixelID, TypeListHasPixelIDValue)
+{
+  namespace sitk = itk::simple;
+
+  EXPECT_FALSE(sitk::TypeListHasPixelIDValue(sitk::sitkUnknown));
+  for (auto id : {sitk::sitkUInt8, sitk::sitkFloat32,
+       sitk::sitkLabelUInt16, sitk::sitkComplexFloat64,
+       sitk::sitkVectorInt16, sitk::sitkVectorFloat64})
+  EXPECT_TRUE(sitk::TypeListHasPixelIDValue(id) );
+
+
+  EXPECT_TRUE(sitk::TypeListHasPixelIDValue<sitk::IntegerPixelIDTypeList>(sitk::sitkInt16));
+  for (auto id : {sitk::sitkLabelUInt8, sitk::sitkComplexFloat32, sitk::sitkFloat32, sitk::sitkVectorInt16})
+  {
+    EXPECT_FALSE(sitk::TypeListHasPixelIDValue<sitk::IntegerPixelIDTypeList>(id));
+  };
+}

--- a/Testing/Unit/sitkCommonTests.cxx
+++ b/Testing/Unit/sitkCommonTests.cxx
@@ -818,33 +818,6 @@ TEST(Logger, Logger)
   EXPECT_EQ( testing::internal::GetCapturedStderr(), expectedOutput);
 }
 
-namespace {
-// A mockup of a logger which saves messages to strings.
-class MockLogger
-:public itk::simple::LoggerBase {
-public:
-
-  MockLogger() = default;
-
-  ~MockLogger() override = default;
-
-  void DisplayText(const char * t) override {m_DisplayText << t;}
-
-  void DisplayErrorText(const char * t) override {m_DisplayErrorText << t;}
-
-  void DisplayWarningText(const char * t) override {m_DisplayWarningText << t;}
-
-  void DisplayGenericOutputText(const char * t) override {m_DisplayGenericOutputText << t;}
-
-  void DisplayDebugText(const char * t) override {m_DisplayDebugText << t;}
-
-  std::stringstream m_DisplayText;
-  std::stringstream m_DisplayErrorText;
-  std::stringstream m_DisplayWarningText;
-  std::stringstream m_DisplayGenericOutputText;
-  std::stringstream m_DisplayDebugText;
-};
-}
 
 
 TEST(Logger, MockLogger)

--- a/Testing/Unit/sitkImageTests.cxx
+++ b/Testing/Unit/sitkImageTests.cxx
@@ -1953,7 +1953,10 @@ TEST_F(Image, Evaluate)
            sitk::sitkBSplineResamplerOrder3,
            sitk::sitkBSplineResamplerOrder4,
            sitk::sitkBSplineResamplerOrder5,
-           sitk::sitkLabelLinear})
+#ifdef SITK_GENERIC_LABEL_INTERPOLATOR
+           sitk::sitkLabelLinear
+#endif
+       })
   {
     EXPECT_ANY_THROW(img.EvaluateAtPhysicalPoint({0.0,0.0}, interp));
   }


### PR DESCRIPTION
Instead of throwing an exception, implicitly convert the input mask to a image of uint8. Also print a warning message that this behavior is deprecated.

Addressed #1992