### PR TITLE
Add ITK_USE_BUILD_DIR option

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -45,6 +45,7 @@ jobs:
               WRAP_R:BOOL=ON
               WRAP_RUBY:BOOL=ON
               SimpleITK_USE_ELASTIX:BOOL=ON
+              ITK_USE_BUILD_DIR:BOOL=ON
           - os: macos-12
             cmake-build-type: "Release"
             cmake-generator: "Ninja"

--- a/Code/ElastixTransformixWrappers/src/CMakeLists.txt
+++ b/Code/ElastixTransformixWrappers/src/CMakeLists.txt
@@ -5,6 +5,9 @@ find_package(Elastix REQUIRED)
 include(${ELASTIX_CONFIG_TARGETS_FILE})
 
 
+set(use_itk_modules ITKCommon ITKImageGrid ITKImageIO)
+find_package(ITK COMPONENTS REQUIRED ${use_itk_modules} )
+
 add_library( ElastixImageFilter sitkElastixImageFilter.cxx  sitkElastixImageFilterImpl.cxx )
 target_include_directories( ElastixImageFilter
   PUBLIC
@@ -20,6 +23,7 @@ target_link_libraries( ElastixImageFilter
     transformix_lib )
 target_compile_options( ElastixImageFilter PUBLIC ${SimpleITK_PUBLIC_COMPILE_OPTIONS} PRIVATE ${SimpleITK_PRIVATE_COMPILE_OPTIONS} )
 target_compile_features( ElastixImageFilter PUBLIC cxx_std_17 )
+sitk_target_use_itk ( ElastixImageFilter PRIVATE ${use_itk_modules} )
 sitk_install_exported_target( ElastixImageFilter )
 
 
@@ -38,4 +42,5 @@ target_link_libraries( TransformixImageFilter
     transformix_lib )
 target_compile_options( TransformixImageFilter PUBLIC ${SimpleITK_PUBLIC_COMPILE_OPTIONS} PRIVATE ${SimpleITK_PRIVATE_COMPILE_OPTIONS} )
 target_compile_features( TransformixImageFilter PUBLIC cxx_std_17 )
+sitk_target_use_itk ( TransformixImageFilter PRIVATE ${use_itk_modules} )
 sitk_install_exported_target( TransformixImageFilter )

--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -11,6 +11,11 @@ some platforms."
   mark_as_advanced(ITK_USE_64BITS_IDS)
 endif()
 
+
+option(ITK_USE_BUILD_DIR "When ON, ITK will not be installed and SimpleITK built against the ITK build
+directory." OFF)
+mark_as_advanced(ITK_USE_BUILD_DIR)
+
 if(NOT DEFINED ITK_BUILD_DEFAULT_MODULES)
   set(ITK_BUILD_DEFAULT_MODULES ON)
 endif()
@@ -92,6 +97,10 @@ if (NOT DEFINED CMAKE_CXX_STANDARD)
   list( APPEND ep_itk_args "-DCMAKE_CXX_STANDARD:STRING=17")
 endif()
 
+if (ITK_USE_BUILD_DIR)
+  set( ITK_INSTALL_COMMAND INSTALL_COMMAND ${CMAKE_COMMAND} -E echo "Skipping install step.")
+endif()
+
 list( APPEND ep_itk_args "-DITK_LEGACY_REMOVE:BOOL=ON" )
 
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/${proj}-build/CMakeCacheInit.txt" "${ep_itk_cache}\n${ep_common_cache}" )
@@ -100,6 +109,7 @@ ExternalProject_Add(${proj}
   GIT_REPOSITORY ${ITK_GIT_REPOSITORY}
   ${ITK_TAG_COMMAND}
   UPDATE_COMMAND ""
+  ${ITK_INSTALL_COMMAND}
   SOURCE_DIR ${proj}
   BINARY_DIR ${proj}-build
   CMAKE_GENERATOR ${gen}
@@ -124,6 +134,11 @@ ExternalProject_Add(${proj}
   ${External_Project_USES_TERMINAL}
   )
 
+if (ITK_USE_BUILD_DIR)
+  ExternalProject_Get_Property(${proj} BINARY_DIR)
 
-ExternalProject_Get_Property(${proj} install_dir)
-set(ITK_DIR "${install_dir}/lib/cmake/ITK")
+  set(ITK_DIR "${BINARY_DIR}")
+else()
+  ExternalProject_Get_Property(${proj} install_dir)
+  set(ITK_DIR "${install_dir}/lib/cmake/ITK")
+endif()


### PR DESCRIPTION
In a Superbuild enable using ITK from the build directory. This can reduce disk usage and enables testing of ITK component usage.