### PR TITLE
In R, remove overloaded AddCommand method

### DIFF
--- a/Testing/Unit/R/CMakeLists.txt
+++ b/Testing/Unit/R/CMakeLists.txt
@@ -25,3 +25,6 @@ sitk_add_r_test( Image2Array2Image
 sitk_add_r_test( MethodExceptions
   "${CMAKE_CURRENT_SOURCE_DIR}/Rmethodexceptions.R"
   )
+sitk_add_r_test( Commands
+  "${CMAKE_CURRENT_SOURCE_DIR}/RCommands.R"
+  )

--- a/Testing/Unit/R/RCommands.R
+++ b/Testing/Unit/R/RCommands.R
@@ -1,0 +1,79 @@
+## Test the AddCommand method and command classes
+
+library(SimpleITK)
+
+options(warn=2)
+
+
+commandFromFunctionTest <- function()
+{
+    img <- Image(64, 64, 'sitkFloat32')
+
+    castFilter <- CastImageFilter()
+
+    output_text <- ""
+    commandFunction <- function()
+    {
+        output_text <<- paste(output_text, 'start', sep='')
+    }
+
+    castFilter$AddCommand('sitkStartEvent', commandFunction)
+
+    output <- castFilter$Execute(img)
+    cat(paste('output_text: "', output_text, '"\n', sep=''))
+
+    # test that output_text is 'start'
+
+     if(output_text != 'start')
+     {
+         stop("commandFromFunctionTest failed, expected 'start' got \"", output_text, '"')
+     }
+}
+
+
+commandFromLambda <- function()
+{
+    img <- Image(64, 64, 'sitkFloat32')
+
+    castFilter <- CastImageFilter()
+
+    output_text <- ''
+    castFilter$AddCommand('sitkStartEvent', function() output_text <<- paste(output_text, 'start', sep=''))
+
+    output <- castFilter$Execute(img)
+
+    if(output_text != 'start')
+    {
+        stop("commandFromLambda failed, expected 'start' got \"", output_text, '"')
+    }
+}
+
+
+commandFromLambdaWithClosure <- function()
+{
+    img <- Image(64, 64, 'sitkFloat32')
+
+    output_text = ''
+
+    commandWithArguments <- function(filter)
+    {
+        output_text <<- paste(output_text, filter$GetName(), sep='')
+    }
+
+
+
+    castFilter <- CastImageFilter()
+
+    castFilter$AddCommand('sitkEndEvent', function() commandWithArguments(castFilter))
+
+    output = castFilter$Execute(img)
+    if(output_text != 'CastImageFilter')
+    {
+        stop("commandFromLambdaWithClosure failed, expected 'CastImageFilter' got \"", output_text, '"')
+    }
+}
+
+
+commandFromFunctionTest()
+commandFromLambda()
+commandFromLambdaWithClosure()

--- a/Wrapping/R/R.i
+++ b/Wrapping/R/R.i
@@ -196,10 +196,11 @@ itk::simple::Image ArrayAsIm(SEXP arr,
 // Finer control will require putting swig code in the right
 // scope.
 
-%typemap("rtype") SEXP "function";
 %{
 #include "sitkRCommand.h"
 %}
+
+%ignore itk::simple::ProcessObject::AddCommand(itk::simple::EventEnum event, itk::simple::Command &cmd);
 
 %extend itk::simple::ProcessObject {
   int AddCommand( itk::simple::EventEnum e, SEXP obj )
@@ -226,8 +227,6 @@ itk::simple::Image ArrayAsIm(SEXP arr,
      }
  }
 };
-
-//#define %rcode %insert("sinit")
 
 %Rruntime %{
 


### PR DESCRIPTION
SWIG 4.2 is unable to resolve the overloaded method taking SEXP, and sitk::Command.