### PR TITLE
Remove signed label image support from label intensity filter

### DIFF
--- a/Code/BasicFilters/yaml/LabelIntensityStatisticsImageFilter.yaml
+++ b/Code/BasicFilters/yaml/LabelIntensityStatisticsImageFilter.yaml
@@ -4,7 +4,7 @@ template_code_filename: DualImageFilter
 template_test_filename: ImageFilter
 number_of_inputs: 0
 doc: Docs
-pixel_types: IntegerPixelIDTypeList
+pixel_types: IntegerLabelPixelIDTypeList
 pixel_types2: BasicPixelIDTypeList
 filter_type: itk::LabelImageToStatisticsLabelMapFilter<InputImageType,InputImageType2, itk::LabelMap< itk::StatisticsLabelObject<
   int64_t, InputImageType::ImageDimension > > >


### PR DESCRIPTION
Only support unsigned label input images for the
LabelIntensityStatisticsImageFilter. This filter is a dual dispatch filter with intensity image input. The generated output object file for this filter was by far the largest. On a MAC ARM system this reduced the size of the object file from 27MB to 14MB.

Updated to work with YAML configuration files instead of JSON.