### PR TITLE
ENH: Use stderr in R, and modify string formatting to avoid compiler …

### DIFF
--- a/Wrapping/R/sitkRArray.cxx
+++ b/Wrapping/R/sitkRArray.cxx
@@ -51,7 +51,7 @@ ImAsArray(itk::simple::Image src)
     case itk::simple::sitkUnknown: {
       char error_msg[1024];
       snprintf(error_msg, 1024, "Exception thrown ImAsArray : unknown pixel type");
-      Rprintf(error_msg);
+      REprintf("%s\n", error_msg);
       return (res);
     }
     break;
@@ -204,7 +204,7 @@ ImAsArray(itk::simple::Image src)
     default:
       char error_msg[1024];
       snprintf(error_msg, 1024, "Exception thrown ImAsArray : unsupported pixel type: %d", PID);
-      Rprintf(error_msg);
+      REprintf("%s\n", error_msg);
   }
   UNPROTECT(1);
   return (res);
@@ -234,7 +234,7 @@ ArrayAsIm(SEXP                      arr,
   {
     char error_msg[1024];
     snprintf(error_msg, 1024, "Exception thrown ArrayAsIm : unsupported array type");
-    Rprintf(error_msg);
+    REprintf("%s\n", error_msg);
   }
   itk::simple::Image res = importer.Execute();
   return (res);


### PR DESCRIPTION
…warnings

New versions of R are elevating warnings to errors, meaning installations with SimpleITKRinstaller are failing.

compiler warning/error was:

"format not a string literal and no format arguments [-Werror=format-security]"

The old version used Rprintf, however these are error messages and have therefore using REprintf makes more sense.