### PR TITLE
Address Doxygen build issue with no python executable

### DIFF
--- a/Utilities/Doxygen/docker/run.sh
+++ b/Utilities/Doxygen/docker/run.sh
@@ -23,7 +23,7 @@ mkdir -p ${BLD_DIR} && \
     cmake -G Ninja\
           -DBUILD_DOXYGEN=ON\
           -DWRAP_DEFAULT=OFF\
-          -DPython_EXECUTABLE=$(which python)\
+          -DPython_EXECUTABLE=$(which python | which python3)\
           -DSimpleITK_BUILD_DISTRIBUTE:BOOL=ON\
           ${SRC_DIR}/SuperBuild/ && \
     cmake --build . --target SimpleITK-doc && \


### PR DESCRIPTION
Only python3 exists.