### PR TITLE
Remove Python 3.8 from GHA

### DIFF
--- a/.github/workflows/BatchBuild.yml
+++ b/.github/workflows/BatchBuild.yml
@@ -153,12 +153,12 @@ jobs:
           enableCrossOsArchive: true
           restore-keys: |
             external-data-v1-
-      - name: Set up Python 3.8
+      - name: Set up Python 3.11
         if: matrix.os != 'self-hosted-arm'
         uses: actions/setup-python@v5
         id: cpy
         with:
-          python-version: 3.8
+          python-version: 3.11
       - name: Update Path for shared libraries
         shell: bash
         if: contains( ${{ matrix.ctest-cache }}, 'BUILD_SHARED_LIBS:BOOL=ON' ) && contains( ${{ matrix.os }}, 'windows' )

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -95,12 +95,12 @@ jobs:
         enableCrossOsArchive: true
         restore-keys: |
           external-data-v1-
-    - name: Set up Python 3.8
+    - name: Set up Python 3.11
       uses: actions/setup-python@v5
       if: matrix.os != 'self-hosted-arm'
       id: cpy
       with:
-        python-version: 3.8
+        python-version: 3.11
 
     - name: Install build dependencies
       if: matrix.os != 'self-hosted-arm'

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -222,11 +222,6 @@ jobs:
         with:
           python-version: 3.9
 
-      - name: Package Python 3.8
-        uses: ./.github/actions/package_python
-        with:
-          python-version: 3.8
-
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/PythonLintAndSpell.yml
+++ b/.github/workflows/PythonLintAndSpell.yml
@@ -41,10 +41,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: "3.10"
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Python 3.10 is EOL 2024-10.

Update to 3.11 for github actions. Remove building binaries for 3.8.