### PR TITLE
Remove end namespace comments

### DIFF
--- a/Code/BasicFilters/include/itkHashImageFilter.h
+++ b/Code/BasicFilters/include/itkHashImageFilter.h
@@ -109,7 +109,7 @@ private:
 };
 
 
-} // end namespace itk
+}
 
 
 #include "itkHashImageFilter.hxx"

--- a/Code/BasicFilters/include/itkHashImageFilter.hxx
+++ b/Code/BasicFilters/include/itkHashImageFilter.hxx
@@ -194,6 +194,6 @@ HashImageFilter<TImageType>::PrintSelf(std::ostream & os, Indent indent) const
 }
 
 
-} // end namespace itk
+}
 
 #endif // itkHashImageFilter_hxx

--- a/Code/BasicFilters/src/sitkBSplineTransformInitializerFilter.cxx
+++ b/Code/BasicFilters/src/sitkBSplineTransformInitializerFilter.cxx
@@ -176,4 +176,4 @@ BSplineTransform BSplineTransformInitializer ( const Image& image1, const std::v
 }
 
 
-} // end namespace itk
+}

--- a/Code/BasicFilters/src/sitkCastImageFilter-2.cxx
+++ b/Code/BasicFilters/src/sitkCastImageFilter-2.cxx
@@ -36,4 +36,4 @@ void CastImageFilter::RegisterMemberFactory2()
 
 }
 
-} // end namespace itk
+}

--- a/Code/BasicFilters/src/sitkCastImageFilter-2l.cxx
+++ b/Code/BasicFilters/src/sitkCastImageFilter-2l.cxx
@@ -32,4 +32,4 @@ void CastImageFilter::RegisterMemberFactory2l()
   m_DualMemberFactory->RegisterMemberFunctions<LabelPixelIDTypeList, IntegerPixelIDTypeList, 2, LabelToAddressor<MemberFunctionType> > ();
 }
 
-} // end namespace itk
+}

--- a/Code/BasicFilters/src/sitkCastImageFilter-2v.cxx
+++ b/Code/BasicFilters/src/sitkCastImageFilter-2v.cxx
@@ -34,4 +34,4 @@ void CastImageFilter::RegisterMemberFactory2v()
 
 }
 
-} // end namespace itk
+}

--- a/Code/BasicFilters/src/sitkCastImageFilter-3.cxx
+++ b/Code/BasicFilters/src/sitkCastImageFilter-3.cxx
@@ -36,4 +36,4 @@ void CastImageFilter::RegisterMemberFactory3()
 
 }
 
-} // end namespace itk
+}

--- a/Code/BasicFilters/src/sitkCastImageFilter-3l.cxx
+++ b/Code/BasicFilters/src/sitkCastImageFilter-3l.cxx
@@ -33,4 +33,4 @@ void CastImageFilter::RegisterMemberFactory3l()
 
 }
 
-} // end namespace itk
+}

--- a/Code/BasicFilters/src/sitkCastImageFilter-3v.cxx
+++ b/Code/BasicFilters/src/sitkCastImageFilter-3v.cxx
@@ -33,4 +33,4 @@ void CastImageFilter::RegisterMemberFactory3v()
   m_DualMemberFactory->RegisterMemberFunctions<BasicPixelIDTypeList, VectorPixelIDTypeList, 3, ToVectorAddressor<MemberFunctionType> > ();
 }
 
-} // end namespace itk
+}

--- a/Code/BasicFilters/src/sitkCastImageFilter-4.cxx
+++ b/Code/BasicFilters/src/sitkCastImageFilter-4.cxx
@@ -36,4 +36,4 @@ void CastImageFilter::RegisterMemberFactory4()
 #endif
 }
 
-} // end namespace itk
+}

--- a/Code/BasicFilters/src/sitkCastImageFilter.cxx
+++ b/Code/BasicFilters/src/sitkCastImageFilter.cxx
@@ -106,4 +106,4 @@ Image Cast ( const Image& image, PixelIDValueEnum pixelID ) {
 }
 
 
-} // end namespace itk
+}

--- a/Code/BasicFilters/src/sitkCastImageFilter.hxx
+++ b/Code/BasicFilters/src/sitkCastImageFilter.hxx
@@ -127,6 +127,6 @@ Image CastImageFilter::ExecuteInternalLabelToImage( const Image& inImage )
   return Image( filter->GetOutput() );
 }
 
-} // end namespace itk
+}
 
 #endif // sitkCastImageFilter_hxx

--- a/Code/BasicFilters/src/sitkCenteredTransformInitializerFilter.cxx
+++ b/Code/BasicFilters/src/sitkCenteredTransformInitializerFilter.cxx
@@ -157,4 +157,4 @@ Transform CenteredTransformInitializer ( const Image & fixedImage, const Image &
   return filter.Execute( fixedImage, movingImage, transform );
 }
 
-} // end namespace itk
+}

--- a/Code/BasicFilters/src/sitkCenteredVersorTransformInitializerFilter.cxx
+++ b/Code/BasicFilters/src/sitkCenteredVersorTransformInitializerFilter.cxx
@@ -149,4 +149,4 @@ Transform CenteredVersorTransformInitializer ( const Image & fixedImage, const I
   return filter.Execute( fixedImage, movingImage, transform  );
 }
 
-} // end namespace itk
+}

--- a/Code/BasicFilters/src/sitkCreateKernel.h
+++ b/Code/BasicFilters/src/sitkCreateKernel.h
@@ -63,7 +63,7 @@ CreateKernel( KernelEnum kernelType, const std::vector<uint32_t> &size )
 }
 
 
-} // end namespace itk
+}
 
 
 #endif // sitkCreateKernel_h

--- a/Code/BasicFilters/src/sitkExtractImageFilter.cxx
+++ b/Code/BasicFilters/src/sitkExtractImageFilter.cxx
@@ -203,4 +203,4 @@ Image Extract ( Image&& image1, std::vector<unsigned int> size, std::vector<int>
   return filter.Execute ( std::move(image1) );
 }
 
-} // end namespace itk
+}

--- a/Code/BasicFilters/src/sitkImageFilter.cxx
+++ b/Code/BasicFilters/src/sitkImageFilter.cxx
@@ -89,4 +89,4 @@ void ImageFilter::CheckImageMatchingSize(const Image &image1, const Image& image
   return itk::simple::CheckImageMatchingSize(image1, image2, image2Name, this->GetName());
 }
 
-} // end namespace itk
+}

--- a/Code/BasicFilters/src/sitkImageToKernel.hxx
+++ b/Code/BasicFilters/src/sitkImageToKernel.hxx
@@ -83,6 +83,6 @@ return kernelOperator;
 }
 
 }
-} // end namespace itk
+}
 
 #endif

--- a/Code/BasicFilters/src/sitkLandmarkBasedTransformInitializerFilter.cxx
+++ b/Code/BasicFilters/src/sitkLandmarkBasedTransformInitializerFilter.cxx
@@ -214,4 +214,4 @@ Transform LandmarkBasedTransformInitializer ( const Transform & transform,
 }
 
 
-} // end namespace itk
+}

--- a/Code/BasicFilters/src/sitkPasteImageFilter.cxx
+++ b/Code/BasicFilters/src/sitkPasteImageFilter.cxx
@@ -316,4 +316,4 @@ Image Paste ( Image && destinationImage, const Image & sourceImage, std::vector<
   return filter.Execute ( std::move(destinationImage), sourceImage );
 }
 
-} // end namespace itk
+}

--- a/Code/BasicFilters/templates/sitkBinaryFunctorFilterTemplate.cxx.in
+++ b/Code/BasicFilters/templates/sitkBinaryFunctorFilterTemplate.cxx.in
@@ -228,4 +228,4 @@ Image ${name:gsub("ImageFilter$", ""):gsub("Filter$", "")} ( ${constant_type} co
                             end) );
 }
 $(if not #members==0 then OUT=[[#error BinaryFunctorTemplate does not support members, yet]]end)
-} // end namespace itk
+}

--- a/Code/Common/include/Ancillary/type_list2.h
+++ b/Code/Common/include/Ancillary/type_list2.h
@@ -251,5 +251,5 @@ private:
 };
 
 
-} // namespace typelist2
+}
 #endif // typelist_h_

--- a/Code/Common/include/itkHolderCommand.h
+++ b/Code/Common/include/itkHolderCommand.h
@@ -101,6 +101,6 @@ private:
 
 };
 
-} // end namespace
+}
 
 #endif

--- a/Code/Common/include/sitkCommand.h
+++ b/Code/Common/include/sitkCommand.h
@@ -76,6 +76,6 @@ protected:
 #endif
 };
 
-} // end namespace itk
+}
 
 #endif

--- a/Code/Common/include/sitkCreateInterpolator.hxx
+++ b/Code/Common/include/sitkCreateInterpolator.hxx
@@ -294,7 +294,7 @@ CreateInterpolator(const TImageType *image, InterpolatorEnum itype) {
 }
 
 }
-} // end namespace itk
+}
 
 
 #endif // sitkCreateInterpolator_hxx

--- a/Code/Common/include/sitkDualMemberFunctionFactory.h
+++ b/Code/Common/include/sitkDualMemberFunctionFactory.h
@@ -179,7 +179,7 @@ protected:
 
 };
 
-} // end namespace itk
+}
 
 #include "sitkDualMemberFunctionFactory.hxx"
 

--- a/Code/Common/include/sitkDualMemberFunctionFactory.hxx
+++ b/Code/Common/include/sitkDualMemberFunctionFactory.hxx
@@ -190,7 +190,7 @@ DualMemberFunctionFactory< TMemberFunctionPointer >
 }
 
 
-} // end namespace itk
+}
 
 
 #endif //  sitkDualMemberFunctionFactory_hxx

--- a/Code/Common/include/sitkEvent.h
+++ b/Code/Common/include/sitkEvent.h
@@ -65,6 +65,6 @@ enum EventEnum {
 SITKCommon_EXPORT std::ostream& operator<<(std::ostream& os, const EventEnum k);
 #endif
 
-} // end namespace itk
+}
 
 #endif

--- a/Code/Common/include/sitkFunctionCommand.h
+++ b/Code/Common/include/sitkFunctionCommand.h
@@ -72,6 +72,6 @@ private:
 
 };
 
-} // end namespace itk
+}
 
 #endif

--- a/Code/Common/include/sitkInterpolator.h
+++ b/Code/Common/include/sitkInterpolator.h
@@ -166,7 +166,7 @@ enum InterpolatorEnum {
 SITKCommon_EXPORT std::ostream& operator<<(std::ostream& os, const InterpolatorEnum i);
 #endif
 
-} // end namespace itk
+}
 
 
 #endif // sitkInterpolator_h

--- a/Code/Common/include/sitkKernel.h
+++ b/Code/Common/include/sitkKernel.h
@@ -64,7 +64,7 @@ enum KernelEnum {
 SITKCommon_EXPORT std::ostream& operator<<(std::ostream& os, const KernelEnum k);
 #endif
 
-} // end namespace itk
+}
 
 
 #endif // sitkKernel_h

--- a/Code/Common/include/sitkLogger.h
+++ b/Code/Common/include/sitkLogger.h
@@ -146,7 +146,7 @@ private:
   itk::OutputWindow * m_OutputWindow{ nullptr };
 };
 
-} // namespace simple
-} // namespace itk
+}
+}
 
 #endif

--- a/Code/Common/include/sitkMemberFunctionFactory.h
+++ b/Code/Common/include/sitkMemberFunctionFactory.h
@@ -184,7 +184,7 @@ protected:
 
 };
 
-} // end namespace itk
+}
 
 #include "sitkMemberFunctionFactory.hxx"
 

--- a/Code/Common/include/sitkMemberFunctionFactory.hxx
+++ b/Code/Common/include/sitkMemberFunctionFactory.hxx
@@ -154,7 +154,7 @@ MemberFunctionFactory<TMemberFunctionPointer>
 }
 
 
-} // end namespace itk
+}
 
 
 #endif //  sitkMemberFunctionFactory_h

--- a/Code/Common/include/sitkMemberFunctionFactoryBase.h
+++ b/Code/Common/include/sitkMemberFunctionFactoryBase.h
@@ -424,6 +424,6 @@ protected:
 
 };
 
-} // end namespace itk
+}
 
 #endif // sitkMemberFunctionFactoryBase_h

--- a/Code/Common/include/sitkNonCopyable.h
+++ b/Code/Common/include/sitkNonCopyable.h
@@ -56,6 +56,6 @@ public:
 };
 
 
-} // end namespace itk
+}
 
 #endif //  sitkNonCopyable_h

--- a/Code/Common/include/sitkObjectOwnedBase.h
+++ b/Code/Common/include/sitkObjectOwnedBase.h
@@ -119,6 +119,6 @@ private:
   std::string                                         m_Name;
 };
 
-} // namespace simple
-} // namespace itk
+}
+}
 #endif

--- a/Code/Common/include/sitkRandomSeed.h
+++ b/Code/Common/include/sitkRandomSeed.h
@@ -29,7 +29,7 @@ enum SeedEnum {
   sitkWallClock = 0
 };
 
-} // end namespace itk
+}
 
 
 #endif // RandomSeed_h

--- a/Code/Common/src/sitkCommand.cxx
+++ b/Code/Common/src/sitkCommand.cxx
@@ -57,4 +57,4 @@ size_t Command::RemoveProcessObject(const itk::simple::ProcessObject *co)
 }
 
 
-} // end namespace itk
+}

--- a/Code/Common/src/sitkEvent.cxx
+++ b/Code/Common/src/sitkEvent.cxx
@@ -40,4 +40,4 @@ std::ostream& operator<<(std::ostream& os, const EventEnum k)
   return os;
 }
 
-} // end namespace itk
+}

--- a/Code/Common/src/sitkFunctionCommand.cxx
+++ b/Code/Common/src/sitkFunctionCommand.cxx
@@ -51,4 +51,4 @@ void FunctionCommand::SetCallbackFunction(const std::function<void()> &func)
   m_Function = func;
 }
 
-} // end namespace itk
+}

--- a/Code/Common/src/sitkImage.cxx
+++ b/Code/Common/src/sitkImage.cxx
@@ -840,4 +840,4 @@ namespace itk::simple
       assert( m_PimpleImage );
       return this->m_PimpleImage->GetReferenceCountOfImage() == 1;
     }
-  } // end namespace itk
+  }

--- a/Code/Common/src/sitkImage.hxx
+++ b/Code/Common/src/sitkImage.hxx
@@ -234,6 +234,6 @@ namespace itk::simple
   }
 
 
-  } // namespace itk
+  }
 
 #endif // sitkImage_h

--- a/Code/Common/src/sitkInterpolator.cxx
+++ b/Code/Common/src/sitkInterpolator.cxx
@@ -53,4 +53,4 @@ std::ostream& operator<<(std::ostream& os, const InterpolatorEnum i)
   return os;
 }
 
-} // end namespace itk
+}

--- a/Code/Common/src/sitkKernel.cxx
+++ b/Code/Common/src/sitkKernel.cxx
@@ -42,4 +42,4 @@ std::ostream& operator<<(std::ostream& os, const KernelEnum k)
   return os;
 }
 
-} // end namespace itk
+}

--- a/Code/Common/src/sitkLogger.cxx
+++ b/Code/Common/src/sitkLogger.cxx
@@ -117,7 +117,7 @@ protected:
 };
 
 
-} // namespace
+}
 
 LoggerBase::~LoggerBase() {}
 
@@ -296,4 +296,4 @@ ITKLogger::SetAsGlobalITKLogger()
   return oldLogger;
 }
 
-} // namespace itk
+}

--- a/Code/Common/src/sitkObjectOwnedBase.cxx
+++ b/Code/Common/src/sitkObjectOwnedBase.cxx
@@ -123,4 +123,4 @@ void ObjectOwnedBase::ExecuteCallbacks()
   }
 }
 
-} // namespace itk
+}

--- a/Code/Common/src/sitkPimpleImageBase.h
+++ b/Code/Common/src/sitkPimpleImageBase.h
@@ -156,7 +156,7 @@ namespace itk::simple
     virtual const void     *GetBufferAsVoid( ) const = 0;
   };
 
-  } // end namespace itk
+  }
 
 
 #endif // sitkPimpleImageBase_h

--- a/Code/Common/src/sitkPimpleImageBase.hxx
+++ b/Code/Common/src/sitkPimpleImageBase.hxx
@@ -970,6 +970,6 @@ namespace itk::simple
 
   }
 
-  } // end namespace itk
+  }
 
 #endif // sitkPimpleImageBase_hxx

--- a/Code/Common/src/sitkProcessObject.cxx
+++ b/Code/Common/src/sitkProcessObject.cxx
@@ -93,7 +93,7 @@ protected:
   ~SimpleAdaptorCommand() override = default;
 };
 
-} // end anonymous namespace
+}
 
 //----------------------------------------------------------------------------
 
@@ -591,4 +591,4 @@ void ProcessObject::RemoveObserverFromActiveProcessObject( EventCommand &e )
 
  }
 
-} // end namespace itk
+}

--- a/Code/ElastixTransformixWrappers/include/sitkElastixImageFilter.h
+++ b/Code/ElastixTransformixWrappers/include/sitkElastixImageFilter.h
@@ -340,7 +340,7 @@ SITKElastix_EXPORT Image Elastix( const Image& fixedImage, const Image& movingIm
 SITKElastix_EXPORT Image Elastix( const Image& fixedImage, const Image& movingImage, const std::map< std::string, std::vector< std::string > >, const Image& fixedMask, const Image& movingMask, const bool logToConsole = false, const bool logToFile = false, const std::string outputDirectory = "." );
 SITKElastix_EXPORT Image Elastix( const Image& fixedImage, const Image& movingImage, std::vector< std::map< std::string, std::vector< std::string > > > parameterMapVector, const Image& fixedMask, const Image& movingMask, const bool logToConsole = false, const bool logToFile = false, const std::string outputDirectory = "." );
 
-} // end namespace simple
-} // end namespace itk
+}
+}
 
 #endif // sitkElastixImageFilter_h

--- a/Code/ElastixTransformixWrappers/include/sitkTransformixImageFilter.h
+++ b/Code/ElastixTransformixWrappers/include/sitkTransformixImageFilter.h
@@ -131,7 +131,7 @@ private:
 SITKElastix_EXPORT Image Transformix( const Image& movingImage, const std::map< std::string, std::vector< std::string > > parameterMap, const bool logToConsole = false, const std::string outputDirectory = "." );
 SITKElastix_EXPORT Image Transformix( const Image& movingImage, const std::vector< std::map< std::string, std::vector< std::string > > > parameterMapVector, const bool logToConsole = false, const std::string outputDirectory = "." );
 
-} // end namespace simple
-} // end namespace itk
+}
+}
 
 #endif // sitkTransformixImageFilter_h

--- a/Code/ElastixTransformixWrappers/src/sitkElastixImageFilter.cxx
+++ b/Code/ElastixTransformixWrappers/src/sitkElastixImageFilter.cxx
@@ -795,5 +795,5 @@ Elastix( const Image& fixedImage, const Image& movingImage, ElastixImageFilter::
   return selx.Execute();
 }
 
-} // end namespace simple
-} // end namespace itk
+}
+}

--- a/Code/ElastixTransformixWrappers/src/sitkElastixImageFilterImpl.cxx
+++ b/Code/ElastixTransformixWrappers/src/sitkElastixImageFilterImpl.cxx
@@ -1077,5 +1077,5 @@ ElastixImageFilter::ElastixImageFilterImpl
   return isEmpty;
 }
 
-} // end namespace simple
-} // end namespace itk
+}
+}

--- a/Code/ElastixTransformixWrappers/src/sitkElastixImageFilterImpl.h
+++ b/Code/ElastixTransformixWrappers/src/sitkElastixImageFilterImpl.h
@@ -170,7 +170,7 @@ public:
 
 };
 
-} // end namespace simple
-} // end namespace itk
+}
+}
 
 #endif // sitkelastiximagefilterimpl_h

--- a/Code/ElastixTransformixWrappers/src/sitkInternalUtilities.h
+++ b/Code/ElastixTransformixWrappers/src/sitkInternalUtilities.h
@@ -12,7 +12,7 @@ namespace itk {
 */
 using FloatPixelIDTypeList = typelist2::typelist<BasicPixelID<float>>;
 
-} // end namespace simple
-} // end namespace itk
+}
+}
 
 #endif

--- a/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilter.cxx
+++ b/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilter.cxx
@@ -467,5 +467,5 @@ Transformix( const Image& movingImage, const TransformixImageFilter::ParameterMa
   return stfx.Execute();
 }
 
-} // end namespace simple
-} // end namespace itk
+}
+}

--- a/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilterImpl.cxx
+++ b/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilterImpl.cxx
@@ -700,5 +700,5 @@ TransformixImageFilter::TransformixImageFilterImpl
   return isEmpty;
 }
 
-} // end namespace simple
-} // end namespace itk
+}
+}

--- a/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilterImpl.h
+++ b/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilterImpl.h
@@ -130,7 +130,7 @@ public:
   bool                    m_LogToFile;
 };
 
-} // end namespace simple
-} // end namespace itk
+}
+}
 
 #endif // sitktransformiximagefilterimpl_h

--- a/Code/IO/src/sitkImageFileWriter.cxx
+++ b/Code/IO/src/sitkImageFileWriter.cxx
@@ -246,4 +246,4 @@ ImageFileWriter& ImageFileWriter::ExecuteInternal( const Image& inImage )
   return *this;
 }
 
-} // end namespace itk
+}

--- a/Code/IO/src/sitkImageViewer.cxx
+++ b/Code/IO/src/sitkImageViewer.cxx
@@ -875,4 +875,4 @@ std::string BuildFullFileName(const std::string & name, const std::string & exte
 
 }
 
-  } // namespace itk
+  }

--- a/Examples/DicomSeriesReader/DicomSeriesReader.cs
+++ b/Examples/DicomSeriesReader/DicomSeriesReader.cs
@@ -57,5 +57,5 @@ static void Main(string[] args) {
   }
 }
 
-    } // class DicomSeriesReader
-} // namespace itk.simple.examples
+    }
+}

--- a/Examples/SimpleIO/SimpleIO.cs
+++ b/Examples/SimpleIO/SimpleIO.cs
@@ -72,5 +72,5 @@ static void Main(string[] args) {
   }
 }
 
-    } // class SimpleIO
-} // namespace itk.simple.examples
+    }
+}

--- a/Testing/Unit/sitkElastixImageFilterTests.cxx
+++ b/Testing/Unit/sitkElastixImageFilterTests.cxx
@@ -364,5 +364,5 @@ TEST(ElastixImageFilter, GetParameterWhenOneParameterMapIsPresent)
     EXPECT_EQ(silx.GetParameter(key), values);
 }
 
-} // namespace simple
-} // namespace itk
+}
+}

--- a/Testing/Unit/sitkTransformixImageFilterTests.cxx
+++ b/Testing/Unit/sitkTransformixImageFilterTests.cxx
@@ -143,5 +143,5 @@ TEST( TransformixImageFilter, Transformation4D )
 
 #endif
 
-} // namespace simple
-} // namespace itk
+}
+}

--- a/Wrapping/Python/sitkPyCommand.cxx
+++ b/Wrapping/Python/sitkPyCommand.cxx
@@ -138,5 +138,5 @@ void PyCommand::Execute()
 }
 
 
-} // namespace simple
-} // namespace itk
+}
+}

--- a/Wrapping/Python/sitkPyCommand.h
+++ b/Wrapping/Python/sitkPyCommand.h
@@ -75,7 +75,7 @@ private:
   PyObject *m_Object;
 };
 
-} // namespace simple
-} // namespace itk
+}
+}
 
 #endif // _sitkPyCommand_h

--- a/Wrapping/R/sitkRCommand.cxx
+++ b/Wrapping/R/sitkRCommand.cxx
@@ -119,5 +119,5 @@ void RCommand::Execute()
 }
 
 
-} // namespace simple
-} // namespace itk
+}
+}

--- a/Wrapping/R/sitkRCommand.h
+++ b/Wrapping/R/sitkRCommand.h
@@ -93,7 +93,7 @@ private:
   SEXP m_FunctionClosure;
 };
 
-} // namespace simple
-} // namespace itk
+}
+}
 
 #endif // _sitkRCommand_h


### PR DESCRIPTION
With the usage of concatinated namespaces, the comments are no longer needed.