### PR TITLE
Update Build.yml to use Codebuild runners

### DIFF
--- a/.github/workflows/BatchBuild.yml
+++ b/.github/workflows/BatchBuild.yml
@@ -68,16 +68,18 @@ jobs:
               WRAP_JAVA:BOOL=ON
               SimpleITK_USE_ELASTIX:BOOL=ON
 
-          - os: self-hosted-x64
+          - os: codebuild-SimpleITK-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-xlarge
             cmake-build-type: "Release"
             cmake-generator: "Ninja"
+            apt-get-dependencies: "g++-10"
             ctest-cache: |
               WRAP_PYTHON:BOOL=ON
               SimpleITK_USE_ELASTIX:BOOL=ON
 
-          - os: self-hosted-x64
+          - os: codebuild-SimpleITK-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-xlarge
             cmake-build-type: "Release"
             cmake-generator: "Ninja"
+            apt-get-dependencies: "g++-10"
             CXX: "g++-10"
             CC: "gcc-10"
             ctest-cache: |

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -42,7 +42,7 @@ jobs:
               CMAKE_CXX_VISIBILITY_PRESET:STRING=hidden
               CMAKE_VISIBILITY_INLINES_HIDDEN:BOOL=ON
               SimpleITK_EXPLICIT_INSTANTIATION:BOOL=ON
-          - os: self-hosted-x64
+          - os: codebuild-SimpleITK-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-xlarge
             cmake-build-type: "Release"
             cmake-generator: "Ninja"
             ctest-cache: |

--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         include:
 
-          - os: coverage-x64
+          - os: codebuild-SimpleITK-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-2xlarge
             name: coverage
             cmake-build-type: "RelWithDebInfo"
             ctest-cache: |
@@ -52,7 +52,7 @@ jobs:
               -Ddashboard_track="Nightly" \
               -DCTEST_COVERAGE_COMMAND="$(which gcov)"
 
-          - os: coverage-x64
+          - os: codebuild-SimpleITK-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-2xlarge
             name: valgrind
             cmake-build-type: "RelWithDebInfo"
             ctest-test-timeout: 10000
@@ -87,6 +87,16 @@ jobs:
           enableCrossOsArchive: true
           restore-keys: |
             external-data-v1-
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        id: cpy
+        with:
+          python-version: 3.11
+  
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ninja cmake~=3.29.0
       - name: Build and Test
         shell: bash
         env:
@@ -116,7 +126,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: coverage-x64
+          - os: codebuild-SimpleITK-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-2xlarge
             name: itk-valgrind
             cmake-build-type: Debug
             ctest-test-timeout: 5000
@@ -131,7 +141,7 @@ jobs:
               -DCTEST_MEMORYCHECK_COMMAND_OPTIONS="--trace-children=yes --quiet --tool=memcheck --leak-check=yes --show-reachable=yes --num-callers=50 --verbose --demangle=yes --gen-suppressions=all  --child-silent-after-fork=yes" \
               -DCTEST_MEMORYCHECK_SUPPRESSIONS_FILE="${CTEST_SOURCE_DIRECTORY}/ITK/CMake/InsightValgrind-Ubuntu2004.supp"
 
-          - os: coverage-x64
+          - os: codebuild-SimpleITK-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-2xlarge
             name: itk-coverage
             cmake-build-type: Debug
             ctest-test-timeout: 1800
@@ -153,6 +163,16 @@ jobs:
           repository: InsightSoftwareConsortium/ITK
           path: ITK-dashboard
           ref: dashboard
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        id: cpy
+        with:
+          python-version: 3.11
+  
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ninja cmake~=3.29.0
       - name: CTest Build and Test
         shell: bash
         env:


### PR DESCRIPTION
This PR changes the label from the Monarch self-hosted runners to a new set of runners that use AWS Codebuild as a backend.  A Codebuild project has been set up according to the AWS documentation to [Configure a CodeBuild-hosted GitHub Actions runner](https://docs.aws.amazon.com/codebuild/latest/userguide/action-runner.html#sample-github-action-runners-config).