### PR TITLE
BUG: Correct SITK_MAX_DIMENSION usage - For Release

### DIFF
--- a/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilterImpl.cxx
+++ b/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilterImpl.cxx
@@ -5,6 +5,7 @@
 #include "sitkCastImageFilter.h"
 #include "sitkImageConvert.h"
 #include "sitkInternalUtilities.h"
+#include "sitkImageConvert.hxx"
 
 namespace itk::simple
 {
@@ -125,7 +126,7 @@ TransformixImageFilter::TransformixImageFilterImpl ::TransformixImageFilterImpl(
   this->m_MemberFactory->RegisterMemberFunctions<FloatPixelIDTypeList, 2>();
   this->m_MemberFactory->RegisterMemberFunctions<FloatPixelIDTypeList, 3>();
 
-#if SITK_MAX_DIMENSIONS >= 4
+#if SITK_MAX_DIMENSION >= 4
   m_MemberFactory->RegisterMemberFunctions<FloatPixelIDTypeList, 4>();
 #endif
 

--- a/Testing/Unit/sitkTransformixImageFilterTests.cxx
+++ b/Testing/Unit/sitkTransformixImageFilterTests.cxx
@@ -122,7 +122,7 @@ TEST(TransformixImageFilter, ComputeDeformationField)
   EXPECT_GT(deformationVector[1], 1.0);
 }
 
-#if SITK_MAX_DIMENSIONS >= 4
+#if SITK_MAX_DIMENSION >= 4
 
 TEST(TransformixImageFilter, Transformation4D)
 {


### PR DESCRIPTION
Fixes instantiation of 4D Elastix.