### PR TITLE
ENH: Fix ITK code coverage nightly build CXX CTest flags

### DIFF
--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -117,7 +117,8 @@ jobs:
               CMAKE_C_FLAGS:STRING=--coverage
               CMAKE_EXE_LINKER_FLAGS=-lgcov
             ctest-extra-args: |
-              -Ddashboard_do_coverage=1
+              -Ddashboard_do_coverage=1 \
+              -DCTEST_COVERAGE_COMMAND="$(which gcov)"
 
     env:
       CTEST_SOURCE_DIRECTORY: "${{ github.workspace }}"


### PR DESCRIPTION
Fix ITK code coverage nightly build CXX CTest flags so that the coverage can be actually computed and reported.

Current dashboard shows no coverage reports, despite the coverage build under the name `itk-coverage (...)` actually taking place and being displayed as a build:
https://open.cdash.org/index.php?project=Insight&date=2023-10-21