### PR TITLE
Fix SyntaxWarning in Python 3.12

### DIFF
--- a/Wrapping/Python/SimpleITK/extra.py
+++ b/Wrapping/Python/SimpleITK/extra.py
@@ -473,7 +473,7 @@ def DiscreteGaussian(
 
     Also See
     --------
-      \sa itk::simple::DiscreteGaussianImageFilter for the object oriented interface
+     itk::simple::DiscreteGaussianImageFilter for the object oriented interface
     """
     f = DiscreteGaussianImageFilter()
     f.SetVariance(variance)


### PR DESCRIPTION
Fixes #2189.