### PR TITLE
Use PathType for file paths

### DIFF
--- a/Code/Common/include/sitkPathType.h
+++ b/Code/Common/include/sitkPathType.h
@@ -1,0 +1,27 @@
+/*=========================================================================
+*
+*  Copyright NumFOCUS
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*         http://www.apache.org/licenses/LICENSE-2.0.txt
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*=========================================================================*/
+#ifndef sitk_PathType_h
+#define sitk_PathType_h
+
+#include <string>
+
+namespace itk::simple {
+  using PathType = std::string;
+}
+
+#endif

--- a/Code/Common/include/sitkTransform.h
+++ b/Code/Common/include/sitkTransform.h
@@ -21,6 +21,7 @@
 #include "sitkCommon.h"
 #include "sitkExceptionObject.h"
 #include "sitkImage.h"
+#include "sitkPathType.h"
 #include <vector>
 
 
@@ -311,10 +312,10 @@ private:
 
 
 // read
-SITKCommon_EXPORT Transform ReadTransform( const std::string &filename );
+SITKCommon_EXPORT Transform ReadTransform( const PathType &filename );
 
 // write
-SITKCommon_EXPORT void WriteTransform( const Transform &transform, const std::string &filename);
+SITKCommon_EXPORT void WriteTransform( const Transform &transform, const PathType &filename);
 
 }
 }

--- a/Code/Common/src/sitkTransform.cxx
+++ b/Code/Common/src/sitkTransform.cxx
@@ -650,7 +650,7 @@ void Transform::InternalInitialization(TransformType *t)
   Self::SetPimpleTransform(std::make_unique<PimpleTransform<TransformType>>(t));
 }
 
-  Transform ReadTransform( const std::string &filename )
+  Transform ReadTransform( const PathType &filename )
   {
     TransformFileReader::Pointer reader = TransformFileReader::New();
     reader->SetFileName(filename.c_str() );
@@ -717,7 +717,7 @@ void Transform::InternalInitialization(TransformType *t)
   }
 
   // write
-  void WriteTransform( const Transform &transform, const std::string &filename)
+  void WriteTransform( const Transform &transform, const PathType &filename)
   {
     itk::TransformFileWriter::Pointer writer = itk::TransformFileWriter::New();
     writer->SetFileName(filename.c_str());

--- a/Code/IO/include/sitkImageFileReader.h
+++ b/Code/IO/include/sitkImageFileReader.h
@@ -85,8 +85,8 @@ namespace itk {
       /** return user readable name of the filter */
       std::string GetName() const override { return std::string("ImageFileReader"); }
 
-      SITK_RETURN_SELF_TYPE_HEADER SetFileName ( const std::string &fn );
-      std::string GetFileName() const;
+      SITK_RETURN_SELF_TYPE_HEADER SetFileName ( const PathType &fn);
+      PathType GetFileName() const;
 
       Image Execute() override;
 
@@ -220,7 +220,7 @@ namespace itk {
       std::function<bool(const std::string &)> m_pfHasMetaDataKey;
       std::function<std::string(const std::string &)> m_pfGetMetaData;
 
-      std::string m_FileName;
+      PathType m_FileName;
 
       std::unique_ptr<MetaDataDictionary> m_MetaDataDictionary;
 
@@ -248,7 +248,7 @@ namespace itk {
    * \sa itk::simple::ImageFileReader for reading a single file.
    * \sa itk::simple::ImageSeriesReader for reading a series and meta-data dictionaries.
    */
-  SITKIO_EXPORT Image ReadImage ( const std::string &filename,
+  SITKIO_EXPORT Image ReadImage ( const PathType &filename,
                                   PixelIDValueEnum outputPixelType = sitkUnknown,
                                   const std::string &imageIO = "");
   }

--- a/Code/IO/include/sitkImageFileWriter.h
+++ b/Code/IO/include/sitkImageFileWriter.h
@@ -19,6 +19,7 @@
 #define sitkImageFileWriter_h
 
 #include "sitkMacro.h"
+#include "sitkPathType.h"
 #include "sitkImage.h"
 #include "sitkMemberFunctionFactory.h"
 #include "sitkIO.h"
@@ -135,15 +136,15 @@ class SmartPointer;
       SITK_RETURN_SELF_TYPE_HEADER KeepOriginalImageUIDOff( ) { return this->SetKeepOriginalImageUID(false); }
       /** @} */
 
-      SITK_RETURN_SELF_TYPE_HEADER SetFileName ( const std::string &fileName );
-      std::string GetFileName() const;
+      SITK_RETURN_SELF_TYPE_HEADER SetFileName ( const PathType &fileName );
+      PathType GetFileName() const;
 
       SITK_RETURN_SELF_TYPE_HEADER Execute ( const Image& );
-      SITK_RETURN_SELF_TYPE_HEADER Execute ( const Image& , const std::string &inFileName, bool useCompression, int compressionLevel );
+      SITK_RETURN_SELF_TYPE_HEADER Execute ( const Image& , const PathType &inFileName, bool useCompression, int compressionLevel );
 
     private:
 
-      itk::SmartPointer<ImageIOBase> GetImageIOBase(const std::string &fileName);
+      itk::SmartPointer<ImageIOBase> GetImageIOBase(const PathType &fileName);
 
       template <class T> Self& ExecuteInternal ( const Image& );
 
@@ -151,7 +152,7 @@ class SmartPointer;
       int         m_CompressionLevel;
       std::string m_Compressor;
 
-      std::string m_FileName;
+      PathType m_FileName;
       bool        m_KeepOriginalImageUID;
       std::string m_ImageIOName;
 
@@ -178,7 +179,7 @@ class SmartPointer;
    * \sa itk::simple::ImageFileWriter for writing a single file.
    */
   SITKIO_EXPORT void WriteImage (const Image& image,
-                                 const std::string &fileName,
+                                 const PathType &fileName,
                                  bool useCompression=false,
                                  int compressionLevel=-1);
   }

--- a/Code/IO/include/sitkImageReaderBase.h
+++ b/Code/IO/include/sitkImageReaderBase.h
@@ -20,6 +20,7 @@
 
 #include "sitkProcessObject.h"
 #include "sitkPixelIDValues.h"
+#include "sitkPathType.h"
 #include "sitkIO.h"
 
 namespace itk {
@@ -104,20 +105,20 @@ class SmartPointer;
        * encountered such as the file does not exist, then an empty
        * string ("") will be returned.
        */
-      static std::string GetImageIOFromFileName(const std::string &fileName);
+      static std::string GetImageIOFromFileName(const PathType &fileName);
 
     protected:
 
-      itk::SmartPointer<ImageIOBase> GetImageIOBase(const std::string &fileName);
+      itk::SmartPointer<ImageIOBase> GetImageIOBase(const PathType &fileName);
 
-      void GetPixelIDFromImageIO( const std::string &fileName,
+      void GetPixelIDFromImageIO( const PathType &fileName,
                                   PixelIDValueType &outPixelType,
                                   unsigned int & outDimensions );
       void GetPixelIDFromImageIO( const itk::ImageIOBase* iobase,
                                   PixelIDValueType &outPixelType,
                                   unsigned int & outDimensions );
 
-      unsigned int GetDimensionFromImageIO( const std::string &fileName, unsigned int i );
+      unsigned int GetDimensionFromImageIO( const PathType &filename, unsigned int i );
       unsigned int GetDimensionFromImageIO( const itk::ImageIOBase* iobase, unsigned int i );
 
 

--- a/Code/IO/include/sitkImageSeriesReader.h
+++ b/Code/IO/include/sitkImageSeriesReader.h
@@ -122,7 +122,7 @@ namespace itk::simple {
        *
        * \sa itk::GDCMSeriesFileNames
        **/
-      static std::vector<std::string> GetGDCMSeriesFileNames( const std::string &directory,
+      static std::vector<PathType> GetGDCMSeriesFileNames( const PathType &directory,
                                                               const std::string &seriesID = "",
                                                               bool useSeriesDetails = false,
                                                               bool recursive = false,
@@ -138,11 +138,11 @@ namespace itk::simple {
        * value used in the call to GDCMSeriesFileNames.
        * \sa itk::GDCMSeriesFileNames
        **/
-      static std::vector<std::string> GetGDCMSeriesIDs( const std::string &directory,
+      static std::vector<std::string> GetGDCMSeriesIDs( const PathType &directory,
                                                         bool useSeriesDetails = false );
 
-      SITK_RETURN_SELF_TYPE_HEADER SetFileNames ( const std::vector<std::string> &fileNames );
-      const std::vector<std::string> &GetFileNames() const;
+      SITK_RETURN_SELF_TYPE_HEADER SetFileNames ( const std::vector<PathType> &fileNames );
+      const std::vector<PathType> &GetFileNames() const;
 
       Image Execute() override;
 
@@ -199,7 +199,7 @@ namespace itk::simple {
       itk::ProcessObject *m_Filter;
 
 
-      std::vector<std::string> m_FileNames;
+      std::vector<PathType> m_FileNames;
 
       bool m_MetaDataDictionaryArrayUpdate;
     };
@@ -228,7 +228,7 @@ namespace itk::simple {
    * \sa itk::simple::ImageFileReader for reading a single file.
    * \sa itk::simple::ImageSeriesReader for reading a series and meta-data dictionaries.
    */
-  SITKIO_EXPORT Image ReadImage ( const std::vector<std::string> &fileNames,
+  SITKIO_EXPORT Image ReadImage ( const std::vector<PathType> &fileNames,
                                   PixelIDValueEnum outputPixelType=sitkUnknown,
                                   const std::string &imageIO="");
   }

--- a/Code/IO/include/sitkImageSeriesWriter.h
+++ b/Code/IO/include/sitkImageSeriesWriter.h
@@ -21,6 +21,7 @@
 #include "sitkMacro.h"
 #include "sitkImage.h"
 #include "sitkProcessObject.h"
+#include "sitkPathType.h"
 #include "sitkIO.h"
 #include "sitkMemberFunctionFactory.h"
 
@@ -120,13 +121,13 @@ class ImageIOBase;
         * The number of filenames must match the number of slices in
         * the image.
         * @{ */
-      SITK_RETURN_SELF_TYPE_HEADER SetFileNames ( const std::vector<std::string> &fileNames );
-      const std::vector<std::string> &GetFileNames() const;
+      SITK_RETURN_SELF_TYPE_HEADER SetFileNames ( const std::vector<PathType> &fileNames );
+      const std::vector<PathType> &GetFileNames() const;
       /** @} */
 
 
       SITK_RETURN_SELF_TYPE_HEADER Execute( const Image& );
-      SITK_RETURN_SELF_TYPE_HEADER Execute( const Image &image, const std::vector<std::string> &inFileNames, bool useCompression, int compressionLevel );
+      SITK_RETURN_SELF_TYPE_HEADER Execute( const Image &image, const std::vector<PathType> &inFileNames, bool useCompression, int compressionLevel );
 
     protected:
 
@@ -134,7 +135,7 @@ class ImageIOBase;
 
     private:
 
-      itk::SmartPointer<ImageIOBase> GetImageIOBase(const std::string &fileName);
+      itk::SmartPointer<ImageIOBase> GetImageIOBase(const PathType &fileName);
 
       // function pointer type
       typedef Self& (Self::*MemberFunctionType)( const Image& );
@@ -147,7 +148,7 @@ class ImageIOBase;
       int         m_CompressionLevel;
       std::string m_Compressor;
 
-      std::vector<std::string> m_FileNames;
+      std::vector<PathType> m_FileNames;
 
       std::string m_ImageIOName;
     };
@@ -168,7 +169,7 @@ class ImageIOBase;
    * \sa itk::simple::ImageFileWriter for writing a single file.
    */
   SITKIO_EXPORT void WriteImage(const Image &                    image,
-                                const std::vector<std::string> & fileNames,
+                                const std::vector<PathType> & fileNames,
                                 bool                             useCompression = false,
                                 int                              compressionLevel = -1);
   }

--- a/Code/IO/include/sitkImageViewer.h
+++ b/Code/IO/include/sitkImageViewer.h
@@ -19,6 +19,7 @@
 #define sitkImageViewer_h
 
 #include "sitkImage.h"
+#include "sitkPathType.h"
 #include "sitkIO.h"
 #include "sitkProcessObject.h"
 
@@ -60,15 +61,15 @@ public:
   /** \brief Set/Get the search path used to find the viewing application
    * @{
    */
-  static void SetGlobalDefaultSearchPath( const std::vector<std::string> & path );
-  static const std::vector<std::string> & GetGlobalDefaultSearchPath();
+  static void SetGlobalDefaultSearchPath( const std::vector<PathType> & path );
+  static const std::vector<PathType> & GetGlobalDefaultSearchPath();
   /**@}*/
 
   /** \brief Set/Get name list used to find the viewing application
    * @{
    */
-  static void SetGlobalDefaultExecutableNames( const std::vector<std::string> & names );
-  static const std::vector<std::string> & GetGlobalDefaultExecutableNames();
+  static void SetGlobalDefaultExecutableNames( const std::vector<PathType> & names );
+  static const std::vector<PathType> & GetGlobalDefaultExecutableNames();
   /**@}*/
 
   /** \brief Set/Get the default file extension
@@ -84,8 +85,8 @@ public:
   /** \brief Set/Get the default application used in the command string.
    * @{
    */
-  static void SetGlobalDefaultApplication( const std::string & app );
-  static const std::string & GetGlobalDefaultApplication();
+  static void SetGlobalDefaultApplication( const PathType & app );
+  static const PathType & GetGlobalDefaultApplication();
   /**@}*/
 
   /** \brief Set the full path to the viewing application used in the command string.
@@ -106,10 +107,10 @@ public:
    * set to `"%a %f"` which simply means *the application path*
    * followed by *the temporary image file*.
    */
-  void SetApplication( const std::string & app, const std::string & command = "%a %f" );
+  void SetApplication( const PathType & app, const std::string & command = "%a %f" );
 
   /** \brief Get the full path to the viewing application used in the command string.  */
-  const std::string & GetApplication() const;
+  const PathType & GetApplication() const;
 
   /** \brief Set the command string used to launch the viewing application
    *
@@ -210,7 +211,7 @@ private:
   std::string m_ViewCommand;
   std::string m_CustomCommand;
 
-  std::string m_Application;
+  PathType m_Application;
 
   std::string m_FileExtension;
 

--- a/Code/IO/src/sitkImageFileReader.cxx
+++ b/Code/IO/src/sitkImageFileReader.cxx
@@ -64,7 +64,7 @@ namespace itk::simple {
       }
   }
 
-  Image ReadImage ( const std::string &filename,
+  Image ReadImage ( const PathType &filename,
                     PixelIDValueEnum outputPixelType,
                     const std::string &imageIO )
     {
@@ -116,12 +116,12 @@ namespace itk::simple {
       return out.str();
     }
 
-    ImageFileReader& ImageFileReader::SetFileName ( const std::string &fn ) {
+    ImageFileReader& ImageFileReader::SetFileName ( const PathType &fn ) {
       this->m_FileName = fn;
       return *this;
     }
 
-    std::string ImageFileReader::GetFileName() const {
+    PathType ImageFileReader::GetFileName() const {
       return this->m_FileName;
     }
 

--- a/Code/IO/src/sitkImageFileWriter.cxx
+++ b/Code/IO/src/sitkImageFileWriter.cxx
@@ -28,7 +28,7 @@
 
 namespace itk::simple {
 
-void WriteImage ( const Image& image, const std::string &inFileName, bool useCompression, int compressionLevel )
+void WriteImage ( const Image& image, const PathType &inFileName, bool useCompression, int compressionLevel )
 {
   ImageFileWriter writer;
   writer.Execute ( image, inFileName, useCompression, compressionLevel );
@@ -143,18 +143,18 @@ bool ImageFileWriter::GetKeepOriginalImageUID( ) const
   return this->m_KeepOriginalImageUID;
 }
 
-ImageFileWriter& ImageFileWriter::SetFileName ( const std::string &fn )
+ImageFileWriter& ImageFileWriter::SetFileName ( const PathType &fn )
 {
   this->m_FileName = fn;
   return *this;
 }
 
-std::string ImageFileWriter::GetFileName() const
+PathType ImageFileWriter::GetFileName() const
 {
   return this->m_FileName;
 }
 
-ImageFileWriter& ImageFileWriter::Execute ( const Image& image, const std::string &inFileName, bool useCompression, int compressionLevel )
+ImageFileWriter& ImageFileWriter::Execute ( const Image& image, const PathType &inFileName, bool useCompression, int compressionLevel )
 {
   this->SetFileName( inFileName );
   this->SetUseCompression( useCompression );
@@ -190,7 +190,7 @@ ImageFileWriter
 
 itk::SmartPointer<ImageIOBase>
 ImageFileWriter
-::GetImageIOBase(const std::string &fileName)
+::GetImageIOBase(const PathType &fileName)
 {
   itk::ImageIOBase::Pointer iobase;
   if (this->m_ImageIOName.empty())

--- a/Code/IO/src/sitkImageReaderBase.cxx
+++ b/Code/IO/src/sitkImageReaderBase.cxx
@@ -76,7 +76,7 @@ ImageReaderBase
 
 itk::SmartPointer<ImageIOBase>
 ImageReaderBase
-::GetImageIOBase(const std::string &fileName)
+::GetImageIOBase(const PathType &fileName)
 {
   itk::ImageIOBase::Pointer iobase;
   if (this->m_ImageIOName.empty())
@@ -182,7 +182,7 @@ ImageReaderBase
 
 std::string
 ImageReaderBase
-::GetImageIOFromFileName( const std::string &fileName )
+::GetImageIOFromFileName( const PathType &fileName )
 {
   itk::ImageIOBase::Pointer iobase;
   try
@@ -205,7 +205,7 @@ ImageReaderBase
 
 void
 ImageReaderBase
-::GetPixelIDFromImageIO( const std::string &fileName,
+::GetPixelIDFromImageIO( const PathType &fileName,
                          PixelIDValueType &outPixelType,
                          unsigned int & outDimensions )
 {
@@ -274,7 +274,7 @@ ImageReaderBase
 
 unsigned int
 ImageReaderBase
-::GetDimensionFromImageIO(const std::string &filename, unsigned int i)
+::GetDimensionFromImageIO(const PathType  &filename, unsigned int i)
 {
   itk::ImageIOBase::Pointer iobase = this->GetImageIOBase(filename);
 

--- a/Code/IO/src/sitkImageSeriesReader.cxx
+++ b/Code/IO/src/sitkImageSeriesReader.cxx
@@ -31,7 +31,7 @@
 
 namespace itk::simple {
 
-  Image ReadImage ( const std::vector<std::string> &filenames,
+  Image ReadImage ( const std::vector<PathType> &filenames,
                     PixelIDValueEnum outputPixelType,
                     const std::string &imageIO )
     {
@@ -43,7 +43,7 @@ namespace itk::simple {
     }
 
 
-  std::vector<std::string> ImageSeriesReader::GetGDCMSeriesFileNames( const std::string &directory,
+  std::vector<PathType> ImageSeriesReader::GetGDCMSeriesFileNames( const PathType &directory,
                                                                       const std::string &seriesID,
                                                                       bool useSeriesDetails,
                                                                       bool recursive,
@@ -61,10 +61,11 @@ namespace itk::simple {
 
     gdcmSeries->Update();
 
-    return gdcmSeries->GetFileNames(seriesID);
+    auto filenames = gdcmSeries->GetFileNames(seriesID);
+    return std::vector<PathType>(filenames.begin(), filenames.end());
     }
 
-  std::vector<std::string> ImageSeriesReader::GetGDCMSeriesIDs( const std::string &directory,
+  std::vector<std::string> ImageSeriesReader::GetGDCMSeriesIDs( const PathType &directory,
                                                                 bool useSeriesDetails )
     {
     GDCMSeriesFileNames::Pointer gdcmSeries = GDCMSeriesFileNames::New();
@@ -103,24 +104,22 @@ namespace itk::simple {
       out << std::endl;
 
       out << "  FileNames:" << std::endl;
-      std::vector<std::string>::const_iterator iter  = m_FileNames.begin();
-      while( iter != m_FileNames.end() )
+      for ( auto name : m_FileNames)
         {
-        out << "    \"" << *iter << "\"" << std::endl;
-        ++iter;
+        out << "    \"" << name << "\"" << std::endl;
         }
 
       out << ImageReaderBase::ToString();
       return out.str();
     }
 
-  ImageSeriesReader& ImageSeriesReader::SetFileNames ( const std::vector<std::string> &filenames )
+  ImageSeriesReader& ImageSeriesReader::SetFileNames ( const std::vector<PathType> &filenames )
     {
     this->m_FileNames = filenames;
     return *this;
     }
 
-  const std::vector<std::string> &ImageSeriesReader::GetFileNames() const
+  const std::vector<PathType> &ImageSeriesReader::GetFileNames() const
     {
     return this->m_FileNames;
     }
@@ -190,7 +189,7 @@ namespace itk::simple {
     assert( imageio != nullptr );
     typename Reader::Pointer reader = Reader::New();
     reader->SetImageIO( imageio );
-    reader->SetFileNames( this->m_FileNames );
+    reader->SetFileNames( std::vector<std::string>(this->m_FileNames.begin(), this->m_FileNames.end()) );
     // save some computation by not updating this unneeded data-structure
     reader->SetMetaDataDictionaryArrayUpdate(m_MetaDataDictionaryArrayUpdate);
 

--- a/Code/IO/src/sitkImageSeriesWriter.cxx
+++ b/Code/IO/src/sitkImageSeriesWriter.cxx
@@ -32,7 +32,7 @@
 
 namespace itk::simple {
 
-  void WriteImage ( const Image& inImage, const std::vector<std::string> &filenames, bool useCompression, int compressionLevel )
+  void WriteImage ( const Image& inImage, const std::vector<PathType> &filenames, bool useCompression, int compressionLevel )
   {
     ImageSeriesWriter writer;
     writer.Execute( inImage, filenames, useCompression, compressionLevel );
@@ -76,11 +76,9 @@ namespace itk::simple {
     out << std::endl;
 
     out << "  FileNames:" << std::endl;
-    std::vector<std::string>::const_iterator iter  = m_FileNames.begin();
-    while( iter != m_FileNames.end() )
+    for (auto v : m_FileNames)
       {
-      out << "    \"" << *iter << "\"" << std::endl;
-      ++iter;
+      out << "    \"" << v << "\"" << std::endl;
       }
 
     out << "  ImageIOName: ";
@@ -117,7 +115,7 @@ namespace itk::simple {
 
   itk::SmartPointer<ImageIOBase>
   ImageSeriesWriter
-  ::GetImageIOBase(const std::string &fileName)
+  ::GetImageIOBase(const PathType &fileName)
   {
     itk::ImageIOBase::Pointer iobase;
     if (this->m_ImageIOName.empty())
@@ -177,19 +175,19 @@ namespace itk::simple {
   }
 
 
-  ImageSeriesWriter& ImageSeriesWriter::SetFileNames ( const std::vector<std::string> &filenames )
+  ImageSeriesWriter& ImageSeriesWriter::SetFileNames ( const std::vector<PathType> &filenames )
   {
     this->m_FileNames = filenames;
     return *this;
   }
 
-  const std::vector<std::string> &ImageSeriesWriter::GetFileNames() const
+  const std::vector<PathType> &ImageSeriesWriter::GetFileNames() const
   {
     return this->m_FileNames;
   }
 
 
-  ImageSeriesWriter& ImageSeriesWriter::Execute ( const Image& image, const std::vector<std::string> &inFileNames, bool useCompression, int compressionLevel )
+  ImageSeriesWriter& ImageSeriesWriter::Execute ( const Image& image, const std::vector<PathType> &inFileNames, bool useCompression, int compressionLevel )
   {
     this->SetFileNames( inFileNames );
     this->SetUseCompression( useCompression );
@@ -241,7 +239,7 @@ namespace itk::simple {
 
     typename Writer::Pointer writer = Writer::New();
     writer->SetUseCompression( this->m_UseCompression );
-    writer->SetFileNames( this->m_FileNames );
+    writer->SetFileNames( std::vector<std::string>(this->m_FileNames.begin(), this->m_FileNames.end()) );
     writer->SetInput( image );
 
     itk::ImageIOBase::Pointer imageio = this->GetImageIOBase( this->m_FileNames[0] );

--- a/Examples/DicomSeriesReader/DicomSeriesReader.cxx
+++ b/Examples/DicomSeriesReader/DicomSeriesReader.cxx
@@ -37,7 +37,7 @@ int main ( int argc, char* argv[] ) {
 
   // Read the Dicom image series
   sitk::ImageSeriesReader reader;
-  const std::vector<std::string> dicom_names = sitk::ImageSeriesReader::GetGDCMSeriesFileNames( argv[1] );
+  auto dicom_names = sitk::ImageSeriesReader::GetGDCMSeriesFileNames( argv[1] );
   reader.SetFileNames( dicom_names );
 
   sitk::Image image = reader.Execute();

--- a/Testing/Unit/Python/sitkImageReadWrite.py
+++ b/Testing/Unit/Python/sitkImageReadWrite.py
@@ -69,6 +69,13 @@ class ImageReadWrite(unittest.TestCase):
         out = sitk.ReadImage(path)
         self.assertEqual(sitk.Hash(img), sitk.Hash(out))
 
+        z_size = 3
+        path_list = [
+            Path(self.test_dir) / f"write_pathlib_{i}.mha" for i in range(z_size)
+        ]
+        img = sitk.Image([32, 32, z_size], sitk.sitkUInt8)
+        sitk.WriteImage(img, path_list)
+
     def test_write_procedure(self):
         """Test basic functionality of the ImageRead and ImageWrite procedures."""
 
@@ -92,6 +99,7 @@ class ImageReadWrite(unittest.TestCase):
         ]
         sitk.WriteImage(img, fns, compressionLevel=90)
         img = sitk.ReadImage(fns, imageIO="TIFFImageIO")
+
     def test_path_type(self):
         """
         Test functionality of wrapping the PathType object.
@@ -114,8 +122,19 @@ class ImageReadWrite(unittest.TestCase):
         writer.Execute(img)
         self.assertTrue(out_path.exists())
 
+        writer = sitk.ImageSeriesWriter()
+        z_size = 3
+        out_path_series = [
+            Path(self.test_dir) / f"test_path_type_{i}.mha" for i in range(z_size)
+        ]
+        img = sitk.Image([32, 32, z_size], sitk.sitkUInt8)
+        writer.SetFileNames(out_path_series)
 
+        self.assertTrue(all(isinstance(p, str) for p in writer.GetFileNames()))
 
+        writer.Execute(img)
+        for p in out_path_series:
+            self.assertTrue(p.exists())
 
     def _read_write_test(self, img, tmp_filename):
         """ """

--- a/Testing/Unit/Python/sitkImageReadWrite.py
+++ b/Testing/Unit/Python/sitkImageReadWrite.py
@@ -92,6 +92,30 @@ class ImageReadWrite(unittest.TestCase):
         ]
         sitk.WriteImage(img, fns, compressionLevel=90)
         img = sitk.ReadImage(fns, imageIO="TIFFImageIO")
+    def test_path_type(self):
+        """
+        Test functionality of wrapping the PathType object.
+        """
+
+        img = sitk.Image([32, 32], sitk.sitkUInt8)
+
+        writer = sitk.ImageFileWriter()
+        out_path = Path(self.test_dir) / "test_path_type.mha"
+
+        self.assertFalse(out_path.exists())
+        writer.SetFileName(out_path)
+        self.assertTrue(isinstance(writer.GetFileName(), str))
+        writer.Execute(img)
+        self.assertTrue(out_path.exists())
+
+        out_path = Path(self.test_dir) / "test_path_type_str.mha"
+        writer.SetFileName(str(out_path))
+        self.assertTrue(isinstance(writer.GetFileName(), str))
+        writer.Execute(img)
+        self.assertTrue(out_path.exists())
+
+
+
 
     def _read_write_test(self, img, tmp_filename):
         """ """

--- a/Testing/Unit/sitkImageIOTests.cxx
+++ b/Testing/Unit/sitkImageIOTests.cxx
@@ -350,7 +350,7 @@ namespace sitk = itk::simple;
 
 TEST(IO, SeriesReader) {
 
-  std::vector< std::string > fileNames;
+  std::vector< sitk::PathType > fileNames;
   fileNames.push_back( dataFinder.GetFile ( "Input/BlackDots.png" ) );
   fileNames.push_back( dataFinder.GetFile ( "Input/BlackDots.png" ) );
   fileNames.push_back( dataFinder.GetFile ( "Input/BlackDots.png" ) );
@@ -443,7 +443,7 @@ TEST(IO,Write_BadName) {
 
 TEST(IO, DicomSeriesReader) {
 
-  std::vector< std::string > fileNames;
+  std::vector< sitk::PathType > fileNames;
   std::vector< std::string > seriesIDs;
   std::string dicomDir;
 
@@ -528,7 +528,7 @@ TEST(IO, ImageSeriesWriter )
 
 
 
-  std::vector< std::string > fileNames;
+  std::vector< sitk::PathType > fileNames;
   fileNames.push_back( dataFinder.GetOutputDirectory()+"/ImageSeriesWriter_1.png" );
   fileNames.push_back( dataFinder.GetOutputDirectory()+"/ImageSeriesWriter_2.png" );
   fileNames.push_back( dataFinder.GetOutputDirectory()+"/ImageSeriesWriter_3.png" );
@@ -589,7 +589,7 @@ TEST(IO, VectorImageSeriesWriter )
 {
 
 
-  std::vector< std::string > fileNames;
+  std::vector< sitk::PathType > fileNames;
   fileNames.push_back( dataFinder.GetOutputDirectory()+"/VectorImageSeriesWriter_1.png" );
   fileNames.push_back( dataFinder.GetOutputDirectory()+"/VectorImageSeriesWriter_2.png" );
   fileNames.push_back( dataFinder.GetOutputDirectory()+"/VectorImageSeriesWriter_3.png" );

--- a/Testing/Unit/sitkImageViewerTest.cxx
+++ b/Testing/Unit/sitkImageViewerTest.cxx
@@ -27,24 +27,6 @@
 
 namespace sitk = itk::simple;
 
-// returns true of two word lists are the same
-//
-bool compare_word_lists(std::vector<std::string> a, std::vector<std::string> b)
-  {
-  if ( a.size() != b.size() )
-    {
-    return false;
-    }
-
-  unsigned int i;
-  for (i=0; i< a.size(); i++)
-    {
-    if (a[i].compare(b[i]))
-      return false;
-    }
-  return true;
-  }
-
 TEST(ImageViewerTest,Methods)
   {
   itk::simple::ImageViewer iv;
@@ -79,19 +61,19 @@ TEST(ImageViewerTest,GlobalDefaults)
   {
   itk::simple::ImageViewer iv;
 
-  std::vector<std::string> words;
+  std::vector<itk::simple::PathType> words;
   words.emplace_back("alpha" );
   words.emplace_back("beta" );
 
-  std::vector<std::string> path;
+  std::vector<itk::simple::PathType> path;
   iv.SetGlobalDefaultSearchPath( words );
   path = iv.GetGlobalDefaultSearchPath();
-  EXPECT_EQ( compare_word_lists(words, path), true );
+  EXPECT_EQ( words, path);
 
-  std::vector<std::string> names;
+  std::vector<itk::simple::PathType> names;
   iv.SetGlobalDefaultExecutableNames( words );
   names = iv.GetGlobalDefaultExecutableNames();
-  EXPECT_EQ( compare_word_lists(words, names), true );
+  EXPECT_EQ( words, names);
 
   //
   iv.SetGlobalDefaultDebug( true );

--- a/Wrapping/Common/SimpleITK_Common.i
+++ b/Wrapping/Common/SimpleITK_Common.i
@@ -95,8 +95,10 @@
 %{
 #include <SimpleITK.h>
 #include <sitkImageOperators.h>
+
 %}
 
+%apply std::string { itk::simple::PathType };
 
 // Help SWIG handle std vectors
 namespace std
@@ -170,6 +172,7 @@ namespace std
 // Common
 %include "sitkConfigure.h"
 %include "sitkVersion.h"
+%include "sitkPathType.h"
 %include "sitkPixelIDValues.h"
 %include "sitkInterpolator.h"
 %include "sitkImage.h"

--- a/Wrapping/Python/CMakeLists.txt
+++ b/Wrapping/Python/CMakeLists.txt
@@ -34,7 +34,8 @@ set(CMAKE_SWIG_OUTDIR ${CMAKE_CURRENT_BINARY_DIR}/SimpleITK)
 set(SWIG_MODULE_SimpleITK_EXTRA_DEPS ${SWIG_EXTRA_DEPS}
   ${CMAKE_CURRENT_SOURCE_DIR}/Python.i
   ${CMAKE_CURRENT_SOURCE_DIR}/sitkImage.i
-  ${CMAKE_CURRENT_SOURCE_DIR}/sitkTransform.i )
+  ${CMAKE_CURRENT_SOURCE_DIR}/sitkTransform.i
+  ${CMAKE_CURRENT_SOURCE_DIR}/sitkPathType.i)
 SWIG_add_module ( SimpleITK python
   SimpleITK.i
   sitkPyCommand.cxx )

--- a/Wrapping/Python/Python.i
+++ b/Wrapping/Python/Python.i
@@ -26,6 +26,7 @@
 %}
 
 %include "PythonDocstrings.i"
+%include "sitkPathType.i"
  //%feature("autodoc", "1");
 
 // ignore overload methods of int type when there is an enum

--- a/Wrapping/Python/SimpleITK/extra.py
+++ b/Wrapping/Python/SimpleITK/extra.py
@@ -374,10 +374,10 @@ def ReadImage(
 
     if isinstance(fileName, (str, Path)):
         reader = ImageFileReader()
-        reader.SetFileName(str(fileName))
+        reader.SetFileName(fileName)
     else:
         reader = ImageSeriesReader()
-        reader.SetFileNames([str(name) for name in fileName])
+        reader.SetFileNames(fileName)
 
     reader.SetImageIO(imageIO)
     reader.SetOutputPixelType(outputPixelType)
@@ -422,10 +422,10 @@ def WriteImage(
     """
     if isinstance(fileName, (str, Path)):
         writer = ImageFileWriter()
-        writer.SetFileName(str(fileName))
+        writer.SetFileName(fileName)
     else:
         writer = ImageSeriesWriter()
-        writer.SetFileNames([str(name) for name in fileName])
+        writer.SetFileNames(fileName)
 
     writer.SetUseCompression(useCompression)
     writer.SetCompressionLevel(compressionLevel)

--- a/Wrapping/Python/sitkPathType.i
+++ b/Wrapping/Python/sitkPathType.i
@@ -50,6 +50,8 @@ SWIG_sitk_PathType_isPathInstance(PyObject * obj)
   }
 
 }
+%typemap(freearg) itk::simple::Path {}
+
 
 %typemap(freearg) itk::simple::PathType {}
 

--- a/Wrapping/Python/sitkPathType.i
+++ b/Wrapping/Python/sitkPathType.i
@@ -1,0 +1,94 @@
+/* -----------------------------------------------------------------------------
+ * Based on std_filesystem.i
+ *
+ * Allows convertsion from Python Strings or pathlib.Path to sitk.PathType
+ * ----------------------------------------------------------------------------- */
+
+
+%fragment("SWIG_sitk_PathType", "header"){
+  SWIGINTERN PyObject * SWIG_sitk_PathType_importPathClass()
+{
+  PyObject * module = PyImport_ImportModule("pathlib");
+  PyObject * cls = PyObject_GetAttrString(module, "Path");
+  Py_DECREF(module);
+  return cls;
+}
+
+SWIGINTERN bool
+SWIG_sitk_PathType_isPathInstance(PyObject * obj)
+{
+  PyObject * cls = SWIG_sitk_PathType_importPathClass();
+  bool       is_instance = PyObject_IsInstance(obj, cls);
+  Py_DECREF(cls);
+  return is_instance;
+}
+}
+
+%typemap(in, fragment="SWIG_sitk_PathType", fragment="<type_traits>") itk::simple::PathType {
+  This is not being currently used
+  if (PyUnicode_Check($input)) {
+    PyObject *bytes = NULL;
+    const char *s = SWIG_PyUnicode_AsUTF8AndSize($input, NULL, &bytes);
+    $1 = itk::simple::PathType(s);
+    Py_XDECREF(bytes);
+  } else if (SWIG_sitk_PathType_isPathInstance($input)) {
+    PyObject *str_obj = PyObject_Str($input);
+    PyObject *bytes = NULL;
+    const char *s = SWIG_PyUnicode_AsUTF8AndSize(str_obj, NULL, &bytes);
+    $1 = itk::simpleitk::PathType(s);
+    Py_XDECREF(bytes);
+    Py_DECREF(str_obj);
+
+  } else {
+    std::string *ptr = (std::string *)0;
+    int res = SWIG_AsPtr_std_string(obj1, &ptr);
+    if (!SWIG_IsOK(res)) {
+      %argument_fail(res, "$type", $symname, $argnum);
+    }
+  std::string * temp = %reinterpret_cast(ptr, $1_ltype*);
+  $1 = itk::simple::PathType(*temp);
+  }
+
+}
+
+%typemap(freearg) itk::simple::PathType {}
+
+
+
+%typemap(in, fragment="SWIG_sitk_PathType", fragment="<type_traits>") const itk::simple::PathType &(itk::simple::PathType temp_path) {
+  if (PyUnicode_Check($input)) {
+    PyObject *bytes = NULL;
+    const char *s = SWIG_PyUnicode_AsUTF8AndSize($input, NULL, &bytes);
+    temp_path = itk::simple::PathType(s);
+    $1 = &temp_path;
+    Py_XDECREF(bytes);
+  } else if (SWIG_sitk_PathType_isPathInstance($input)) {
+    PyObject *str_obj = PyObject_Str($input);
+    PyObject *bytes = NULL;
+    const char *s = SWIG_PyUnicode_AsUTF8AndSize(str_obj, NULL, &bytes);
+    temp_path = itk::simple::PathType(s);
+    $1 = &temp_path;
+    Py_XDECREF(bytes);
+    Py_DECREF(str_obj);
+  } else {
+    void *argp = 0;
+    int res = SWIG_ConvertPtr($input, &argp, $descriptor, $disown | 0);
+    if (!SWIG_IsOK(res)) {
+      %argument_fail(res, "$type", $symname, $argnum);
+    }
+    $1 = %reinterpret_cast(argp, $1_ltype);
+  }
+}
+
+%typemap(freearg) const itk::simple::PathType &{}
+
+
+// Fallback to the std::string "out" typemap
+//
+//%typemap(out, fragment="SWIG_sitk_PathType", fragment="<type_traits>") itk::simple::PathType {
+//  $result = SWIG_From_std_string($1);
+//}
+
+//%typemap(out, fragment="SWIG_sitk_PathType", fragment="<type_traits>") const itk::simple::PathType & {
+//  $result = SWIG_From_std_string(*$1);
+//}

--- a/Wrapping/Python/sitkTransform.i
+++ b/Wrapping/Python/sitkTransform.i
@@ -32,21 +32,10 @@
  val = val.Downcast()
 };
 
-%pythonprepend itk::simple::ReadTransform
-{
-  filename=str(filename)
-};
 %pythonappend itk::simple::ReadTransform
 {
  val = val.Downcast()
 };
-%pythonprepend itk::simple::WriteTransform %{
-  filename = str(filename)
-%}
-
-%pythonprepend itk::simple::Transform::WriteTransform %{
-  filename = str(filename)
-%}
 
 %extend itk::simple::Transform {
    %pythoncode


### PR DESCRIPTION
Introduce PathType where std::string is used to enable easy change of the type to std::filesystem::path.