### PR TITLE
BUG: Normalize Python package name to simpleitk

### DIFF
--- a/Wrapping/Python/Packaging/setup.py.in
+++ b/Wrapping/Python/Packaging/setup.py.in
@@ -47,7 +47,7 @@ class build_ext(_build_ext):
 
 
 setup(
-    name = 'SimpleITK',
+    name = 'simpleitk',
     version = __version__,
     author = 'Insight Software Consortium',
     author_email = 'insight-users@itk.org',


### PR DESCRIPTION
Change the name of the wheel package to be all lower case per Python Packaging enforcement.