### PR TITLE
Add mac-arm64 to Build.yml

### DIFF
--- a/.github/actions/package_csharp/scripts/mac_build_csharp.sh
+++ b/.github/actions/package_csharp/scripts/mac_build_csharp.sh
@@ -7,11 +7,30 @@ export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=2
 echo "COREBINARYDIRECTORY: ${COREBINARYDIRECTORY}"
 echo "CTEST_SOURCE_DIRECTORY: ${CTEST_SOURCE_DIRECTORY}"
 
+# Detect OS
+OS_NAME=$(uname -s)
+
+# Detect version (for macOS)
+if [ "$OS_NAME" == "Darwin" ]; then
+    OS_ARCH=$(uname -m)
+    if [ "$OS_ARCH" == "x86_64" ]; then
+        OS_VERSION="10.9"
+    elif [ "$OS_ARCH" == "arm64" ]; then
+        OS_VERSION="11.0"
+    else
+        echo "Unsupported architecture: $OS_ARCH"
+        exit 1
+    fi
+else
+    echo "Unsupported OS: $OS_NAME"
+    exit 1
+fi
+
 read -r -d '' CTEST_CACHE << EOM || true
 CMAKE_PREFIX_PATH:PATH=${COREBINARYDIRECTORY}
 CMAKE_CXX_VISIBILITY_PRESET:STRING=hidden
 CMAKE_VISIBILITY_INLINES_HIDDEN:BOOL=ON
-CMAKE_OSX_DEPLOYMENT_TARGET=10.9
+CMAKE_OSX_DEPLOYMENT_TARGET=$OS_VERSION
 SWIG_EXECUTABLE:FILEPATH=${COREBINARYDIRECTORY}/Swig/bin/swig
 BUILD_EXAMPLES:BOOL=ON
 BUILD_TESTING:BOOL=ON

--- a/.github/actions/package_java/scripts/mac_build_java.sh
+++ b/.github/actions/package_java/scripts/mac_build_java.sh
@@ -7,11 +7,32 @@ export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=2
 echo "COREBINARYDIRECTORY: ${COREBINARYDIRECTORY}"
 echo "CTEST_SOURCE_DIRECTORY: ${CTEST_SOURCE_DIRECTORY}"
 
+# Detect OS
+OS_NAME=$(uname -s)
+
+# Detect version (for macOS)
+if [ "$OS_NAME" == "Darwin" ]; then
+    OS_ARCH=$(uname -m)
+    if [ "$OS_ARCH" == "x86_64" ]; then
+        OS_VERSION="10.9"
+    elif [ "$OS_ARCH" == "arm64" ]; then
+        OS_VERSION="11.0"
+    else
+        echo "Unsupported architecture: $OS_ARCH"
+        exit 1
+    fi
+
+    SIMPLEITK_PYTHON_PLAT_NAME="macosx-$OS_VERSION-$OS_ARCH"
+else
+    echo "Unsupported OS: $OS_NAME"
+    exit 1
+fi
+
 read -r -d '' CTEST_CACHE << EOM || true
 CMAKE_PREFIX_PATH:PATH=${COREBINARYDIRECTORY}
 CMAKE_CXX_VISIBILITY_PRESET:STRING=hidden
 CMAKE_VISIBILITY_INLINES_HIDDEN:BOOL=ON
-CMAKE_OSX_DEPLOYMENT_TARGET=10.9
+CMAKE_OSX_DEPLOYMENT_TARGET=$OS_VERSION
 SWIG_EXECUTABLE:FILEPATH=${COREBINARYDIRECTORY}/Swig/bin/swig
 BUILD_EXAMPLES:BOOL=ON
 BUILD_TESTING:BOOL=ON

--- a/.github/actions/package_python/scripts/mac_build_python.sh
+++ b/.github/actions/package_python/scripts/mac_build_python.sh
@@ -11,15 +11,35 @@ which python
 python --version
 PYTHON_VERSION=$(python -c 'import sys;print ("{0}{1}".format(sys.version_info[0], sys.version_info[1]))')
 
+# Detect OS
+OS_NAME=$(uname -s)
+
+# Detect version (for macOS)
+if [ "$OS_NAME" == "Darwin" ]; then
+    OS_ARCH=$(uname -m)
+    if [ "$OS_ARCH" == "x86_64" ]; then
+        OS_VERSION="10.9"
+    elif [ "$OS_ARCH" == "arm64" ]; then
+        OS_VERSION="11.0"
+    else
+        echo "Unsupported architecture: $OS_ARCH"
+        exit 1
+    fi
+    SIMPLEITK_PYTHON_PLAT_NAME="macosx-$OS_VERSION-$OS_ARCH"
+else
+    echo "Unsupported OS: $OS_NAME"
+    exit 1
+fi
+
 read -r -d '' CTEST_CACHE << EOM || true
 CMAKE_PREFIX_PATH:PATH=${COREBINARYDIRECTORY}
 CMAKE_CXX_VISIBILITY_PRESET:STRING=hidden
 CMAKE_VISIBILITY_INLINES_HIDDEN:BOOL=ON
-CMAKE_OSX_DEPLOYMENT_TARGET=10.9
+CMAKE_OSX_DEPLOYMENT_TARGET=$OS_VERSION
 SWIG_EXECUTABLE:FILEPATH=${COREBINARYDIRECTORY}/Swig/bin/swig
 BUILD_EXAMPLES:BOOL=ON
 BUILD_TESTING:BOOL=ON
-SimpleITK_PYTHON_PLAT_NAME:STRING=macosx-10.9-x86_64
+SimpleITK_PYTHON_PLAT_NAME:STRING=$SIMPLEITK_PYTHON_PLAT_NAME
 SimpleITK_BUILD_DISTRIBUTE:BOOL=ON
 SimpleITK_PYTHON_WHEEL:BOOL=1
 SimpleITK_BUILD_STRIP:BOOL=1

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -21,8 +21,6 @@ concurrency:
 jobs:
 
   build:
-
-
     # The CMake configure and build commands are platform-agnostic and should work a cross
     # platforms.
     if: github.repository == 'SimpleITK/SimpleITK'
@@ -30,9 +28,20 @@ jobs:
     env:
       CTEST_SOURCE_DIRECTORY: "${{ github.workspace }}"
     strategy:
-      max-parallel: 4
+      max-parallel: 5
       matrix:
         include:
+          - os: mac-arm64
+            cmake-build-type: "RelMinSize"
+            cmake-generator: "Ninja"
+            ctest-cache: |
+              WRAP_PYTHON:BOOL=ON
+              WRAP_JAVA:BOOL=ON
+              CMAKE_CXX_FLAGS:STRING=-fvisibility=hidden -fvisibility-inlines-hidden
+              CMAKE_C_FLAGS:STRING=-fvisibility=hidden
+              CMAKE_CXX_VISIBILITY_PRESET:STRING=hidden
+              CMAKE_VISIBILITY_INLINES_HIDDEN:BOOL=ON
+              SimpleITK_EXPLICIT_INSTANTIATION:BOOL=ON
           - os: self-hosted-x64
             cmake-build-type: "Release"
             cmake-generator: "Ninja"

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -87,7 +87,7 @@ jobs:
       CTEST_CONFIGURATION_TYPE: "${{ matrix.cmake-build-type }}"
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 5
       matrix:
         include:
           - os: macos-13
@@ -97,6 +97,16 @@ jobs:
               CMAKE_CXX_FLAGS:STRING=-fvisibility=hidden -fvisibility-inlines-hidden
               CMAKE_C_FLAGS:STRING=-fvisibility=hidden
               CMAKE_OSX_DEPLOYMENT_TARGET=10.9
+              ITK_C_OPTIMIZATION_FLAGS:STRING=
+              ITK_CXX_OPTIMIZATION_FLAGS:STRING=
+              SimpleITK_BUILD_DISTRIBUTE:BOOL=ON
+          - os: mac-arm64
+            cmake-build-type: "Release"
+            cmake-generator: "Ninja"
+            ctest-cache: |
+              CMAKE_CXX_FLAGS:STRING=-fvisibility=hidden -fvisibility-inlines-hidden
+              CMAKE_C_FLAGS:STRING=-fvisibility=hidden
+              CMAKE_OSX_DEPLOYMENT_TARGET=11.0
               ITK_C_OPTIMIZATION_FLAGS:STRING=
               ITK_CXX_OPTIMIZATION_FLAGS:STRING=
               SimpleITK_BUILD_DISTRIBUTE:BOOL=ON


### PR DESCRIPTION
This PR adds a self-hosted Github Runner `mac-arm64` to the build workflow to support arm64 builds on MacOS.