### PR TITLE
Use new CMP0156 to address duplicate library warnings.

### DIFF
--- a/CMake/sitkProjectLanguageCommon.cmake
+++ b/CMake/sitkProjectLanguageCommon.cmake
@@ -1,5 +1,6 @@
 
 foreach(p
+        CMP0156 # De-duplicate libraries on link lines based on linker capabilities.
     )
   if(POLICY ${p})
     cmake_policy(SET ${p} NEW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ project ( SimpleITK )
 cmake_policy( VERSION ${SITK_CMAKE_POLICY_VERSION} )
 
 foreach(p
+        CMP0156 # De-duplicate libraries on link lines based on linker capabilities.
     )
   if(POLICY ${p})
     cmake_policy(SET ${p} NEW)


### PR DESCRIPTION
With XCode 15.0+ addresses :
 ld: warning: ignoring duplicate libraries: '-lm'