### PR TITLE
Use cmake_minimum_required with ...max_policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,12 @@
 
 include("${CMAKE_CURRENT_SOURCE_DIR}/CMake/sitkCMakeInit.cmake")
-cmake_minimum_required(VERSION ${SITK_CMAKE_MINIMUM_REQUIRED_VERSION})
+cmake_minimum_required(VERSION ${SITK_CMAKE_MINIMUM_REQUIRED_VERSION}...${SITK_CMAKE_POLICY_VERSION} )
 
 # Explicitly add INCREMENTAL linking option to command lines.
 # http://www.cmake.org/pipermail/cmake/2010-February/035174.html
 SET(MSVC_INCREMENTAL_DEFAULT ON)
 
 project ( SimpleITK )
-
-cmake_policy( VERSION ${SITK_CMAKE_POLICY_VERSION} )
 
 foreach(p
         CMP0156 # De-duplicate libraries on link lines based on linker capabilities.

--- a/SuperBuild/CMakeLists.txt
+++ b/SuperBuild/CMakeLists.txt
@@ -14,10 +14,8 @@ endif()
 
 
 include("${CMAKE_CURRENT_SOURCE_DIR}/../CMake/sitkCMakeInit.cmake")
-cmake_minimum_required(VERSION ${SITK_CMAKE_MINIMUM_REQUIRED_VERSION})
+cmake_minimum_required(VERSION ${SITK_CMAKE_MINIMUM_REQUIRED_VERSION}...${SITK_CMAKE_POLICY_VERSION})
 project ( SuperBuildSimpleITK )
-
-cmake_policy( VERSION ${SITK_CMAKE_POLICY_VERSION} )
 
 
 foreach(p "CMP0135"

--- a/SuperBuild/swig_configure_step.cmake.in
+++ b/SuperBuild/swig_configure_step.cmake.in
@@ -1,10 +1,10 @@
 # Set the important environmental variables that auto-conf uses to
 # configure, mostly these are passed from the CMake
 # configuration. Others are just explicitly passed from the
-# enviroment. If there is a problem with them in the future they can
+# environment. If there is a problem with them in the future they can
 # be addressed in CMake with the same structure.
 
-cmake_policy(VERSION 3.16.3)
+cmake_minimum_required(VERSION 3.16.3...3.26.0)
 
 set(ENV{CC} "@CMAKE_C_COMPILER_LAUNCHER@ @CMAKE_C_COMPILER@")
 set(ENV{CFLAGS} "@REQUIRED_C_FLAGS@ @CMAKE_C_FLAGS@ @CMAKE_C_FLAGS_RELEASE@")

--- a/Wrapping/CSharp/CMakeLists.txt
+++ b/Wrapping/CSharp/CMakeLists.txt
@@ -1,5 +1,5 @@
 include("${CMAKE_CURRENT_SOURCE_DIR}/../../CMake/sitkCMakeInit.cmake")
-cmake_minimum_required(VERSION ${SITK_CMAKE_MINIMUM_REQUIRED_VERSION})
+cmake_minimum_required(VERSION ${SITK_CMAKE_MINIMUM_REQUIRED_VERSION}...${SITK_CMAKE_POLICY_VERSION})
 
 project( SimpleITK_CSharp )
 

--- a/Wrapping/Java/CMakeLists.txt
+++ b/Wrapping/Java/CMakeLists.txt
@@ -1,5 +1,5 @@
 include("${CMAKE_CURRENT_SOURCE_DIR}/../../CMake/sitkCMakeInit.cmake")
-cmake_minimum_required(VERSION ${SITK_CMAKE_MINIMUM_REQUIRED_VERSION})
+cmake_minimum_required(VERSION ${SITK_CMAKE_MINIMUM_REQUIRED_VERSION}...${SITK_CMAKE_POLICY_VERSION})
 
 
 project( SimpleITK_Java )

--- a/Wrapping/Lua/CMakeLists.txt
+++ b/Wrapping/Lua/CMakeLists.txt
@@ -1,5 +1,5 @@
 include("${CMAKE_CURRENT_SOURCE_DIR}/../../CMake/sitkCMakeInit.cmake")
-cmake_minimum_required(VERSION ${SITK_CMAKE_MINIMUM_REQUIRED_VERSION})
+cmake_minimum_required(VERSION ${SITK_CMAKE_MINIMUM_REQUIRED_VERSION}...${SITK_CMAKE_POLICY_VERSION})
 
 project( SimpleITK_Lua )
 

--- a/Wrapping/Python/CMakeLists.txt
+++ b/Wrapping/Python/CMakeLists.txt
@@ -1,5 +1,5 @@
 include("${CMAKE_CURRENT_SOURCE_DIR}/../../CMake/sitkCMakeInit.cmake")
-cmake_minimum_required(VERSION ${SITK_CMAKE_MINIMUM_REQUIRED_VERSION})
+cmake_minimum_required(VERSION ${SITK_CMAKE_MINIMUM_REQUIRED_VERSION}...${SITK_CMAKE_POLICY_VERSION})
 
 project( SimpleITK_Python )
 

--- a/Wrapping/R/CMakeLists.txt
+++ b/Wrapping/R/CMakeLists.txt
@@ -1,5 +1,5 @@
 include("${CMAKE_CURRENT_SOURCE_DIR}/../../CMake/sitkCMakeInit.cmake")
-cmake_minimum_required(VERSION ${SITK_CMAKE_MINIMUM_REQUIRED_VERSION})
+cmake_minimum_required(VERSION ${SITK_CMAKE_MINIMUM_REQUIRED_VERSION}...${SITK_CMAKE_POLICY_VERSION})
 
 project( SimpleITK_R )
 

--- a/Wrapping/Ruby/CMakeLists.txt
+++ b/Wrapping/Ruby/CMakeLists.txt
@@ -1,5 +1,5 @@
 include("${CMAKE_CURRENT_SOURCE_DIR}/../../CMake/sitkCMakeInit.cmake")
-cmake_minimum_required(VERSION ${SITK_CMAKE_MINIMUM_REQUIRED_VERSION})
+cmake_minimum_required(VERSION ${SITK_CMAKE_MINIMUM_REQUIRED_VERSION}...${SITK_CMAKE_POLICY_VERSION})
 
 project( SimpleITK_Ruby )
 

--- a/Wrapping/Tcl/CMakeLists.txt
+++ b/Wrapping/Tcl/CMakeLists.txt
@@ -1,5 +1,5 @@
 include("${CMAKE_CURRENT_SOURCE_DIR}/../../CMake/sitkCMakeInit.cmake")
-cmake_minimum_required(VERSION ${SITK_CMAKE_MINIMUM_REQUIRED_VERSION})
+cmake_minimum_required(VERSION ${SITK_CMAKE_MINIMUM_REQUIRED_VERSION}...${SITK_CMAKE_POLICY_VERSION})
 
 
 project( SimpleITK_TCL )

--- a/docs/images/CMakeLists.txt
+++ b/docs/images/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required ( VERSION 3.0 FATAL_ERROR )
+cmake_minimum_required ( VERSION 3.16.3..3.30.0 FATAL_ERROR )
 
 project( SimpleITKSphinx-Data LANGUAGES NONE )
 


### PR DESCRIPTION
Remove the need for a separate cmake_policy command, and eliminates future deprecation warnings related to cmake version compatibility.