### PR TITLE
Tidy modernize avoid bind

### DIFF
--- a/Code/Common/include/sitkFunctionCommand.h
+++ b/Code/Common/include/sitkFunctionCommand.h
@@ -50,7 +50,7 @@ public:
   template <class T>
     void SetCallbackFunction ( T *object, void(T::* pMemberFunction )() )
   {
-    m_Function = std::bind(pMemberFunction, object);
+    m_Function = [object, pMemberFunction] { std::invoke(pMemberFunction, object); };
   }
 
   /** Set a C-Style function to be called in the Execute method */

--- a/Code/Common/include/sitkMemberFunctionFactoryBase.h
+++ b/Code/Common/include/sitkMemberFunctionFactoryBase.h
@@ -140,11 +140,7 @@ protected:
    */
   static FunctionObjectType  BindObject( MemberFunctionType pfunc, ObjectType *objectPointer)
     {
-
-      // this is really only needed because std::bind1st does not work
-      // with tr1::function... that is with tr1::bind, we need to
-      // specify the other arguments, and can't just bind the first
-      return std::bind( pfunc,objectPointer );
+      return [pfunc, objectPointer]{ return std::invoke(pfunc, objectPointer); };
     }
 
   using FunctionMapType = std::unordered_map< TKey, FunctionObjectType, hash<TKey> >;
@@ -194,15 +190,12 @@ protected:
    *  object.
    */
   static FunctionObjectType  BindObject( MemberFunctionType pfunc, ObjectType *objectPointer)
-    {
-      // needed for _1 place holder
-      using namespace std::placeholders;
+  {
 
-      // this is really only needed because std::bind1st does not work
-      // with tr1::function... that is with tr1::bind, we need to
-      // specify the other arguments, and can't just bind the first
-      return std::bind( pfunc,objectPointer, _1 );
-    }
+    return [pfunc, objectPointer](auto && PH1) -> MemberFunctionResultType {
+      return std::invoke(pfunc, objectPointer, std::forward<decltype(PH1)>(PH1));
+    };
+  }
 
 
   using FunctionMapType = std::unordered_map< TKey, FunctionObjectType, hash<TKey> >;
@@ -248,13 +241,9 @@ protected:
    */
   static FunctionObjectType  BindObject( MemberFunctionType pfunc, ObjectType *objectPointer)
     {
-      // needed for _1 place holder
-      using namespace std::placeholders;
-
-      // this is really only needed because std::bind1st does not work
-      // with tr1::function... that is with tr1::bind, we need to
-      // specify the other arguments, and can't just bind the first
-      return std::bind( pfunc, objectPointer, _1, _2 );
+      return [pfunc, objectPointer] (auto &&PH1, auto &&PH2){
+        return std::invoke(pfunc, objectPointer, std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+      };
     }
 
   using FunctionMapType = std::unordered_map< TKey, FunctionObjectType, hash<TKey> >;
@@ -299,15 +288,15 @@ protected:
    *  object
    */
   static FunctionObjectType  BindObject( MemberFunctionType pfunc, ObjectType *objectPointer)
-    {
-      // needed for _1 place holder
-      using namespace std::placeholders;
-
-      // this is really only needed because std::bind1st does not work
-      // with tr1::function... that is with tr1::bind, we need to
-      // specify the other arguments, and can't just bind the first
-      return std::bind( pfunc, objectPointer, _1, _2, _3 );
-    }
+  {
+    return [pfunc, objectPointer](auto && PH1, auto && PH2, auto && PH3) {
+      return std::invoke(pfunc,
+                         objectPointer,
+                         std::forward<decltype(PH1)>(PH1),
+                         std::forward<decltype(PH2)>(PH2),
+                         std::forward<decltype(PH3)>(PH3));
+    };
+  }
 
   using FunctionMapType = std::unordered_map< TKey, FunctionObjectType, hash<TKey> >;
 
@@ -353,14 +342,15 @@ protected:
    */
   static FunctionObjectType  BindObject( MemberFunctionType pfunc, ObjectType *objectPointer)
     {
-      // needed for _1 place holder
-      using namespace std::placeholders;
-
-      // this is really only needed because std::bind1st does not work
-      // with tr1::function... that is with tr1::bind, we need to
-      // specify the other arguments, and can't just bind the first
-      return std::bind( pfunc, objectPointer, _1, _2, _3, _4 );
-    }
+    return [pfunc, objectPointer](auto && PH1, auto && PH2, auto && PH3, auto && PH4) {
+      return std::invoke(pfunc,
+                         objectPointer,
+                         std::forward<decltype(PH1)>(PH1),
+                         std::forward<decltype(PH2)>(PH2),
+                         std::forward<decltype(PH3)>(PH3),
+                         std::forward<decltype(PH4)>(PH4));
+    };
+  }
 
   using FunctionMapType = std::unordered_map< TKey, FunctionObjectType, hash<TKey> >;
 
@@ -412,14 +402,16 @@ protected:
    */
   static FunctionObjectType  BindObject( MemberFunctionType pfunc, ObjectType *objectPointer)
     {
-      // needed for _1 place holder
-      using namespace std::placeholders;
-
-      // this is really only needed because std::bind1st does not work
-      // with tr1::function... that is with tr1::bind, we need to
-      // specify the other arguments, and can't just bind the first
-      return std::bind( pfunc, objectPointer, _1, _2, _3, _4, _5 );
-    }
+    return [pfunc, objectPointer](auto && PH1, auto && PH2, auto && PH3, auto && PH4, auto && PH5) {
+      return std::invoke(pfunc,
+                         objectPointer,
+                         std::forward<decltype(PH1)>(PH1),
+                         std::forward<decltype(PH2)>(PH2),
+                         std::forward<decltype(PH3)>(PH3),
+                         std::forward<decltype(PH4)>(PH4),
+                         std::forward<decltype(PH5)>(PH5));
+    };
+  }
 
 
   using FunctionMapType = std::unordered_map< TKey, FunctionObjectType, hash<TKey> >;

--- a/Code/Common/src/sitkAffineTransform.cxx
+++ b/Code/Common/src/sitkAffineTransform.cxx
@@ -199,11 +199,11 @@ void AffineTransform::InternalInitialization(TransformType *t)
 
   this->m_pfScale2 = [t](double v, bool b) { t->Scale(v, b); };
 
-  this->m_pfShear = std::bind(&TransformType::Shear,t,std::placeholders::_1,std::placeholders::_2,std::placeholders::_3,std::placeholders::_4);
+  this->m_pfShear = [t](auto && PH1, auto && PH2, auto && PH3, auto && PH4) { t->Shear(std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2), std::forward<decltype(PH3)>(PH3), std::forward<decltype(PH4)>(PH4)); };
   this->m_pfTranslate = [t] (const std::vector<double> &v, bool b) {
     t->Translate(sitkSTLVectorToITK<typename TransformType::OutputVectorType>(v),b);
   };
-  this->m_pfRotate = std::bind(&TransformType::Rotate,t,std::placeholders::_1,std::placeholders::_2,std::placeholders::_3,std::placeholders::_4);
+  this->m_pfRotate = [t](auto && PH1, auto && PH2, auto && PH3, auto && PH4) { t->Rotate(std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2), std::forward<decltype(PH3)>(PH3), std::forward<decltype(PH4)>(PH4)); };
 }
 
 }

--- a/Code/Common/src/sitkBSplineTransform.cxx
+++ b/Code/Common/src/sitkBSplineTransform.cxx
@@ -272,7 +272,7 @@ void BSplineTransform::InternalInitialization(TransformType *t)
   this->m_pfGetCoefficientImages = [t] () {
     return sitkImageArrayConvert(t->GetCoefficientImages());
   };
-  this->m_pfSetCoefficientImages = std::bind(SetCoefficientImages<TransformType>, t, std::placeholders::_1);
+  this->m_pfSetCoefficientImages = [t](auto && PH1) { return SetCoefficientImages<TransformType>(t, std::forward<decltype(PH1)>(PH1)); };
 
   this->m_pfGetOrder =  &sitkGetOrder<TransformType>;
 }

--- a/Code/Common/src/sitkDisplacementFieldTransform.cxx
+++ b/Code/Common/src/sitkDisplacementFieldTransform.cxx
@@ -16,20 +16,6 @@
 *
 *=========================================================================*/
 
-
-#if defined(_MSC_VER) && _MSC_VER == 1700
-// VS11 (Visual Studio 2012) has limited variadic argument support for
-// std::bind, the following increases the number of supported
-// arguments.
-// https://connect.microsoft.com/VisualStudio/feedback/details/723448/very-few-function-arguments-for-std-bind
-
- #if defined(_VARIADIC_MAX) && _VARIADIC_MAX < 10
-  #error "_VARIADIC_MAX already defined. Some STL classes may have insufficient number of template parameters."
- #else
-  #define _VARIADIC_MAX 10
- #endif
-#endif
-
 #include "sitkDisplacementFieldTransform.h"
 #include "sitkPimpleTransform.hxx"
 #include "sitkImageConvert.hxx"

--- a/Code/Common/src/sitkDisplacementFieldTransform.cxx
+++ b/Code/Common/src/sitkDisplacementFieldTransform.cxx
@@ -280,27 +280,17 @@ void DisplacementFieldTransform::InternalInitialization(itk::TransformBase *tran
 template<class TransformType>
 void DisplacementFieldTransform::InternalInitialization(TransformType *t)
 {
-  this->m_pfSetDisplacementField = std::bind(&InternalSetDisplacementField<TransformType>, t, std::placeholders::_1);
-  this->m_pfGetDisplacementField = std::bind(&DisplacementFieldTransform::InternalGetDisplacementField<TransformType>, t);
+  this->m_pfSetDisplacementField = [t](auto && PH1) { return InternalSetDisplacementField<TransformType>(t, std::forward<decltype(PH1)>(PH1)); };
+  this->m_pfGetDisplacementField = [t] { return DisplacementFieldTransform::InternalGetDisplacementField<TransformType>(t); };
 
-  this->m_pfSetInverseDisplacementField = std::bind(&InternalSetInverseDisplacementField<TransformType>, t, std::placeholders::_1);
-  this->m_pfGetInverseDisplacementField = std::bind(&DisplacementFieldTransform::InternalGetInverseDisplacementField<TransformType>, t);
+  this->m_pfSetInverseDisplacementField = [t](auto && PH1) { return InternalSetInverseDisplacementField<TransformType>(t, std::forward<decltype(PH1)>(PH1)); };
+  this->m_pfGetInverseDisplacementField = [t] { return DisplacementFieldTransform::InternalGetInverseDisplacementField<TransformType>(t); };
 
-  this->m_pfSetInterpolator = std::bind(&InternalSetInterpolator<TransformType>, t, std::placeholders::_1);
+  this->m_pfSetInterpolator = [t](auto && PH1) { return InternalSetInterpolator<TransformType>(t, std::forward<decltype(PH1)>(PH1)); };
 
-  m_pfSetSmoothingOff = std::bind(&Self::InternalSetSmoothingOff<TransformType>, this, t);
-  m_pfSetSmoothingGaussianOnUpdate = std::bind(&Self::InternalSetSmoothingGaussianOnUpdate<TransformType>,
-                                                 this,
-                                                 t,
-                                                 std::placeholders::_1,
-                                                 std::placeholders::_2 );
-  m_pfSetSmoothingBSplineOnUpdate = std::bind(&Self::InternalSetSmoothingBSplineOnUpdate<TransformType>,
-                                                this,
-                                                t,
-                                                std::placeholders::_1,
-                                                std::placeholders::_2,
-                                                std::placeholders::_3,
-                                                std::placeholders::_4 );
+  m_pfSetSmoothingOff = [this, t] { this->InternalSetSmoothingOff(t); };
+  m_pfSetSmoothingGaussianOnUpdate = [this, t](auto && PH1, auto && PH2) { this->InternalSetSmoothingGaussianOnUpdate(t, std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2)); };
+  m_pfSetSmoothingBSplineOnUpdate = [this, t](auto && PH1, auto && PH2, auto && PH3, auto && PH4) { this->InternalSetSmoothingBSplineOnUpdate(t, std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2), std::forward<decltype(PH3)>(PH3), std::forward<decltype(PH4)>(PH4)); };
 }
 
 PimpleTransformBase *DisplacementFieldTransform::CreateDisplacementFieldPimpleTransform(unsigned int dimension)

--- a/Code/Common/src/sitkEuler2DTransform.cxx
+++ b/Code/Common/src/sitkEuler2DTransform.cxx
@@ -161,8 +161,8 @@ void Euler2DTransform::InternalInitialization(TransformType *t)
   SITK_TRANSFORM_SET_MPF_GetMatrix();
   SITK_TRANSFORM_SET_MPF_SetMatrix();
 
-  this->m_pfSetAngle = std::bind(&TransformType::SetAngle,t,std::placeholders::_1);
-  this->m_pfGetAngle = std::bind(&TransformType::GetAngle,t);
+  this->m_pfSetAngle = [t](auto && PH1) { t->SetAngle(std::forward<decltype(PH1)>(PH1)); };
+  this->m_pfGetAngle = [t] { return t->GetAngle(); };
 }
 
 }

--- a/Code/Common/src/sitkEuler3DTransform.cxx
+++ b/Code/Common/src/sitkEuler3DTransform.cxx
@@ -187,12 +187,12 @@ void Euler3DTransform::InternalInitialization(TransformType *t)
   SITK_TRANSFORM_SET_MPF_GetMatrix();
   SITK_TRANSFORM_SET_MPF_SetMatrix();
 
-  this->m_pfSetRotation = std::bind(&TransformType::SetRotation,t,std::placeholders::_1,std::placeholders::_2,std::placeholders::_3);
-  this->m_pfGetAngleX = std::bind(&TransformType::GetAngleX,t);
-  this->m_pfGetAngleY = std::bind(&TransformType::GetAngleY,t);
-  this->m_pfGetAngleZ = std::bind(&TransformType::GetAngleZ,t);
-  this->m_pfSetComputeZYX = std::bind(&TransformType::SetComputeZYX,t,std::placeholders::_1);
-  this->m_pfGetComputeZYX = std::bind(&TransformType::GetComputeZYX,t);
+  this->m_pfSetRotation = [t](auto && PH1, auto && PH2, auto && PH3) { t->SetRotation(std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2), std::forward<decltype(PH3)>(PH3)); };
+  this->m_pfGetAngleX = [t] { return t->GetAngleX(); };
+  this->m_pfGetAngleY = [t] { return t->GetAngleY(); };
+  this->m_pfGetAngleZ = [t] { return t->GetAngleZ(); };
+  this->m_pfSetComputeZYX = [t](auto && PH1) { t->SetComputeZYX(std::forward<decltype(PH1)>(PH1)); };
+  this->m_pfGetComputeZYX = [t] { return t->GetComputeZYX(); };
 
 }
 

--- a/Code/Common/src/sitkFunctionCommand.cxx
+++ b/Code/Common/src/sitkFunctionCommand.cxx
@@ -45,7 +45,7 @@ void FunctionCommand::SetCallbackFunction ( void(* pFunction )() )
 
 void FunctionCommand::SetCallbackFunction( void(* pFunction )(void *), void *clientData )
 {
-  m_Function = std::bind(pFunction, clientData);
+  m_Function = [clientData, pFunction] {pFunction(clientData); };
 }
 
 void FunctionCommand::SetCallbackFunction(const std::function<void()> &func)

--- a/Code/Common/src/sitkImageExplicit.cxx
+++ b/Code/Common/src/sitkImageExplicit.cxx
@@ -16,20 +16,6 @@
 *
 *=========================================================================*/
 
-#if defined(_MSC_VER) && _MSC_VER == 1700
-// VS11 (Visual Studio 2012) has limited variadic argument support for
-// std::bind, the following increases the number of supported
-// arguments.
-// https://connect.microsoft.com/VisualStudio/feedback/details/723448/very-few-function-arguments-for-std-bind
-
- #if defined(_VARIADIC_MAX) && _VARIADIC_MAX < 10
-  #error "_VARIADIC_MAX already defined. Some STL classes may have insufficient number of template parameters."
- #else
-  #define _VARIADIC_MAX 10
- #endif
-#endif
-
-
 #include "sitkImage.hxx"
 #include "sitkMemberFunctionFactory.h"
 

--- a/Code/Common/src/sitkSimilarity2DTransform.cxx
+++ b/Code/Common/src/sitkSimilarity2DTransform.cxx
@@ -176,11 +176,11 @@ void Similarity2DTransform::InternalInitialization(TransformType *t)
   SITK_TRANSFORM_SET_MPF_GetMatrix();
   SITK_TRANSFORM_SET_MPF_SetMatrix();
 
-  this->m_pfSetAngle = std::bind(&TransformType::SetAngle,t,std::placeholders::_1);
-  this->m_pfGetAngle = std::bind(&TransformType::GetAngle,t);
+  this->m_pfSetAngle = [t](auto && PH1) { t->SetAngle(std::forward<decltype(PH1)>(PH1)); };
+  this->m_pfGetAngle = [t] { return t->GetAngle(); };
 
-  this->m_pfSetScale = std::bind(&TransformType::SetScale,t,std::placeholders::_1);
-  this->m_pfGetScale = std::bind(&TransformType::GetScale,t);
+  this->m_pfSetScale = [t](auto && PH1) { t->SetScale(std::forward<decltype(PH1)>(PH1)); };
+  this->m_pfGetScale = [t] { return t->GetScale(); };
 }
 
 }

--- a/Code/Common/src/sitkSimilarity3DTransform.cxx
+++ b/Code/Common/src/sitkSimilarity3DTransform.cxx
@@ -215,8 +215,8 @@ void Similarity3DTransform::InternalInitialization(TransformType *t)
     return sitkITKVersorToSTL<double>(t->GetVersor());
   };
 
-  this->m_pfSetScale = std::bind(&TransformType::SetScale,t,std::placeholders::_1);
-  this->m_pfGetScale = std::bind(&TransformType::GetScale,t);
+  this->m_pfSetScale = [t](auto && PH1) { t->SetScale(std::forward<decltype(PH1)>(PH1)); };
+  this->m_pfGetScale = [t] {return t->GetScale(); };
 
   // pre argument has no effect
   // pre argument has no effect

--- a/Code/IO/src/sitkImageFileReader.cxx
+++ b/Code/IO/src/sitkImageFileReader.cxx
@@ -169,9 +169,9 @@ namespace itk {
       swap(spacing, m_Spacing);
       swap(size, m_Size);
 
-      this->m_pfGetMetaDataKeys = std::bind(&MetaDataDictionary::GetKeys, this->m_MetaDataDictionary.get());
-      this->m_pfHasMetaDataKey = std::bind(&MetaDataDictionary::HasKey, this->m_MetaDataDictionary.get(), std::placeholders::_1);
-      this->m_pfGetMetaData = std::bind(&GetMetaDataDictionaryCustomCast::CustomCast, this->m_MetaDataDictionary.get(), std::placeholders::_1);
+      this->m_pfGetMetaDataKeys = [capture0 = this->m_MetaDataDictionary.get()] { return capture0->GetKeys(); };
+      this->m_pfHasMetaDataKey = [capture0 = this->m_MetaDataDictionary.get()](auto && PH1) { return capture0->HasKey(std::forward<decltype(PH1)>(PH1)); };
+      this->m_pfGetMetaData = [capture0 = this->m_MetaDataDictionary.get()](auto && PH1) { return GetMetaDataDictionaryCustomCast::CustomCast(capture0, std::forward<decltype(PH1)>(PH1)); };
     }
 
     PixelIDValueEnum

--- a/Code/IO/src/sitkImageSeriesReader.cxx
+++ b/Code/IO/src/sitkImageSeriesReader.cxx
@@ -210,9 +210,9 @@ namespace itk {
       {
       this->m_Filter = reader;
       this->m_Filter->Register();
-      this->m_pfGetMetaDataKeys = std::bind(&GetMetaDataKeysCustomCast<Reader>::CustomCast, reader.GetPointer(), std::placeholders::_1 );
-      this->m_pfHasMetaDataKey = std::bind(&HasMetaDataKeyCustomCast<Reader>::CustomCast, reader.GetPointer(), std::placeholders::_1, std::placeholders::_2 );
-      this->m_pfGetMetaData = std::bind(&GetMetaDataCustomCast<Reader>::CustomCast, reader.GetPointer(), std::placeholders::_1, std::placeholders::_2 );
+      this->m_pfGetMetaDataKeys = [capture0 = reader.GetPointer()](auto && PH1) { return GetMetaDataKeysCustomCast<Reader>::CustomCast(capture0, std::forward<decltype(PH1)>(PH1)); };
+      this->m_pfHasMetaDataKey = [capture0 = reader.GetPointer()](auto && PH1, auto && PH2) { return HasMetaDataKeyCustomCast<Reader>::CustomCast(capture0, std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2)); };
+      this->m_pfGetMetaData = [capture0 = reader.GetPointer()](auto && PH1, auto && PH2) { return GetMetaDataCustomCast<Reader>::CustomCast(capture0, std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2)); };
       }
 
     reader->Update();

--- a/Code/Registration/src/sitkImageRegistrationMethod.cxx
+++ b/Code/Registration/src/sitkImageRegistrationMethod.cxx
@@ -955,9 +955,9 @@ Transform ImageRegistrationMethod::ExecuteInternal ( const Image &inFixed, const
                  << *registration->GetOptimizer()
                  << *registration->GetMetric());
 
-  m_pfGetOptimizerStopConditionDescription =  std::bind(&_OptimizerType::GetStopConditionDescription, optimizer.GetPointer());
+  m_pfGetOptimizerStopConditionDescription =  [capture0 = optimizer.GetPointer()] { return capture0->GetStopConditionDescription(); };
 
-  m_pfGetCurrentLevel = std::bind(&CurrentLevelCustomCast::CustomCast<RegistrationType>,registration.GetPointer());
+  m_pfGetCurrentLevel = [capture0 = registration.GetPointer()] { return CurrentLevelCustomCast::CustomCast<RegistrationType>(capture0); };
 
 
   try

--- a/Code/Registration/src/sitkImageRegistrationMethod_CreateMetric.hxx
+++ b/Code/Registration/src/sitkImageRegistrationMethod_CreateMetric.hxx
@@ -64,7 +64,7 @@ ImageRegistrationMethod::CreateMetric( )
     typedef itk::ANTSNeighborhoodCorrelationImageToImageMetricv4<FixedImageType, MovingImageType > _MetricType;
 
       typename _MetricType::Pointer metric = _MetricType::New();
-      this->m_pfGetMetricNumberOfValidPoints = std::bind(&NumberOfValidPointsCustomCast::CustomCast<_MetricType>,metric.GetPointer());
+      this->m_pfGetMetricNumberOfValidPoints = [metric = metric.GetPointer()] { return NumberOfValidPointsCustomCast::CustomCast<_MetricType>(metric); };
       typename _MetricType::RadiusType radius;
       radius.Fill( m_MetricRadius );
       metric->SetRadius( radius );
@@ -76,7 +76,7 @@ ImageRegistrationMethod::CreateMetric( )
       typedef itk::CorrelationImageToImageMetricv4< FixedImageType, MovingImageType > _MetricType;
 
       typename _MetricType::Pointer metric = _MetricType::New();
-      this->m_pfGetMetricNumberOfValidPoints = std::bind(&NumberOfValidPointsCustomCast::CustomCast<_MetricType>,metric.GetPointer());
+      this->m_pfGetMetricNumberOfValidPoints =  [metric = metric.GetPointer()] { return NumberOfValidPointsCustomCast::CustomCast<_MetricType>(metric); };
       metric->Register();
       return metric.GetPointer();
     }
@@ -84,7 +84,7 @@ ImageRegistrationMethod::CreateMetric( )
     {
       typedef itk::DemonsImageToImageMetricv4< FixedImageType, MovingImageType > _MetricType;
       typename _MetricType::Pointer metric = _MetricType::New();
-      this->m_pfGetMetricNumberOfValidPoints = std::bind(&NumberOfValidPointsCustomCast::CustomCast<_MetricType>,metric.GetPointer());
+      this->m_pfGetMetricNumberOfValidPoints =  [metric = metric.GetPointer()] { return NumberOfValidPointsCustomCast::CustomCast<_MetricType>(metric); };
       metric->SetIntensityDifferenceThreshold(m_MetricIntensityDifferenceThreshold);
       metric->Register();
       return metric.GetPointer();
@@ -93,7 +93,7 @@ ImageRegistrationMethod::CreateMetric( )
     {
       typedef itk::JointHistogramMutualInformationImageToImageMetricv4< FixedImageType, MovingImageType > _MetricType;
       typename _MetricType::Pointer metric = _MetricType::New();
-      this->m_pfGetMetricNumberOfValidPoints = std::bind(&NumberOfValidPointsCustomCast::CustomCast<_MetricType>,metric.GetPointer());
+      this->m_pfGetMetricNumberOfValidPoints = [metric = metric.GetPointer()] { return NumberOfValidPointsCustomCast::CustomCast<_MetricType>(metric); };
       metric->SetNumberOfHistogramBins(m_MetricNumberOfHistogramBins);
       metric->SetVarianceForJointPDFSmoothing(m_MetricVarianceForJointPDFSmoothing);
       metric->Register();
@@ -103,7 +103,7 @@ ImageRegistrationMethod::CreateMetric( )
     {
       typedef itk::MeanSquaresImageToImageMetricv4< FixedImageType, MovingImageType > _MetricType;
       typename _MetricType::Pointer metric = _MetricType::New();
-      this->m_pfGetMetricNumberOfValidPoints = std::bind(&NumberOfValidPointsCustomCast::CustomCast<_MetricType>,metric.GetPointer());
+      this->m_pfGetMetricNumberOfValidPoints = [metric = metric.GetPointer()] { return NumberOfValidPointsCustomCast::CustomCast<_MetricType>(metric); };
       metric->Register();
       return metric.GetPointer();
     }
@@ -111,7 +111,7 @@ ImageRegistrationMethod::CreateMetric( )
     {
       typedef itk::MattesMutualInformationImageToImageMetricv4< FixedImageType, MovingImageType > _MetricType;
       typename _MetricType::Pointer metric = _MetricType::New();
-      this->m_pfGetMetricNumberOfValidPoints = std::bind(&NumberOfValidPointsCustomCast::CustomCast<_MetricType>,metric.GetPointer());
+      this->m_pfGetMetricNumberOfValidPoints = [metric = metric.GetPointer()] { return NumberOfValidPointsCustomCast::CustomCast<_MetricType>(metric); };
       metric->SetNumberOfHistogramBins(m_MetricNumberOfHistogramBins);
       metric->Register();
       return metric.GetPointer();

--- a/Code/Registration/src/sitkImageRegistrationMethod_CreateOptimizer.cxx
+++ b/Code/Registration/src/sitkImageRegistrationMethod_CreateOptimizer.cxx
@@ -101,16 +101,16 @@ namespace simple
       optimizer->SetDoEstimateLearningRateOnce( this->m_OptimizerEstimateLearningRate==Once );
       optimizer->SetMaximumStepSizeInPhysicalUnits( this->m_OptimizerMaximumStepSizeInPhysicalUnits );
 
-      this->m_pfGetMetricValue = std::bind(&_OptimizerType::GetCurrentMetricValue,optimizer.GetPointer());
-      this->m_pfGetOptimizerIteration = std::bind(&CurrentIterationCustomCast::CustomCast,optimizer.GetPointer());
-      this->m_pfGetOptimizerPosition = std::bind(&PositionOptimizerCustomCast::CustomCast,optimizer.GetPointer());
-      this->m_pfGetOptimizerLearningRate = std::bind(&_OptimizerType::GetLearningRate,optimizer.GetPointer());
-      this->m_pfGetOptimizerConvergenceValue = std::bind(&_OptimizerType::GetConvergenceValue,optimizer.GetPointer());
+      this->m_pfGetMetricValue = [capture0 = optimizer.GetPointer()] { return capture0->GetCurrentMetricValue(); };
+      this->m_pfGetOptimizerIteration = [capture0 = optimizer.GetPointer()] { return CurrentIterationCustomCast::CustomCast(capture0); };
+      this->m_pfGetOptimizerPosition = [capture0 = optimizer.GetPointer()] { return PositionOptimizerCustomCast::CustomCast(capture0); };
+      this->m_pfGetOptimizerLearningRate = [capture0 = optimizer.GetPointer()] { return capture0->GetLearningRate(); };
+      this->m_pfGetOptimizerConvergenceValue = [capture0 = optimizer.GetPointer()] { return capture0->GetConvergenceValue(); };
       auto x = optimizer.GetPointer();
       this->m_pfGetOptimizerScales = [x]() {
         return PositionOptimizerCustomCast::Helper(x->GetScales());
       };
-      this->m_pfOptimizerStopRegistration = std::bind(&_OptimizerType::StopOptimization, optimizer.GetPointer());
+      this->m_pfOptimizerStopRegistration = [capture0 = optimizer.GetPointer()] { capture0->StopOptimization(); };
 
       optimizer->Register();
       return optimizer.GetPointer();
@@ -127,16 +127,16 @@ namespace simple
       optimizer->SetDoEstimateLearningRateOnce( this->m_OptimizerEstimateLearningRate==Once );
       optimizer->SetMaximumStepSizeInPhysicalUnits( this->m_OptimizerMaximumStepSizeInPhysicalUnits );
 
-      this->m_pfGetMetricValue = std::bind(&_OptimizerType::GetCurrentMetricValue,optimizer.GetPointer());
-      this->m_pfGetOptimizerIteration = std::bind(&CurrentIterationCustomCast::CustomCast,optimizer.GetPointer());
-      this->m_pfGetOptimizerPosition = std::bind(&PositionOptimizerCustomCast::CustomCast,optimizer.GetPointer());
-      this->m_pfGetOptimizerLearningRate = std::bind(&_OptimizerType::GetLearningRate,optimizer.GetPointer());
-      this->m_pfGetOptimizerConvergenceValue = std::bind(&_OptimizerType::GetConvergenceValue,optimizer.GetPointer());
+      this->m_pfGetMetricValue = [capture0 = optimizer.GetPointer()] { return capture0->GetCurrentMetricValue(); };
+      this->m_pfGetOptimizerIteration = [capture0 = optimizer.GetPointer()] { return CurrentIterationCustomCast::CustomCast(capture0); };
+      this->m_pfGetOptimizerPosition = [capture0 = optimizer.GetPointer()] { return PositionOptimizerCustomCast::CustomCast(capture0); };
+      this->m_pfGetOptimizerLearningRate = [capture0 = optimizer.GetPointer()] { return capture0->GetLearningRate(); };
+      this->m_pfGetOptimizerConvergenceValue = [capture0 = optimizer.GetPointer()] { return capture0->GetConvergenceValue(); };
       auto x = optimizer.GetPointer();
       this->m_pfGetOptimizerScales = [x]() {
         return PositionOptimizerCustomCast::Helper(x->GetScales());
       };
-      this->m_pfOptimizerStopRegistration = std::bind(&_OptimizerType::StopOptimization, optimizer.GetPointer());
+      this->m_pfOptimizerStopRegistration = [capture0 = optimizer.GetPointer()] { capture0->StopOptimization(); };
 
       optimizer->Register();
       return optimizer.GetPointer();
@@ -157,16 +157,16 @@ namespace simple
       optimizer->SetDoEstimateLearningRateOnce( this->m_OptimizerEstimateLearningRate==Once );
       optimizer->SetMaximumStepSizeInPhysicalUnits( this->m_OptimizerMaximumStepSizeInPhysicalUnits );
 
-      this->m_pfGetMetricValue = std::bind(&_OptimizerType::GetCurrentMetricValue,optimizer.GetPointer());
-      this->m_pfGetOptimizerIteration = std::bind(&CurrentIterationCustomCast::CustomCast,optimizer.GetPointer());
-      this->m_pfGetOptimizerPosition = std::bind(&PositionOptimizerCustomCast::CustomCast,optimizer.GetPointer());
-      this->m_pfGetOptimizerLearningRate = std::bind(&_OptimizerType::GetLearningRate,optimizer.GetPointer());
-      this->m_pfGetOptimizerConvergenceValue = std::bind(&_OptimizerType::GetConvergenceValue,optimizer.GetPointer());
+      this->m_pfGetMetricValue = [capture0 = optimizer.GetPointer()] { return capture0->GetCurrentMetricValue(); };
+      this->m_pfGetOptimizerIteration = [capture0 = optimizer.GetPointer()] { return CurrentIterationCustomCast::CustomCast(capture0); };
+      this->m_pfGetOptimizerPosition = [capture0 = optimizer.GetPointer()] { return PositionOptimizerCustomCast::CustomCast(capture0); };
+      this->m_pfGetOptimizerLearningRate = [capture0 = optimizer.GetPointer()] { return capture0->GetLearningRate(); };
+      this->m_pfGetOptimizerConvergenceValue = [capture0 = optimizer.GetPointer()] { return capture0->GetConvergenceValue(); };
       auto x = optimizer.GetPointer();
       this->m_pfGetOptimizerScales = [x]() {
         return PositionOptimizerCustomCast::Helper(x->GetScales());
       };
-      this->m_pfOptimizerStopRegistration = std::bind(&_OptimizerType::StopOptimization, optimizer.GetPointer());
+      this->m_pfOptimizerStopRegistration = [capture0 = optimizer.GetPointer()] { capture0->StopOptimization(); };
 
 
       optimizer->Register();
@@ -187,16 +187,16 @@ namespace simple
       optimizer->SetMaximumStepSizeInPhysicalUnits( this->m_OptimizerMaximumStepSizeInPhysicalUnits );
       optimizer->Register();
 
-      this->m_pfGetMetricValue = std::bind(&_OptimizerType::GetValue,optimizer);
-      this->m_pfGetOptimizerIteration = std::bind(&CurrentIterationCustomCast::CustomCast,optimizer.GetPointer());
-      this->m_pfGetOptimizerPosition = std::bind(&PositionOptimizerCustomCast::CustomCast,optimizer.GetPointer());
-      this->m_pfGetOptimizerLearningRate = std::bind(&_OptimizerType::GetLearningRate,optimizer.GetPointer());
-      this->m_pfGetOptimizerConvergenceValue = std::bind(&_OptimizerType::GetConvergenceValue,optimizer.GetPointer());
+      this->m_pfGetMetricValue = [optimizer] { return optimizer->GetValue(); };
+      this->m_pfGetOptimizerIteration = [capture0 = optimizer.GetPointer()] { return CurrentIterationCustomCast::CustomCast(capture0); };
+      this->m_pfGetOptimizerPosition = [capture0 = optimizer.GetPointer()] { return PositionOptimizerCustomCast::CustomCast(capture0); };
+      this->m_pfGetOptimizerLearningRate = [capture0 = optimizer.GetPointer()] { return capture0->GetLearningRate(); };
+      this->m_pfGetOptimizerConvergenceValue = [capture0 = optimizer.GetPointer()] { return capture0->GetConvergenceValue(); };
       auto x = optimizer.GetPointer();
       this->m_pfGetOptimizerScales = [x]() {
         return PositionOptimizerCustomCast::Helper(x->GetScales());
       };
-      this->m_pfOptimizerStopRegistration = std::bind(&_OptimizerType::StopOptimization, optimizer.GetPointer());
+      this->m_pfOptimizerStopRegistration = [capture0 = optimizer.GetPointer()] { capture0->StopOptimization(); };
 
 
       return optimizer.GetPointer();
@@ -242,9 +242,9 @@ namespace simple
       optimizer->SetTrace( m_OptimizerTrace );
       optimizer->Register();
 
-      this->m_pfGetMetricValue = std::bind(&_OptimizerType::GetValue,optimizer.GetPointer());
-      this->m_pfGetOptimizerIteration = std::bind(&CurrentIterationCustomCast::CustomCast,optimizer.GetPointer());
-      this->m_pfGetOptimizerPosition = std::bind(&PositionOptimizerCustomCast::CustomCast,optimizer.GetPointer());
+      this->m_pfGetMetricValue = [capture0 = optimizer.GetPointer()] { return capture0->GetValue(); };
+      this->m_pfGetOptimizerIteration = [capture0 = optimizer.GetPointer()] { return CurrentIterationCustomCast::CustomCast(capture0); };
+      this->m_pfGetOptimizerPosition = [capture0 = optimizer.GetPointer()] { return PositionOptimizerCustomCast::CustomCast(capture0); };
       auto x = optimizer.GetPointer();
       this->m_pfGetOptimizerScales = [x]() {
         return PositionOptimizerCustomCast::Helper(x->GetScales());
@@ -270,9 +270,9 @@ namespace simple
       optimizer->SetLineSearchAccuracy( this->m_OptimizerLineSearchAccuracy );
       optimizer->Register();
 
-      this->m_pfGetMetricValue = std::bind(&_OptimizerType::GetValue,optimizer.GetPointer());
-      this->m_pfGetOptimizerIteration = std::bind(&CurrentIterationCustomCast::CustomCast,optimizer.GetPointer());
-      this->m_pfGetOptimizerPosition = std::bind(&PositionOptimizerCustomCast::CustomCast,optimizer.GetPointer());
+      this->m_pfGetMetricValue = [capture0 = optimizer.GetPointer()] { return capture0->GetValue(); };
+      this->m_pfGetOptimizerIteration = [capture0 = optimizer.GetPointer()] { return CurrentIterationCustomCast::CustomCast(capture0); };
+      this->m_pfGetOptimizerPosition = [capture0 = optimizer.GetPointer()] { return PositionOptimizerCustomCast::CustomCast(capture0); };
       auto x = optimizer.GetPointer();
       this->m_pfGetOptimizerScales = [x]() {
         return PositionOptimizerCustomCast::Helper(x->GetScales());
@@ -290,21 +290,18 @@ namespace simple
       optimizer->SetStepLength( this->m_OptimizerStepLength );
       optimizer->SetNumberOfSteps( sitkSTLVectorToITKArray<_OptimizerType::StepsType::ValueType>(this->m_OptimizerNumberOfSteps));
 
-      this->m_pfGetMetricValue = std::bind(&_OptimizerType::GetCurrentValue,optimizer);
-      this->m_pfGetOptimizerIteration = std::bind(&CurrentIterationCustomCast::CustomCast,optimizer.GetPointer());
-      this->m_pfGetOptimizerPosition = std::bind(&PositionOptimizerCustomCast::CustomCast,optimizer);
+      this->m_pfGetMetricValue = [optimizer] { return optimizer->GetCurrentValue(); };
+      this->m_pfGetOptimizerIteration = [capture0 = optimizer.GetPointer()] { return CurrentIterationCustomCast::CustomCast(capture0); };
+      this->m_pfGetOptimizerPosition = [optimizer] { return PositionOptimizerCustomCast::CustomCast(optimizer); };
       auto x = optimizer.GetPointer();
       this->m_pfGetOptimizerScales = [x]() {
         return PositionOptimizerCustomCast::Helper(x->GetScales());
       };
 
 
-      this->m_pfUpdateWithBestValue = std::bind(&UpdateWithBestValueExhaustive<double>,
-                                                  optimizer,
-                                                  &(this->m_MetricValue),
-                                                  std::placeholders::_1);
+      this->m_pfUpdateWithBestValue = [optimizer, capture0 = &(this->m_MetricValue)](auto && PH1) { return UpdateWithBestValueExhaustive<double>(optimizer, capture0, std::forward<decltype(PH1)>(PH1)); };
 
-      this->m_pfOptimizerStopRegistration = std::bind(&_OptimizerType::StopWalking, optimizer.GetPointer());
+      this->m_pfOptimizerStopRegistration = [capture0 = optimizer.GetPointer()] { capture0->StopWalking(); };
 
       optimizer->Register();
       return optimizer.GetPointer();
@@ -324,9 +321,9 @@ namespace simple
       optimizer->SetOptimizeWithRestarts(this->m_OptimizerWithRestarts);
 
 
-      this->m_pfGetMetricValue = std::bind(&_OptimizerType::GetValue,optimizer);
-      this->m_pfGetOptimizerIteration = std::bind(&CurrentIterationCustomCast::CustomCast,optimizer.GetPointer());
-      this->m_pfGetOptimizerPosition = std::bind(&PositionOptimizerCustomCast::CustomCast,optimizer);
+      this->m_pfGetMetricValue = [optimizer] { return optimizer->GetValue(); };
+      this->m_pfGetOptimizerIteration = [capture0 = optimizer.GetPointer()] { return CurrentIterationCustomCast::CustomCast(capture0); };
+      this->m_pfGetOptimizerPosition = [optimizer] { return PositionOptimizerCustomCast::CustomCast(optimizer); };
       auto x = optimizer.GetPointer();
       this->m_pfGetOptimizerScales = [x]() {
         return PositionOptimizerCustomCast::Helper(x->GetScales());
@@ -348,14 +345,14 @@ namespace simple
       optimizer->SetStepTolerance( this->m_OptimizerStepTolerance );
       optimizer->SetValueTolerance( this->m_OptimizerValueTolerance );
 
-      this->m_pfGetMetricValue = std::bind(&_OptimizerType::GetValue,optimizer.GetPointer());
-      this->m_pfGetOptimizerIteration = std::bind(&CurrentIterationCustomCast::CustomCast,optimizer.GetPointer());
-      this->m_pfGetOptimizerPosition = std::bind(&PositionOptimizerCustomCast::CustomCast,optimizer.GetPointer());
+      this->m_pfGetMetricValue = [capture0 = optimizer.GetPointer()] { return capture0->GetValue(); };
+      this->m_pfGetOptimizerIteration = [capture0 = optimizer.GetPointer()] { return CurrentIterationCustomCast::CustomCast(capture0); };
+      this->m_pfGetOptimizerPosition = [capture0 = optimizer.GetPointer()] { return PositionOptimizerCustomCast::CustomCast(capture0); };
       auto x = optimizer.GetPointer();
       this->m_pfGetOptimizerScales = [x]() {
         return PositionOptimizerCustomCast::Helper(x->GetScales());
       };
-      this->m_pfOptimizerStopRegistration = std::bind(&_OptimizerType::StopOptimization, optimizer.GetPointer());
+      this->m_pfOptimizerStopRegistration = [capture0 = optimizer.GetPointer()] { capture0->StopOptimization(); };
 
 
       optimizer->Register();
@@ -387,15 +384,15 @@ namespace simple
         }
       optimizer->SetNormalVariateGenerator( generator );
 
-      this->m_pfGetMetricValue = std::bind(&_OptimizerType::GetValue,optimizer.GetPointer());
-      this->m_pfGetOptimizerIteration = std::bind(&CurrentIterationCustomCast::CustomCast,optimizer.GetPointer());
-      this->m_pfGetOptimizerPosition = std::bind(&PositionOptimizerCustomCast::CustomCast,optimizer.GetPointer());
-      this->m_pfGetOptimizerConvergenceValue = std::bind(&_OptimizerType::GetFrobeniusNorm,optimizer.GetPointer());
+      this->m_pfGetMetricValue = [capture0 = optimizer.GetPointer()] { return capture0->GetValue(); };
+      this->m_pfGetOptimizerIteration = [capture0 = optimizer.GetPointer()] { return CurrentIterationCustomCast::CustomCast(capture0); };
+      this->m_pfGetOptimizerPosition = [capture0 = optimizer.GetPointer()] { return PositionOptimizerCustomCast::CustomCast(capture0); };
+      this->m_pfGetOptimizerConvergenceValue = [capture0 = optimizer.GetPointer()] { return capture0->GetFrobeniusNorm(); };
       auto x = optimizer.GetPointer();
       this->m_pfGetOptimizerScales = [x]() {
         return PositionOptimizerCustomCast::Helper(x->GetScales());
       };
-      this->m_pfOptimizerStopRegistration = std::bind(&_OptimizerType::StopOptimization, optimizer.GetPointer());
+      this->m_pfOptimizerStopRegistration = [capture0 = optimizer.GetPointer()] { capture0->StopOptimization(); };
 
       optimizer->Register();
       return optimizer.GetPointer();

--- a/ExpandTemplateGenerator/Components/ExecuteInternalUpdateAndReturn.cxx.in
+++ b/ExpandTemplateGenerator/Components/ExecuteInternalUpdateAndReturn.cxx.in
@@ -36,19 +36,39 @@ end
 $(if measurements then
 for i = 1,#measurements do
   if measurements[i].active then
-    OUT=OUT..'  this->m_pfGet'..measurements[i].name..' = std::bind('
-    if measurements[i].custom_cast or measurements[i].label_map or measurements[i].itk_get then
-      OUT=OUT..'&'..measurements[i].name..'CustomCast<FilterType>::CustomCast'
-    else
-      OUT=OUT..'&FilterType::Get'..measurements[i].name
-    end
-    OUT=OUT..', filter.GetPointer()'
+    OUT=OUT..'  this->m_pfGet'..measurements[i].name..' = [filter = filter.GetPointer()] '
     if measurements[i].parameters then
+      OUT=OUT..'( '
       for inum=1,#measurements[i].parameters do
-        OUT=OUT..", std::placeholders::_"..inum
+        if (inum ~= 1) then
+          OUT=OUT..', '
+        end
+        OUT=OUT.."auto && PH"..inum
+      end
+      OUT=OUT..') '
+    end
+    OUT=OUT..' { '
+    if measurements[i].custom_cast or measurements[i].label_map or measurements[i].itk_get then
+      OUT=OUT..'return '..measurements[i].name..'CustomCast<FilterType>::CustomCast'
+    else
+      OUT=OUT..'return filter->Get'..measurements[i].name
+    end
+    OUT=OUT..'( '
+    if measurements[i].custom_cast or measurements[i].label_map or measurements[i].itk_get then
+      OUT=OUT..'filter '
+      if measurements[i].parameters then
+        OUT=OUT..', '
       end
     end
-    OUT=OUT..' );\
+    if measurements[i].parameters then
+      for inum=1,#measurements[i].parameters do
+        if (inum ~= 1) then
+          OUT=OUT..', '
+        end
+        OUT=OUT.."std::forward<decltype(PH"..inum..")>(PH"..inum..")"
+      end
+    end
+    OUT=OUT..'); };\
 '
   end
 end


### PR DESCRIPTION
Use clang-tidy with modernize-avoid-bind to migrate to lambda functions over std::bind. A few manual clean up were needed  along with some manual migration of code generation and a couple files.