### PR TITLE
Update Elastix with clang-tidy

### DIFF
--- a/Code/ElastixTransformixWrappers/include/sitkElastixImageFilter.h
+++ b/Code/ElastixTransformixWrappers/include/sitkElastixImageFilter.h
@@ -27,8 +27,7 @@
 #include <string>
 #include <vector>
 
-namespace itk {
-  namespace simple {
+namespace itk::simple {
 
 /** \class ElastixImageFilter
 * \brief The class that wraps the elastix registration library.
@@ -340,7 +339,6 @@ SITKElastix_EXPORT Image Elastix( const Image& fixedImage, const Image& movingIm
 SITKElastix_EXPORT Image Elastix( const Image& fixedImage, const Image& movingImage, const std::map< std::string, std::vector< std::string > >, const Image& fixedMask, const Image& movingMask, const bool logToConsole = false, const bool logToFile = false, const std::string outputDirectory = "." );
 SITKElastix_EXPORT Image Elastix( const Image& fixedImage, const Image& movingImage, std::vector< std::map< std::string, std::vector< std::string > > > parameterMapVector, const Image& fixedMask, const Image& movingMask, const bool logToConsole = false, const bool logToFile = false, const std::string outputDirectory = "." );
 
-}
 }
 
 #endif // sitkElastixImageFilter_h

--- a/Code/ElastixTransformixWrappers/include/sitkTransformixImageFilter.h
+++ b/Code/ElastixTransformixWrappers/include/sitkTransformixImageFilter.h
@@ -27,8 +27,7 @@
 #include <string>
 #include <vector>
 
-namespace itk {
-  namespace simple {
+namespace itk::simple {
 
 class SITKElastix_EXPORT TransformixImageFilter
 {
@@ -131,7 +130,6 @@ private:
 SITKElastix_EXPORT Image Transformix( const Image& movingImage, const std::map< std::string, std::vector< std::string > > parameterMap, const bool logToConsole = false, const std::string outputDirectory = "." );
 SITKElastix_EXPORT Image Transformix( const Image& movingImage, const std::vector< std::map< std::string, std::vector< std::string > > > parameterMapVector, const bool logToConsole = false, const std::string outputDirectory = "." );
 
-}
 }
 
 #endif // sitkTransformixImageFilter_h

--- a/Code/ElastixTransformixWrappers/src/sitkElastixImageFilter.cxx
+++ b/Code/ElastixTransformixWrappers/src/sitkElastixImageFilter.cxx
@@ -1,8 +1,7 @@
 #include "sitkElastixImageFilter.h"
 #include "sitkElastixImageFilterImpl.h"
 
-namespace itk {
-  namespace simple {
+namespace itk::simple {
 
 ElastixImageFilter
 ::ElastixImageFilter() : m_Pimple(std::make_unique<ElastixImageFilterImpl>())
@@ -795,5 +794,4 @@ Elastix( const Image& fixedImage, const Image& movingImage, ElastixImageFilter::
   return selx.Execute();
 }
 
-}
 }

--- a/Code/ElastixTransformixWrappers/src/sitkElastixImageFilterImpl.cxx
+++ b/Code/ElastixTransformixWrappers/src/sitkElastixImageFilterImpl.cxx
@@ -1,16 +1,17 @@
+#include <memory>
+
 #include "sitkElastixImageFilter.h"
 #include "sitkElastixImageFilterImpl.h"
 #include "sitkCastImageFilter.h"
 #include "sitkInternalUtilities.h"
 
-namespace itk {
-  namespace simple {
+namespace itk::simple {
 
 ElastixImageFilter::ElastixImageFilterImpl
 ::ElastixImageFilterImpl( void )
 {
   // Register this class with SimpleITK
-  this->m_DualMemberFactory.reset( new detail::DualMemberFunctionFactory< MemberFunctionType >( this ) );
+  this->m_DualMemberFactory = std::make_unique<detail::DualMemberFunctionFactory< MemberFunctionType >>( this );
   this->m_DualMemberFactory->RegisterMemberFunctions< FloatPixelIDTypeList, FloatPixelIDTypeList, 2 >();
   this->m_DualMemberFactory->RegisterMemberFunctions< FloatPixelIDTypeList, FloatPixelIDTypeList, 3 >();
 
@@ -1077,5 +1078,4 @@ ElastixImageFilter::ElastixImageFilterImpl
   return isEmpty;
 }
 
-}
 }

--- a/Code/ElastixTransformixWrappers/src/sitkElastixImageFilterImpl.h
+++ b/Code/ElastixTransformixWrappers/src/sitkElastixImageFilterImpl.h
@@ -10,8 +10,7 @@
 #include "itkElastixRegistrationMethod.h"
 #include "elxParameterObject.h"
 
-namespace itk {
-  namespace simple {
+namespace itk::simple {
 
 class SITKElastix_HIDDEN ElastixImageFilter::ElastixImageFilterImpl
 {
@@ -170,7 +169,6 @@ public:
 
 };
 
-}
 }
 
 #endif // sitkelastiximagefilterimpl_h

--- a/Code/ElastixTransformixWrappers/src/sitkInternalUtilities.h
+++ b/Code/ElastixTransformixWrappers/src/sitkInternalUtilities.h
@@ -3,8 +3,7 @@
 
 #include "Ancillary/type_list2.h"
 
-namespace itk {
-  namespace simple {
+namespace itk::simple {
 
 /** SimpleElastix and SimpleTransformix is compiled with float pixel type only. This
 * saves compile time and reduces binary size. Images are automatically casted to and
@@ -12,7 +11,6 @@ namespace itk {
 */
 using FloatPixelIDTypeList = typelist2::typelist<BasicPixelID<float>>;
 
-}
 }
 
 #endif

--- a/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilter.cxx
+++ b/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilter.cxx
@@ -1,8 +1,7 @@
 #include "sitkTransformixImageFilter.h"
 #include "sitkTransformixImageFilterImpl.h"
 
-namespace itk {
-  namespace simple {
+namespace itk::simple {
 
 TransformixImageFilter
 ::TransformixImageFilter() : m_Pimple(std::make_unique<TransformixImageFilterImpl>())
@@ -467,5 +466,4 @@ Transformix( const Image& movingImage, const TransformixImageFilter::ParameterMa
   return stfx.Execute();
 }
 
-}
 }

--- a/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilterImpl.cxx
+++ b/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilterImpl.cxx
@@ -1,11 +1,12 @@
+#include <memory>
+
 #include "sitkTransformixImageFilter.h"
 #include "sitkTransformixImageFilterImpl.h"
 #include "sitkCastImageFilter.h"
 #include "sitkImageConvert.h"
 #include "sitkInternalUtilities.h"
 
-namespace itk {
-  namespace simple {
+namespace itk::simple {
 
       namespace {
           const std::string GetPixelIDValueAsElastixParameter(PixelIDValueType type)
@@ -117,7 +118,7 @@ TransformixImageFilter::TransformixImageFilterImpl
 ::TransformixImageFilterImpl()
 {
   // Register this class with SimpleITK
-  this->m_MemberFactory.reset( new detail::MemberFunctionFactory< MemberFunctionType >( this ) );
+  this->m_MemberFactory = std::make_unique<detail::MemberFunctionFactory< MemberFunctionType >>( this );
   this->m_MemberFactory->RegisterMemberFunctions< FloatPixelIDTypeList, 2 >();
   this->m_MemberFactory->RegisterMemberFunctions< FloatPixelIDTypeList, 3 >();
 
@@ -700,5 +701,4 @@ TransformixImageFilter::TransformixImageFilterImpl
   return isEmpty;
 }
 
-}
 }

--- a/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilterImpl.h
+++ b/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilterImpl.h
@@ -9,8 +9,7 @@
 #include "itkTransformixFilter.h"
 #include "elxParameterObject.h"
 
-namespace itk {
-  namespace simple {
+namespace itk::simple {
 
 class SITKElastix_HIDDEN TransformixImageFilter::TransformixImageFilterImpl
 {
@@ -130,7 +129,6 @@ public:
   bool                    m_LogToFile;
 };
 
-}
 }
 
 #endif // sitktransformiximagefilterimpl_h


### PR DESCRIPTION
Applied modernize-make-unique, modernize-concat-nested-namespaces, and modernize-avoid-bind.

Note this was done by setting
  CMAKE_CXX_CLANG_TIDY:STRING=/usr/bin/clang-tidy-14;-checks=-*,modernize-make-unique,modernize-concat-nested-namespaces,modernize-avoid-bind;--header-filter=Code/;-fix