### PR TITLE
Don't use head.sha for ci group

### DIFF
--- a/.github/workflows/BatchBuild.yml
+++ b/.github/workflows/BatchBuild.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: '${{ github.workflow }}@${{ github.event.pull_request.head.sha || github.head_ref || github.ref }}'
+  group: '${{ github.workflow }}@${{ github.head_ref || github.ref }}'
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -15,7 +15,7 @@ on:
       -  '!.github/workflows/Build.yml'
 
 concurrency:
-  group: ci-${{ github.head_ref || github.ref }}
+  group: '${{ github.workflow }}@${{ github.head_ref || github.ref }}'
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This string changes with the hash of each updated which does not enabel auto-canceling of PRS.