### PR TITLE
Use ITK's SizeGreatestPrimeFactor

### DIFF
--- a/Code/BasicFilters/json/FFTPadImageFilter.json
+++ b/Code/BasicFilters/json/FFTPadImageFilter.json
@@ -21,13 +21,24 @@
     {
       "name" : "SizeGreatestPrimeFactor",
       "type" : "int",
-      "default" : "5",
+      "default" : "itk::simple::FFTPadImageFilter::DefaultSizeGreatestPrimeFactor()",
       "briefdescriptionSet" : "",
-      "detaileddescriptionSet" : "Set/Get the greatest prime factor allowed on the size of the padded image. The filter increase the size of the image to reach a size with the greatest prime factor smaller or equal to the specified value. The default value is 13, which is the greatest prime number for which the FFT are precomputed in FFTW, and thus gives very good performance. A greatest prime factor of 2 produce a size which is a power of 2, and thus is suitable for vnl base fft filters. A greatest prime factor of 1 or less - typically 0 - disable the extra padding.",
+      "detaileddescriptionSet" : "Set/Get the greatest prime factor allowed on the size of the padded image. The filter increase the size of the image to reach a size with the greatest prime factor smaller or equal to the specified value. The default value is 5 for VNL, which is the greatest prime number for which the FFT are precomputed in FFTW, and thus gives very good performance. A greatest prime factor of 2 produce a size which is a power of 2, and thus is suitable for vnl base fft filters. A greatest prime factor of 1 or less - typically 0 - disable the extra padding.",
       "briefdescriptionGet" : "",
-      "detaileddescriptionGet" : "Set/Get the greatest prime factor allowed on the size of the padded image. The filter increase the size of the image to reach a size with the greatest prime factor smaller or equal to the specified value. The default value is 13, which is the greatest prime number for which the FFT are precomputed in FFTW, and thus gives very good performance. A greatest prime factor of 2 produce a size which is a power of 2, and thus is suitable for vnl base fft filters. A greatest prime factor of 1 or less - typically 0 - disable the extra padding."
+      "detaileddescriptionGet" : "Set/Get the greatest prime factor allowed on the size of the padded image. The filter increase the size of the image to reach a size with the greatest prime factor smaller or equal to the specified value. The default value is 5 for VNL, which is the greatest prime number for which the FFT are precomputed in FFTW, and thus gives very good performance. A greatest prime factor of 2 produce a size which is a power of 2, and thus is suitable for vnl base fft filters. A greatest prime factor of 1 or less - typically 0 - disable the extra padding."
     }
   ],
+  "custom_methods" : [
+    {
+      "name" : "DefaultSizeGreatestPrimeFactor",
+      "doc" : "The largest prime factor supported by underlying FFT implementation (FFTW or VNL).",
+      "static" : true,
+      "return_type" : "int",
+      "parameters" : [
+      ],
+      "body" : "using RealImageType = itk::Image<float, 2>;\n  return itk::FFTPadImageFilter<RealImageType>::New()->GetSizeGreatestPrimeFactor();"
+    }
+    ],
   "tests" : [
     {
       "tag" : "defaults",

--- a/ExpandTemplateGenerator/Components/CustomMethods.h.in
+++ b/ExpandTemplateGenerator/Components/CustomMethods.h.in
@@ -5,7 +5,11 @@ for i=1,#custom_methods do
   if custom_methods[i].doc then
     OUT=OUT..'      /** '..custom_methods[i].doc..' */\n'
   end
-  OUT=OUT..'      '..custom_methods[i].return_type..' '..custom_methods[i].name..'('
+  OUT=OUT..'      '
+  if custom_methods[i].static then
+    OUT=OUT..'static '
+  end
+  OUT=OUT..custom_methods[i].return_type..' '..custom_methods[i].name..'('
   if custom_methods[i].parameters then
     for pnum=1,#custom_methods[i].parameters do
       if  pnum > 1 then


### PR DESCRIPTION
The value depends on the underly FFT implementation, which could be FFTW or VNL. Using the filter's value allows FFTW implementations to have a 13 value.