### PR TITLE
ENH: Handle error strings in a way that doesn't produce compile warnings

### DIFF
--- a/Wrapping/R/sitkRArray.cxx
+++ b/Wrapping/R/sitkRArray.cxx
@@ -51,7 +51,7 @@ ImAsArray(itk::simple::Image src)
     case itk::simple::sitkUnknown: {
       char error_msg[1024];
       snprintf(error_msg, 1024, "Exception thrown ImAsArray : unknown pixel type");
-      Rprintf(error_msg);
+      REprintf("%s\n", error_msg);
       return (res);
     }
     break;
@@ -204,7 +204,7 @@ ImAsArray(itk::simple::Image src)
     default:
       char error_msg[1024];
       snprintf(error_msg, 1024, "Exception thrown ImAsArray : unsupported pixel type: %d", PID);
-      Rprintf(error_msg);
+      REprintf("%s\n", error_msg);
   }
   UNPROTECT(1);
   return (res);
@@ -234,7 +234,7 @@ ArrayAsIm(SEXP                      arr,
   {
     char error_msg[1024];
     snprintf(error_msg, 1024, "Exception thrown ArrayAsIm : unsupported array type");
-    Rprintf(error_msg);
+    REprintf("%s\n", error_msg);
   }
   itk::simple::Image res = importer.Execute();
   return (res);


### PR DESCRIPTION
Compiler warnings are being elevated to errors when encountered by SimpelITKRInstaller - presumably a change of defaults in the package build process in more recent versions of R.
The various prints are all errors, so the calls have also been changed to REprintf