### PR TITLE
Use constexpr statements over enable_if dispatched functions

### DIFF
--- a/Code/Common/include/sitkDualMemberFunctionFactory.hxx
+++ b/Code/Common/include/sitkDualMemberFunctionFactory.hxx
@@ -42,29 +42,26 @@ struct DualMemberFunctionInstantiater
   {}
 
   template <class TPixelIDType1, class TPixelIDType2 = TPixelIDType1>
-  typename std::enable_if<IsInstantiated<TPixelIDType1, VImageDimension>::Value &&
-                          IsInstantiated<TPixelIDType2, VImageDimension>::Value>::type
+  void
   operator()(TPixelIDType1 * t1 = nullptr, TPixelIDType2 * t2 = nullptr) const
   {
     (void)t1;
     (void)t2;
-    using ImageType1 = typename PixelIDToImageType<TPixelIDType1, VImageDimension>::ImageType;
-    using ImageType2 = typename PixelIDToImageType<TPixelIDType2, VImageDimension>::ImageType;
-    using AddressorType = TAddressor;
 
-    AddressorType addressor;
-    m_Factory.Register(
-      addressor.CLANG_TEMPLATE operator()<ImageType1, ImageType2>(), (ImageType1 *)(nullptr), (ImageType2 *)(nullptr));
-  }
+      if constexpr (IsInstantiated<TPixelIDType1, VImageDimension>::Value &&
+                  IsInstantiated<TPixelIDType2, VImageDimension>::Value)
+      {
+        // conditionally instantiate the member function when PixelID is enabled
 
-  // this methods is conditionally enabled when the PixelID is not instantiated
-  template <class TPixelIDType1, class TPixelIDType2 = TPixelIDType1>
-  typename std::enable_if<!(IsInstantiated<TPixelIDType1, VImageDimension>::Value &&
-                            IsInstantiated<TPixelIDType2, VImageDimension>::Value)>::type
-  operator()(TPixelIDType1 * t1 = nullptr, TPixelIDType2 * t2 = nullptr) const
-  {
-    (void)t1;
-    (void)t2;
+        using ImageType1 = typename PixelIDToImageType<TPixelIDType1, VImageDimension>::ImageType;
+        using ImageType2 = typename PixelIDToImageType<TPixelIDType2, VImageDimension>::ImageType;
+        using AddressorType = TAddressor;
+
+        AddressorType addressor;
+        m_Factory.Register(addressor.CLANG_TEMPLATE operator()<ImageType1, ImageType2>(),
+                           (ImageType1 *)(nullptr),
+                           (ImageType2 *)(nullptr));
+      }
   }
 
 private:

--- a/Code/Common/include/sitkImage.h
+++ b/Code/Common/include/sitkImage.h
@@ -704,23 +704,12 @@ protected:
   void
   Allocate(const std::vector<unsigned int> & size, PixelIDValueEnum valueEnum, unsigned int numberOfComponents);
 
-  /** \brief Dispatched methods for allocating images
-   *
-   * The enable if idiom is used here to enable different methods
-   * for different pixel/image types.
+  /** \brief Allocates images of different types
    *
    * @{
    */
   template <class TImageType>
-  typename std::enable_if<IsBasic<TImageType>::Value>::type
-  AllocateInternal(const std::vector<unsigned int> & size, unsigned int numberOfComponents);
-
-  template <class TImageType>
-  typename std::enable_if<IsVector<TImageType>::Value>::type
-  AllocateInternal(const std::vector<unsigned int> & size, unsigned int numberOfComponents);
-
-  template <class TImageType>
-  typename std::enable_if<IsLabel<TImageType>::Value>::type
+  void
   AllocateInternal(const std::vector<unsigned int> & size, unsigned int numberOfComponents);
   /**@}*/
 
@@ -728,20 +717,14 @@ protected:
    *  @{
    */
   template <class TImageType>
-  std::enable_if_t<IsVector<TImageType>::Value, Image>
+  Image
   ToVectorInternal(bool inPlace);
 
-  template <class TImageType>
-  std::enable_if_t<IsBasic<TImageType>::Value, Image>
-  ToVectorInternal(bool inPlace);
 
   template <class TImageType>
-  std::enable_if_t<IsVector<TImageType>::Value, Image>
+  Image
   ToScalarInternal(bool inPlace);
 
-  template <class TImageType>
-  std::enable_if_t<IsBasic<TImageType>::Value, Image>
-  ToScalarInternal(bool inPlace);
   /**@}*/
 
 private:

--- a/Code/Common/include/sitkMemberFunctionFactory.h
+++ b/Code/Common/include/sitkMemberFunctionFactory.h
@@ -134,20 +134,14 @@ public:
             unsigned int VImageDimension,
             unsigned int VImageDimensionStop,
             typename TAddressor>
-  typename std::enable_if<(VImageDimensionStop > VImageDimension)>::type
+  void
   RegisterMemberFunctions()
   {
     this->RegisterMemberFunctions<TPixelIDTypeList, VImageDimensionStop, TAddressor>();
-    this->RegisterMemberFunctions<TPixelIDTypeList, VImageDimension, VImageDimensionStop - 1, TAddressor>();
-  }
-  template <typename TPixelIDTypeList,
-            unsigned int VImageDimension,
-            unsigned int VImageDimensionStop,
-            typename TAddressor>
-  typename std::enable_if<(VImageDimensionStop == VImageDimension)>::type
-  RegisterMemberFunctions()
-  {
-    this->RegisterMemberFunctions<TPixelIDTypeList, VImageDimensionStop, TAddressor>();
+    if constexpr (VImageDimensionStop > VImageDimension)
+    {
+      this->RegisterMemberFunctions<TPixelIDTypeList, VImageDimension, VImageDimensionStop - 1, TAddressor>();
+    }
   }
   /** @} */
 

--- a/Code/Common/include/sitkMemberFunctionFactory.hxx
+++ b/Code/Common/include/sitkMemberFunctionFactory.hxx
@@ -43,23 +43,18 @@ struct MemberFunctionInstantiater
   {}
 
   template <class TPixelIDType>
-  typename std::enable_if<IsInstantiated<TPixelIDType, VImageDimension>::Value>::type
+  void
   operator()(TPixelIDType * id = nullptr) const
   {
     Unused(id);
-    using ImageType = typename PixelIDToImageType<TPixelIDType, VImageDimension>::ImageType;
-    using AddressorType = TAddressor;
+    if constexpr (IsInstantiated<TPixelIDType, VImageDimension>::Value)
+    {
+      using ImageType = typename PixelIDToImageType<TPixelIDType, VImageDimension>::ImageType;
+      using AddressorType = TAddressor;
 
-    AddressorType addressor;
-    m_Factory.Register(addressor.CLANG_TEMPLATE operator()<ImageType>(), (ImageType *)(nullptr));
-  }
-
-  // this methods is conditionally enabled when the PixelID is not instantiated
-  template <class TPixelIDType>
-  typename std::enable_if<!IsInstantiated<TPixelIDType, VImageDimension>::Value>::type
-  operator()(TPixelIDType * id = nullptr) const
-  {
-    Unused(id);
+      AddressorType addressor;
+      m_Factory.Register(addressor.CLANG_TEMPLATE operator()<ImageType>(), (ImageType *)(nullptr));
+    }
   }
 
 private:

--- a/Code/Common/include/sitkMemberFunctionFactoryBase.h
+++ b/Code/Common/include/sitkMemberFunctionFactoryBase.h
@@ -68,30 +68,14 @@ struct hash<std::pair<S, T>>
 template <class... TupleArgs>
 struct hash<std::tuple<TupleArgs...>>
 {
-private:
-  // recursive hashing of std::tuple from Sarang Baheti's blog
-  // https://www.variadic.xyz/2018/01/15/hashing-stdpair-and-stdtuple/
-  template <size_t Idx, typename... TupleTypes>
-  inline typename std::enable_if<Idx == sizeof...(TupleTypes), void>::type
-  hash_combine_tup(size_t &, const std::tuple<TupleTypes...> &) const
-  {}
-
-  template <size_t Idx, typename... TupleTypes>
-    inline typename std::enable_if < Idx<sizeof...(TupleTypes), void>::type
-                                     hash_combine_tup(size_t & seed, const std::tuple<TupleTypes...> & tup) const
-  {
-    hash_combine(seed, std::get<Idx>(tup));
-
-    //  on to next element
-    hash_combine_tup<Idx + 1>(seed, tup);
-  }
 
 public:
   size_t
   operator()(std::tuple<TupleArgs...> tupleValue) const
   {
     size_t seed = 0;
-    hash_combine_tup<0>(seed, tupleValue);
+    std::apply(
+      [&seed](auto... tupleElement) { (hash_combine(seed, tupleElement), ...); },tupleValue);
     return seed;
   }
 };

--- a/Code/Common/src/sitkImage.hxx
+++ b/Code/Common/src/sitkImage.hxx
@@ -44,14 +44,9 @@ Image::DispatchedInternalInitialization(itk::DataObject * image)
 
 
 template <class TImageType>
-typename std::enable_if<IsBasic<TImageType>::Value>::type
+void
 Image::AllocateInternal(const std::vector<unsigned int> & _size, unsigned int numberOfComponents)
 {
-  if (numberOfComponents != 1 && numberOfComponents != 0)
-  {
-    sitkExceptionMacro("Specified number of components as " << numberOfComponents
-                                                            << " but did not specify pixelID as a vector type!");
-  }
 
   typename TImageType::IndexType index;
   index.Fill(0);
@@ -60,178 +55,158 @@ Image::AllocateInternal(const std::vector<unsigned int> & _size, unsigned int nu
 
   typename TImageType::RegionType region{ index, size };
 
+
   typename TImageType::Pointer image = TImageType::New();
   image->SetRegions(region);
-  image->Allocate();
-  image->FillBuffer(itk::NumericTraits<typename TImageType::PixelType>::ZeroValue());
-  m_PimpleImage.reset(new PimpleImage<TImageType>(image));
-}
 
-template <class TImageType>
-typename std::enable_if<IsVector<TImageType>::Value>::type
-Image::AllocateInternal(const std::vector<unsigned int> & _size, unsigned int numberOfComponents)
-{
-  if (numberOfComponents == 0)
+  if constexpr (IsBasic<TImageType>::Value)
   {
-    numberOfComponents = TImageType::ImageDimension;
+    if (numberOfComponents != 1 && numberOfComponents != 0)
+    {
+      sitkExceptionMacro("Specified number of components as " << numberOfComponents
+                                                              << " but did not specify pixelID as a vector type!");
+    }
+
+    image->Allocate();
+    image->FillBuffer(itk::NumericTraits<typename TImageType::PixelType>::ZeroValue());
   }
-
-  typename TImageType::IndexType index;
-  index.Fill(0);
-
-  typename TImageType::SizeType size = sitkSTLVectorToITK<typename TImageType::SizeType>(_size);
-
-  typename TImageType::RegionType region{ index, size };
-  typename TImageType::PixelType  zero;
-
-  zero.SetSize(numberOfComponents);
-  zero.Fill(itk::NumericTraits<typename TImageType::PixelType::ValueType>::Zero);
-
-  typename TImageType::Pointer image = TImageType::New();
-  image->SetRegions(region);
-  image->SetVectorLength(numberOfComponents);
-  image->Allocate();
-  image->FillBuffer(zero);
-
-  m_PimpleImage.reset(new PimpleImage<TImageType>(image));
-}
-
-template <class TImageType>
-typename std::enable_if<IsLabel<TImageType>::Value>::type
-Image::AllocateInternal(const std::vector<unsigned int> & _size, unsigned int numberOfComponents)
-{
-  if (numberOfComponents != 1 && numberOfComponents != 0)
+  else if constexpr (IsVector<TImageType>::Value)
   {
-    sitkExceptionMacro("Specified number of components as " << numberOfComponents
-                                                            << " but did not specify pixelID as a vector type!");
+    if (numberOfComponents == 0)
+    {
+      numberOfComponents = TImageType::ImageDimension;
+    }
+
+    typename TImageType::PixelType zero;
+
+    zero.SetSize(numberOfComponents);
+    zero.Fill(itk::NumericTraits<typename TImageType::PixelType::ValueType>::Zero);
+
+    image->SetNumberOfComponentsPerPixel(numberOfComponents);
+    image->Allocate();
+    image->FillBuffer(zero);
   }
+  else if (IsLabel<TImageType>::Value)
+  {
+    if (numberOfComponents != 1 && numberOfComponents != 0)
+    {
+      sitkExceptionMacro("Specified number of components as " << numberOfComponents
+                                                              << " but did not specify pixelID as a vector type!");
+    }
 
-  typename TImageType::IndexType index;
-  index.Fill(0);
-
-  typename TImageType::SizeType size = sitkSTLVectorToITK<typename TImageType::SizeType>(_size);
-
-  typename TImageType::RegionType region{ index, size };
-
-  typename TImageType::Pointer image = TImageType::New();
-  image->SetRegions(region);
-  image->Allocate();
-  image->SetBackgroundValue(0);
+    image->Allocate();
+    image->SetBackgroundValue(0);
+  }
 
   m_PimpleImage.reset(new PimpleImage<TImageType>(image));
 }
 
 template <typename TImageType>
-std::enable_if_t<IsVector<TImageType>::Value, Image>
-Image::ToVectorInternal(bool)
-{
-  return *this;
-}
-
-template <typename TImageType>
-std::enable_if_t<IsBasic<TImageType>::Value, Image>
+Image
 Image::ToVectorInternal(bool inPlace)
 {
-  static_assert(TImageType::ImageDimension > 2, "Image dimension must be greater than 2");
-
-  typename TImageType::Pointer itkImage;
-
-  if (inPlace)
+  if constexpr (IsVector<TImageType>::Value)
   {
-    this->MakeUnique();
-    itkImage = dynamic_cast<TImageType *>(this->m_PimpleImage->GetDataBase());
-  }
-  else
-  {
-    auto copy = this->m_PimpleImage->DeepCopy();
-    itkImage = dynamic_cast<TImageType *>(copy->GetDataBase());
-  }
-
-  if (itkImage.GetPointer() == nullptr)
-  {
-    sitkExceptionMacro(<< "Unexpected template dispatch error");
-  }
-
-
-  auto direction = itkImage->GetDirection();
-  for (unsigned int i = 1; i < TImageType::ImageDimension; ++i)
-  {
-    if (direction[i][0] != 0.0 || direction[0][i] != 0.0)
-    {
-      sitkExceptionMacro(<< "Cannot convert image with non-identity direction in first dimension to a vector image");
-    }
-  }
-  if (direction[0][0] != 1.0)
-  {
-    sitkExceptionMacro(<< "Cannot convert image with non-identity direction in first dimension to a vector image");
-  }
-
-  auto itkVectorImage = GetVectorImageFromScalarImage(itkImage.GetPointer());
-
-  itkImage = nullptr;
-  using VectorImageType = typename decltype(itkVectorImage)::ObjectType;
-
-  if (inPlace)
-  {
-    // The pimpleImage does not allow construction when the Image's PixelContainer has more than one reference. So
-    // The pre-existing image must be destroyed before the new one is created.
-    this->m_PimpleImage.reset();
-    this->m_PimpleImage = std::make_unique<PimpleImage<VectorImageType>>(itkVectorImage);
     return *this;
   }
   else
   {
+    static_assert(TImageType::ImageDimension > 2, "Image dimension must be greater than 2");
+
+    typename TImageType::Pointer itkImage;
+
+    if (inPlace)
+    {
+      this->MakeUnique();
+      itkImage = dynamic_cast<TImageType *>(this->m_PimpleImage->GetDataBase());
+    }
+    else
+    {
+      auto copy = this->m_PimpleImage->DeepCopy();
+      itkImage = dynamic_cast<TImageType *>(copy->GetDataBase());
+    }
+
+    if (itkImage.GetPointer() == nullptr)
+    {
+      sitkExceptionMacro(<< "Unexpected template dispatch error");
+    }
+
+
+    auto direction = itkImage->GetDirection();
+    for (unsigned int i = 1; i < TImageType::ImageDimension; ++i)
+    {
+      if (direction[i][0] != 0.0 || direction[0][i] != 0.0)
+      {
+        sitkExceptionMacro(<< "Cannot convert image with non-identity direction in first dimension to a vector image");
+      }
+    }
+    if (direction[0][0] != 1.0)
+    {
+      sitkExceptionMacro(<< "Cannot convert image with non-identity direction in first dimension to a vector image");
+    }
+
+    auto itkVectorImage = GetVectorImageFromScalarImage(itkImage.GetPointer());
+
+    itkImage = nullptr;
+    using VectorImageType = typename decltype(itkVectorImage)::ObjectType;
+
+    if (inPlace)
+    {
+      // The pimpleImage does not allow construction when the Image's PixelContainer has more than one reference. So
+      // The pre-existing image must be destroyed before the new one is created.
+      this->m_PimpleImage.reset();
+      this->m_PimpleImage = std::make_unique<PimpleImage<VectorImageType>>(itkVectorImage);
+      return *this;
+    }
+
     return Image(std::make_unique<PimpleImage<VectorImageType>>(itkVectorImage));
   }
 }
 
 
 template <typename TImageType>
-std::enable_if_t<IsBasic<TImageType>::Value, Image>
-Image::ToScalarInternal(bool)
-{
-  return *this;
-}
-
-template <typename TImageType>
-std::enable_if_t<IsVector<TImageType>::Value, Image>
+Image
 Image::ToScalarInternal(bool inPlace)
 {
-
-  typename TImageType::Pointer itkImage;
-
-  if (inPlace)
+  if constexpr (IsBasic<TImageType>::Value)
   {
-    this->MakeUnique();
-    itkImage = dynamic_cast<TImageType *>(this->m_PimpleImage->GetDataBase());
-  }
-  else
-  {
-    auto copy = this->m_PimpleImage->DeepCopy();
-    itkImage = dynamic_cast<TImageType *>(copy->GetDataBase());
-  }
-
-  if (itkImage.GetPointer() == nullptr)
-  {
-    sitkExceptionMacro(<< "Unexpected template dispatch error");
-  }
-
-  auto itkScalarImage = GetScalarImageFromVectorImage(itkImage.GetPointer());
-  itkImage = nullptr;
-  using ScalarImageType = typename decltype(itkScalarImage)::ObjectType;
-
-  if (inPlace)
-  {
-    this->m_PimpleImage.reset();
-    this->m_PimpleImage = std::make_unique<PimpleImage<ScalarImageType>>(itkScalarImage);
     return *this;
   }
   else
   {
+
+
+    typename TImageType::Pointer itkImage;
+
+    if (inPlace)
+    {
+      this->MakeUnique();
+      itkImage = dynamic_cast<TImageType *>(this->m_PimpleImage->GetDataBase());
+    }
+    else
+    {
+      auto copy = this->m_PimpleImage->DeepCopy();
+      itkImage = dynamic_cast<TImageType *>(copy->GetDataBase());
+    }
+
+    if (itkImage.GetPointer() == nullptr)
+    {
+      sitkExceptionMacro(<< "Unexpected template dispatch error");
+    }
+
+    auto itkScalarImage = GetScalarImageFromVectorImage(itkImage.GetPointer());
+    itkImage = nullptr;
+    using ScalarImageType = typename decltype(itkScalarImage)::ObjectType;
+
+    if (inPlace)
+    {
+      this->m_PimpleImage.reset();
+      this->m_PimpleImage = std::make_unique<PimpleImage<ScalarImageType>>(itkScalarImage);
+      return *this;
+    }
     return Image(std::make_unique<PimpleImage<ScalarImageType>>(itkScalarImage));
   }
 }
-
 
 } // namespace itk::simple
 

--- a/Code/IO/include/sitkImportImageFilter.h
+++ b/Code/IO/include/sitkImportImageFilter.h
@@ -114,17 +114,6 @@ protected:
   Image
   ExecuteInternal();
 
-  // If the output image type is a VectorImage then the number of
-  // components per pixel needs to be set, otherwise the method
-  // does not exist. This is done with the enable if idiom.
-  template <class TImageType>
-  typename std::enable_if<!IsVector<TImageType>::Value>::type
-  SetNumberOfComponentsOnImage(TImageType *)
-  {}
-  template <class TImageType>
-  typename std::enable_if<IsVector<TImageType>::Value>::type
-  SetNumberOfComponentsOnImage(TImageType *);
-
 private:
   // function pointer type
   typedef Image (Self::*MemberFunctionType)();

--- a/Code/IO/src/sitkImportImageFilter.cxx
+++ b/Code/IO/src/sitkImportImageFilter.cxx
@@ -536,22 +536,15 @@ ImportImageFilter::ExecuteInternal()
                                                TheContainerWillTakeCareOfDeletingTheMemoryBuffer);
 
 
-  //
-  // Meta-programmed method to set the number of components if a
-  // vector image
-  //
-  this->SetNumberOfComponentsOnImage(image.GetPointer());
+  // set the number of components if a vector image
+  if constexpr (IsVector<ImageType>::Value)
+  {
+    image->SetNumberOfComponentsPerPixel(m_NumberOfComponentsPerPixel);
+  }
 
   // This line must be the last line in the function to prevent a deep
   // copy caused by a implicit sitk::MakeUnique
   return Image(image);
-}
-
-template <class TFilterType>
-typename std::enable_if<IsVector<TFilterType>::Value>::type
-ImportImageFilter::SetNumberOfComponentsOnImage(TFilterType * image)
-{
-  image->SetNumberOfComponentsPerPixel(m_NumberOfComponentsPerPixel);
 }
 
 } // namespace itk::simple


### PR DESCRIPTION
The conventional if statements with "constexpr" is more readable than complicated enable_if statements. Additionally, the produced object files are smaller due to shorter symbols names. 