### PR TITLE
Explicitly install setuptools in environment - for release

### DIFF
--- a/Wrapping/Python/LegacyPackaging.cmake
+++ b/Wrapping/Python/LegacyPackaging.cmake
@@ -87,7 +87,7 @@ if (SimpleITK_PYTHON_USE_VIRTUALENV)
   add_custom_command( OUTPUT "${VIRTUAL_PYTHON_EXECUTABLE}"
     COMMAND "${Python_EXECUTABLE}" "-m" "venv" "--clear" "${PythonVirtualenvHome}"
     COMMAND "${VIRTUAL_PYTHON_EXECUTABLE}" "-m" "pip" "install" "--upgrade" "pip"
-    COMMAND "${VIRTUAL_PYTHON_EXECUTABLE}" "-m" "pip" "install" "wheel" "numpy!=1.24.1,!=1.24.0" "."
+    COMMAND "${VIRTUAL_PYTHON_EXECUTABLE}" "-m" "pip" "install" "wheel" "numpy!=1.24.1,!=1.24.0" "setuptools>=42" "."
     WORKING_DIRECTORY "${SimpleITK_Python_BINARY_DIR}"
     DEPENDS
     "${SWIG_MODULE_SimpleITKPython_TARGET_NAME}"


### PR DESCRIPTION
setuptools i no longer pre-installed in virtual environments with venv in Python 3.12+.