### PR TITLE
Restrict SWIGWORDSIZE64 definition to required SWIG versions

### DIFF
--- a/Wrapping/R/CMakeLists.txt
+++ b/Wrapping/R/CMakeLists.txt
@@ -18,8 +18,10 @@ set(SWIG_MODULE_SimpleITK_EXTRA_DEPS ${SWIG_EXTRA_DEPS} ${CMAKE_CURRENT_SOURCE_D
 SWIG_add_module ( SimpleITK r SimpleITK.i sitkRCommand.cxx sitkRArray.cxx )
 target_link_libraries ( ${SWIG_MODULE_SimpleITK_TARGET_NAME} ${SimpleITK_LIBRARIES} )
 
-# Workaround for SWIG 4.2.0, 4.2.1 to correctly convert std::vector of 64-bit integer
-if(SITK_ULONG_SAME_AS_UINT64)
+sitk_target_link_libraries_with_dynamic_lookup ( ${SWIG_MODULE_SimpleITK_TARGET_NAME} ${R_LIBRARIES} )
+
+# Workaround for SWIG 4.2.x issue with R and 64-bit integers. See GH issue swig/swig#2847 for details.
+if(SWIG_VERSION VERSION_GREATER_EQUAL "4.2.0" AND SWIG_VERSION VERSION_LESS "4.3.0" AND SITK_ULONG_SAME_AS_UINT64)
   target_compile_definitions( ${SWIG_MODULE_SimpleITK_TARGET_NAME} PRIVATE SWIGWORDSIZE64 )
 endif()
 


### PR DESCRIPTION
Also restore optional linking to R_LIBRARIES.