### PR TITLE
Address missing Generic Label Interpolator - for release

### DIFF
--- a/Code/BasicFilters/src/CMakeLists.txt
+++ b/Code/BasicFilters/src/CMakeLists.txt
@@ -57,7 +57,7 @@ function(add_filter_library library_name src_list_var itk_module_list_var)
 endfunction()
 
 
-find_package(ITK COMPONENTS ITKCommon REQUIRED OPTIONAL_COMPONENTS ITKFFT )
+find_package(ITK REQUIRED COMPONENTS ITKCommon OPTIONAL_COMPONENTS ITKFFT )
 
 
 # common source which all basic filter libraries need to be linked against
@@ -167,8 +167,12 @@ add_filter_library(SimpleITKBasicFilters1 SimpleITKBasicFilters1Source no_itk_de
 target_link_libraries ( SimpleITKBasicFilters1
   PRIVATE ${PREV_SimpleITK_LIBRARIES} )
 
-# Manual dependecy needed for to run the Cast filter
+# Manual dependency needed to run the Cast filter
 target_link_libraries ( SimpleITK_ITKImageIntensity PRIVATE SimpleITK_ITKImageFilterBase )
+
+if (GenericLabelInterpolator IN_LIST ITK_MODULES_ENABLED)
+  sitk_target_use_itk( SimpleITK_ITKImageGrid PRIVATE GenericLabelInterpolator )
+endif()
 
 sitk_target_use_itk_factory( SimpleITK_ITKFFT FFTImageFilterInit )
 sitk_target_use_itk_factory( SimpleITK_ITKConvolution FFTImageFilterInit )

--- a/Code/Common/src/CMakeLists.txt
+++ b/Code/Common/src/CMakeLists.txt
@@ -33,7 +33,10 @@ set ( SimpleITKCommonSource
 
 set(use_itk_modules ITKCommon ITKImageCompose ITKImageIntensity
   ITKLabelMap ITKTransform ITKIOTransformBase ITKDisplacementField )
-find_package(ITK COMPONENTS ${use_itk_modules}  REQUIRED)
+if (GenericLabelInterpolator IN_LIST ITK_MODULES_ENABLED)
+  list(APPEND use_itk_modules GenericLabelInterpolator)
+endif()
+find_package(ITK COMPONENTS  REQUIRED ${use_itk_modules} )
 
 add_library ( SimpleITKCommon ${SimpleITKCommonSource} ${SimpleITKAncillarySource} )
 sitk_target_use_itk (SimpleITKCommon PRIVATE ${use_itk_modules} )

--- a/Code/Registration/src/CMakeLists.txt
+++ b/Code/Registration/src/CMakeLists.txt
@@ -10,6 +10,11 @@ find_package(ITK COMPONENTS ${use_itk_modules} REQUIRED)
 
 add_library ( SimpleITKRegistration ${SimpleITKRegistrationSource} )
 sitk_target_use_itk ( SimpleITKRegistration PRIVATE ${use_itk_modules} )
+
+if (GenericLabelInterpolator IN_LIST ITK_MODULES_ENABLED)
+  sitk_target_use_itk( SimpleITKRegistration PRIVATE GenericLabelInterpolator)
+endif()
+
 # The BasicFiltersLibrary is needed of the Cast filter
 target_link_libraries ( SimpleITKRegistration
   PUBLIC SimpleITKCommon SimpleITK_ITKCommon )


### PR DESCRIPTION
When building against an ITK build ( not install ), the path to the headers for the GenericLabelInterpolator module were missing.