### PR TITLE
Increase the timeout for the ITK coverage build

### DIFF
--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -110,7 +110,7 @@ jobs:
           - os: coverage-x64
             name: itk-coverage
             cmake-build-type: Debug
-            ctest-test-timeout: 1200
+            ctest-test-timeout: 1800
             timeout: 180
             ctest-cache: |
               CMAKE_CXX_FLAGS:STRING=--coverage


### PR DESCRIPTION
This should address the
itkTimeVaryingVelocityFieldImageRegistrationTest failing due to timeout.