### PR TITLE
Second attempt to resolve valgrind issues in LabelErodeDilate

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -32,8 +32,8 @@ foreach(_module ${_SimpleITK_DEFAULT_MODULES})
 endforeach ()
 
 if (Module_LabelErodeDilate AND NOT DEFINED Module_LabelErodeDilate_GIT_TAG)
-  # Remote module version 1.3.1, which contains valgrind fixes
-  set(Module_LabelErodeDilate_GIT_TAG "08c2551096c06fe993b0d5a977a752fb21972896")
+  # Remote module version after 1.3.1, which contains additional valgrind fixes
+  set(Module_LabelErodeDilate_GIT_TAG "2437c0958d35b96dba5b788df1990fc2f8593bb8")
 endif ()
 
 if (NOT DEFINED ITK_DEFAULT_THREADER)


### PR DESCRIPTION
The hash in the remote module is after the 1.3.1 tag.