### PR TITLE
Enable external ITK module LabelErodeDilate by default

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -36,6 +36,10 @@ if (NOT DEFINED Module_GenericLabelInterpolator)
   set(Module_GenericLabelInterpolator ON)
 endif()
 
+if (NOT DEFINED Module_LabelErodeDilate)
+  set(Module_LabelErodeDilate ON)
+endif()
+
 if (NOT DEFINED ITK_DEFAULT_THREADER)
   set( ITK_DEFAULT_THREADER "Platform")
 endif()


### PR DESCRIPTION
As discussed in this [PR](https://github.com/InsightSoftwareConsortium/ITKLabelErodeDilate/pull/40), this pull request enables the external module [LabelErodeDilate](https://github.com/InsightSoftwareConsortium/ITKLabelErodeDilate) by default to test how much it affects the size of binaries/wheels.


