### PR TITLE
Add ThresholdAbove,  ThresholdBelow and OutsideValue methods

### DIFF
--- a/Code/BasicFilters/json/ThresholdImageFilter.json
+++ b/Code/BasicFilters/json/ThresholdImageFilter.json
@@ -15,7 +15,8 @@
       "briefdescriptionSet" : "",
       "detaileddescriptionSet" : "Set/Get methods to set the lower threshold.",
       "briefdescriptionGet" : "",
-      "detaileddescriptionGet" : "Set/Get methods to set the lower threshold."
+      "detaileddescriptionGet" : "Set/Get methods to set the lower threshold.",
+      "custom_itk_cast" : "if (this->m_Lower == NumericTraits<double>::NonpositiveMin()) { filter->SetLower( NumericTraits<typename InputImageType::PixelType>::NonpositiveMin());}else{filter->SetLower(static_cast< typename InputImageType::PixelType> ( this->m_Lower ) );}"
     },
     {
       "name" : "Upper",
@@ -25,7 +26,11 @@
       "briefdescriptionSet" : "",
       "detaileddescriptionSet" : "Set/Get methods to set the upper threshold.",
       "briefdescriptionGet" : "",
-      "detaileddescriptionGet" : "Set/Get methods to set the upper threshold."
+      "detaileddescriptionGet" : "Set/Get methods to set the upper threshold.",
+      "custom_itk_cast" : "if (this->m_Upper == NumericTraits<double>::max()) { filter->SetUpper( NumericTraits<typename InputImageType::PixelType>::max());}else{filter->SetUpper(static_cast< typename InputImageType::PixelType> ( this->m_Upper ) );}"
+
+
+
     },
     {
       "name" : "OutsideValue",
@@ -36,6 +41,51 @@
       "detaileddescriptionSet" : "The pixel type must support comparison operators. Set the \"outside\" pixel value. The default value NumericTraits<PixelType>::ZeroValue() .",
       "briefdescriptionGet" : "",
       "detaileddescriptionGet" : "Get the \"outside\" pixel value."
+    }
+  ],
+  "custom_methods" : [
+    {
+      "name": "ThresholdAbove",
+      "briefdescription": "ThresholdAbove",
+      "detaileddescription": "The values greater than \"threshold\" are set to OutsideValue.",
+      "return_type" : "void",
+      "parameters" : [
+        {
+          "type" : "double",
+          "var_name" : "threshold"
+        }
+      ],
+      "body" : "this->m_Upper = threshold; this->m_Lower = NumericTraits<double>::NonpositiveMin();"
+    },
+    {
+      "name": "ThresholdBelow",
+      "briefdescription": "ThresholdBelow",
+      "detaileddescription": "The values less than \"threshold\" are set to OutsideValue.",
+      "return_type" : "void",
+      "parameters" : [
+        {
+          "type" : "double",
+          "var_name" : "threshold"
+        }
+      ],
+      "body" : "this->m_Lower = threshold; this->m_Upper = NumericTraits<double>::max();"
+    },
+    {
+      "name": "ThresholdOutside",
+      "briefdescription": "ThresholdOutside",
+      "detaileddescription": "The values outside the closed range are set to OutsideValue.",
+      "return_type" : "void",
+      "parameters" : [
+        {
+          "type" : "double",
+          "var_name" : "lower"
+        },
+        {
+          "type" : "double",
+          "var_name" : "upper"
+        }
+      ],
+      "body" : "this->m_Lower = lower; this->m_Upper = upper;"
     }
   ],
   "tests" : [
@@ -90,7 +140,7 @@
     }
   ],
   "briefdescription" : "Set image values to a user-specified value if they are below, above, or between simple threshold values.",
-  "detaileddescription" : "ThresholdImageFilter sets image values to a user-specified \"outside\" value (by default, \"black\") if the image values are below, above, or between simple threshold values.\n\nThe available methods are:\n\nThresholdAbove() : The values greater than the threshold value are set to OutsideValue\n\nThresholdBelow() : The values less than the threshold value are set to OutsideValue\n\nThresholdOutside() : The values outside the threshold range (less than lower or greater than upper) are set to OutsideValue\n\nNote that these definitions indicate that pixels equal to the threshold value are not set to OutsideValue in any of these methods\n\nThe pixels must support the operators >= and <=.",
+  "detaileddescription" : "ThresholdImageFilter sets image values to a user-specified \"outside\" value (by default, \"black\") if the image values are below, above, or outside threshold values.\n\nThe available methods are:\n\nThresholdAbove() : The values greater than the threshold value are set to OutsideValue\n\nThresholdBelow() : The values less than the threshold value are set to OutsideValue\n\nThresholdOutside() : The values outside the threshold range (less than lower or greater than upper) are set to OutsideValue\n\nNote that these definitions indicate that pixels equal to the threshold values are not set to OutsideValue in any of these methods\n\nThe pixels must support the operators >= and <=.",
   "itk_module" : "ITKThresholding",
   "itk_group" : "Thresholding",
   "in_place" : true

--- a/Testing/Unit/sitkBasicFiltersTests.cxx
+++ b/Testing/Unit/sitkBasicFiltersTests.cxx
@@ -44,6 +44,7 @@
 #include <sitkMergeLabelMapFilter.h>
 #include <sitkDiffeomorphicDemonsRegistrationFilter.h>
 #include <sitkFastSymmetricForcesDemonsRegistrationFilter.h>
+#include <sitkThresholdImageFilter.h>
 #include <sitkOtsuThresholdImageFilter.h>
 #include <sitkBSplineTransformInitializerFilter.h>
 #include <sitkCenteredTransformInitializerFilter.h>
@@ -1064,6 +1065,44 @@ TEST(BasicFilters,ResampleImageFilter_DefaultParameters)
   EXPECT_EQ ( 0u, result.GetHeight() );
 }
 
+TEST(BasicFilters, Threshod)
+{
+  namespace sitk = itk::simple;
+
+  sitk::Image input(10,10,sitk::sitkInt32);
+  for (unsigned int y = 0; y < input.GetSize()[1]; ++y)
+  {
+    for (unsigned int x = 0; x < input.GetSize()[0]; ++x)
+    {
+      input.SetPixelAsInt32({x,y}, x + y*input.GetSize()[0]);
+    }
+  }
+
+  sitk::ThresholdImageFilter filter;
+
+  filter.ThresholdOutside(10,20);
+  sitk::Image output = filter.Execute(input);
+  EXPECT_EQ(0u, output.GetPixelAsInt32({1,0}));
+  EXPECT_EQ(0u, output.GetPixelAsInt32({9,0}));
+  EXPECT_EQ(10u, output.GetPixelAsInt32({0,1}));
+  EXPECT_EQ(20u, output.GetPixelAsInt32({0,2}));
+  EXPECT_EQ(0u, output.GetPixelAsInt32({1,2}));
+
+  filter.ThresholdAbove(10);
+  output = filter.Execute(input);
+  EXPECT_EQ(1u, output.GetPixelAsInt32({1,0}));
+  EXPECT_EQ(9u, output.GetPixelAsInt32({9,0}));
+  EXPECT_EQ(10u, output.GetPixelAsInt32({0,1}));
+  EXPECT_EQ(0u, output.GetPixelAsInt32({1,1}));
+
+  filter.ThresholdBelow(10);
+  output = filter.Execute(input);
+  EXPECT_EQ(0u, output.GetPixelAsInt32({1,0}));
+  EXPECT_EQ(0u, output.GetPixelAsInt32({9,0}));
+  EXPECT_EQ(10u, output.GetPixelAsInt32({0,1}));
+  EXPECT_EQ(20, output.GetPixelAsInt32({0,2}));
+
+}
 
 TEST(BasicFilters,OtsuThreshold_CheckNamesInputCompatibility)
 {


### PR DESCRIPTION
This approach uses the double max/min value as magic numbers for the lower and uppler threshold range to set itk filter's parameters to the limits of the input image pixel type.

Addresses #2051 