### PR TITLE
BUG: Example include a DICOM tag number with upper case letter.

### DIFF
--- a/Examples/DicomSeriesReadModifyWrite/DicomSeriesReadModifySeriesWrite.R
+++ b/Examples/DicomSeriesReadModifyWrite/DicomSeriesReadModifySeriesWrite.R
@@ -67,7 +67,7 @@ writer$KeepOriginalImageUIDOn()
 tags_to_copy <- c("0010|0010", # Patient Name
                 "0010|0020", # Patient ID
                 "0010|0030", # Patient Birth Date
-                "0020|000D", # Study Instance UID, for machine consumption
+                "0020|000d", # Study Instance UID, for machine consumption
                 "0020|0010", # Study ID, for human consumption
                 "0008|0020", # Study Date
                 "0008|0030", # Study Time
@@ -84,18 +84,19 @@ modification_date <- format(Sys.time(), "%Y%m%d")
 # by the Filter.
 # For the series instance UID (0020|000e), each of the components is a number, cannot start
 # with zero, and separated by a '.' We create a unique series ID using the date and time.
-# NOTE: DICOM tags represent hexadecimal numbers, so 0020|000D and 0020|000d
+# NOTE: Always represent DICOM tags using lower case hexadecimals.
+#       DICOM tags represent hexadecimal numbers, so 0020|000D and 0020|000d
 #       are equivalent. The ITK/SimpleITK dictionary is string based, so these
 #       are two different keys, case sensitive. When read from a DICOM file the
-#       hexadecimal string representations are in lower case, so we check for
-#       existence and get the value after converting to lower case.
+#       hexadecimal string representations are in lower case. To ensure consistency,
+#       always use lower case for the tags.
 # Tags of interest:
 direction <- filtered_image$GetDirection()
 series_tag_values <- c(Filter(Negate(is.null),
                              lapply(tags_to_copy,
                              function(k) {
-                               if(series_reader$HasMetaDataKey(0,tolower(k))) {
-                                 list(k, series_reader$GetMetaData(0,tolower(k)))
+                               if(series_reader$HasMetaDataKey(0,k)) {
+                                 list(k, series_reader$GetMetaData(0,k))
                                 }
                              })),
                         list(list("0008|0031",modification_time), # Series Time

--- a/Examples/DicomSeriesReadModifyWrite/DicomSeriesReadModifySeriesWrite.py
+++ b/Examples/DicomSeriesReadModifyWrite/DicomSeriesReadModifySeriesWrite.py
@@ -79,7 +79,7 @@ tags_to_copy = [
     "0010|0010",  # Patient Name
     "0010|0020",  # Patient ID
     "0010|0030",  # Patient Birth Date
-    "0020|000D",  # Study Instance UID, for machine consumption
+    "0020|000d",  # Study Instance UID, for machine consumption
     "0020|0010",  # Study ID, for human consumption
     "0008|0020",  # Study Date
     "0008|0030",  # Study Time
@@ -94,17 +94,18 @@ modification_date = time.strftime("%Y%m%d")
 # For the series instance UID (0020|000e), each of the components is a number,
 # cannot start with zero, and separated by a '.' We create a unique series ID
 # using the date and time.
-# NOTE: DICOM tags represent hexadecimal numbers, so 0020|000D and 0020|000d
+# NOTE: Always represent DICOM tags using lower case hexadecimals.
+#       DICOM tags represent hexadecimal numbers, so 0020|000D and 0020|000d
 #       are equivalent. The ITK/SimpleITK dictionary is string based, so these
 #       are two different keys, case sensitive. When read from a DICOM file the
-#       hexadecimal string representations are in lower case, so we check for
-#       existence and get the value after converting to lower case.
+#       hexadecimal string representations are in lower case. To ensure consistency,
+#       always use lower case for the tags.
 # Tags of interest:
 direction = filtered_image.GetDirection()
 series_tag_values = [
-    (k, series_reader.GetMetaData(0, k.lower()))
+    (k, series_reader.GetMetaData(0, k))
     for k in tags_to_copy
-    if series_reader.HasMetaDataKey(0, k.lower())
+    if series_reader.HasMetaDataKey(0, k)
 ] + [
     ("0008|0031", modification_time),  # Series Time
     ("0008|0021", modification_date),  # Series Date

--- a/Examples/DicomSeriesReadModifyWrite/Documentation.rst
+++ b/Examples/DicomSeriesReadModifyWrite/Documentation.rst
@@ -13,6 +13,9 @@ Modifying the 3D image can involve changes to its physical characteristics (spac
 
 Writing the 3D image as a DICOM series is done by configuring the meta-data dictionary for each of the slices and then writing it in DICOM format. In our case we copy some of the meta-data from the original dictionaries which are available from the series reader. We then set some additional meta-data values to indicate that this series is derived from the original acquired data. Note that we write the intensity values as is and thus do not set the rescale slope (0028|1053), rescale intercept (0028|1052) meta-data dictionary values.
 
+Always represent DICOM tags using lower case hexadecimals. DICOM tags represent hexadecimal numbers, so 0020|000D and 0020|000d are equivalent. The ITK/SimpleITK dictionary is string based, so these are two different keys, case sensitive. When read from a DICOM file the hexadecimal string representations are in lower case. To ensure consistency, always use lower case for the tags.
+
+
 See also :ref:`lbl_print_image_meta_data_dictionary`, :ref:`lbl_dicom_series_reader`.
 
 


### PR DESCRIPTION
DICOM tags should be all in lower case letters to match the conversion done by the ITK reader.