### PR TITLE
Update SWIG tags to have v prefix

### DIFF
--- a/SuperBuild/External_Swig.cmake
+++ b/SuperBuild/External_Swig.cmake
@@ -23,7 +23,7 @@ if(NOT SWIG_DIR)
 
   if( USE_SWIG_FROM_GIT )
     set(SWIG_GIT_REPOSITORY "${git_protocol}://github.com/swig/swig.git" CACHE STRING "URL of swig git repo")
-    set(SWIG_GIT_TAG "rel-${SWIG_TARGET_VERSION}" CACHE STRING "Tag in swig git repo")
+    set(SWIG_GIT_TAG "v${SWIG_TARGET_VERSION}" CACHE STRING "Tag in swig git repo")
     mark_as_advanced(SWIG_GIT_REPO)
     mark_as_advanced(SWIG_GIT_TAG)
   endif()


### PR DESCRIPTION
The upstream SWIG repo is using "v" as a prefix for all new tags, and all old releases have tags with the v prefix.