### PR TITLE
Update GHA build to use macos-13

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -46,7 +46,7 @@ jobs:
               WRAP_RUBY:BOOL=ON
               SimpleITK_USE_ELASTIX:BOOL=ON
               ITK_USE_BUILD_DIR:BOOL=ON
-          - os: macos-12
+          - os: macos-13
             cmake-build-type: "Release"
             cmake-generator: "Ninja"
             ctest-cache: |


### PR DESCRIPTION
Changes to use XCode 15.0.1 by default and the system has 4 CPU by default.