### PR TITLE
Address CMake warning about version range unsupported

### DIFF
--- a/CMake/FindLuaInterp.cmake
+++ b/CMake/FindLuaInterp.cmake
@@ -44,12 +44,16 @@ if(LUA_EXECUTABLE)
   endif()
 endif()
 
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 2.19)
+  set(_args "HANDLE_VERSION_RANGE")
+endif()
 
 # handle the QUIETLY and REQUIRED arguments and set LUA_FOUND to TRUE if
 # all listed variables are TRUE
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(LuaInterp
                                   REQUIRED_VARS LUA_EXECUTABLE
-                                  VERSION_VAR LUA_VERSION)
-
+                                  VERSION_VAR LUA_EXECUTABLE_VERSION
+                                  ${_args}
+)
 mark_as_advanced(LUA_EXECUTABLE)

--- a/CMake/sitkGenerateFilterSource.cmake
+++ b/CMake/sitkGenerateFilterSource.cmake
@@ -7,7 +7,12 @@ if ( NOT SimpleITK_LUA_EXECUTABLE )
   get_property( SAVE_LUA_EXECUTABLE_DOCSTRING CACHE LUA_EXECUTABLE PROPERTY HELPSTRING )
   unset(LUA_EXECUTABLE CACHE)
 
-  find_package( LuaInterp 5.3...5.4  REQUIRED )
+  if (CMAKE_VERSION VERSION_GREATER 3.19)
+    # support for ranges added in 3.19
+    find_package( LuaInterp 5.3...<5.5  REQUIRED )
+  else()
+    find_package( LuaInterp 5.3 REQUIRED )
+  endif ()
   set( SimpleITK_LUA_EXECUTABLE ${LUA_EXECUTABLE} CACHE PATH "Lua executable used for code generation." )
 
   if (DEFINED SAVE_LUA_EXECUTABLE)


### PR DESCRIPTION
Only use version range with CMake >=3.20, and add require flag in implementation.