### PR TITLE
DOC: Updated dead URLs in read-the-docs documentation.

### DIFF
--- a/.github/workflows/additional_dictionary.txt
+++ b/.github/workflows/additional_dictionary.txt
@@ -1,3 +1,6 @@
+gitforwindows
+metaio
+structitk
 cran
 readme
 deps

--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -35,7 +35,7 @@ To build SimpleITK you need:
    -  Git is required if building SimpleITK using :ref:`SuperBuild <building_superbuild>`
       to automatically download the matching version of ITK,
       SWIG, etc...
-   -  Windows users may prefer `msysGit <http://msysgit.github.com/>`__
+   -  Windows users may prefer `Git For Windows <https://gitforwindows.org/>`__
 
 -  The Python interface requires Python version 3.5 or greater.
 

--- a/docs/source/conventions.rst
+++ b/docs/source/conventions.rst
@@ -58,7 +58,7 @@ Matrices are represented as a single dimensional vector with the entries in row 
 Image Regions as Index and Size
 ...............................
 
-The `itk::ImageRegion <http://itk.org/Doxygen/html/classitk_1_1ImageRegion.html>`_ is a frequently used class in ITK to define a sub-image area. It is defined by `itk::Index <http://itk.org/Doxygen/html/classitk_1_1Index.html>`_ and `itk::Size <http://itk.org/Doxygen/html/classitk_1_1Size.html>`_ of signed and unsigned integer types respectfully. In SimpleITK, the index and size elements are usually separated into two arguments with separate Set and Get methods.
+The `itk::ImageRegion <https://docs.itk.org/projects/doxygen/en/stable/classitk_1_1ImageRegion.html>`_ is a frequently used class in ITK to define a sub-image area. It is defined by `itk::Index <https://docs.itk.org/projects/doxygen/en/stable/structitk_1_1Index.html>`_ and `itk::Size <https://docs.itk.org/projects/doxygen/en/stable/structitk_1_1Size.html>`_ of signed and unsigned integer types respectfully. In SimpleITK, the index and size elements are usually separated into two arguments with separate Set and Get methods.
 
 When specified as a single argument value, it is a 1 dimensional array with the index values followed by the size values i.e. :math:`[idx_x, idx_y, idx_z, size_x, size_y, size_z]`.
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -127,7 +127,7 @@ programmatically hard code this header information. The suggested way is
 to create a Meta image header file (\*.mhd) which references the raw
 data file and describes the size and type of the data. The documentation
 on how to write a Meta image header can be found
-`here <https://www.itk.org/Wiki/MetaIO/Documentation#Reading_a_Brick-of-Bytes_.28an_N-Dimensional_volume_in_a_single_file.29>`__.
+`here <https://docs.itk.org/en/latest/learn/metaio.html#reading-a-brick-of-bytes-an-n-dimensional-volume-in-a-single-file>`__.
 
 The following is a sample Meta image header file, perhaps of name
 sample.mhd:

--- a/docs/source/filters.rst
+++ b/docs/source/filters.rst
@@ -86,7 +86,7 @@ SimpleITK Filters
      - BinaryThreshold projection.
    * - `BinomialBlurImageFilter <https://simpleitk.org/doxygen/latest/html/classitk_1_1simple_1_1BinomialBlurImageFilter.html>`_
      - Performs a separable blur on each dimension of an image.
-   * - `BitwiseNotImageFilter <https://simpleitk.org/doxygen/latest/html/classitk_1_1simple_1_1UnaryFunctorImageFilter.html>`_
+   * - `BitwiseNotImageFilter <https://simpleitk.org/doxygen/latest/html/classitk_1_1simple_1_1BitwiseNotImageFilter.html>`_
      - Implements pixel-wise generic operation on one image.
    * - `BlackTopHatImageFilter <https://simpleitk.org/doxygen/latest/html/classitk_1_1simple_1_1BlackTopHatImageFilter.html>`_
      - Black top hat extracts local minima that are smaller than the structuring element.
@@ -162,7 +162,7 @@ SimpleITK Filters
      - Blurs an image by separable convolution with discrete gaussian kernels. This filter performs Gaussian blurring by separable convolution of an image and a discrete Gaussian operator (kernel).
    * - `DisplacementFieldJacobianDeterminantFilter <https://simpleitk.org/doxygen/latest/html/classitk_1_1simple_1_1DisplacementFieldJacobianDeterminantFilter.html>`_
      - Computes a scalar image from a vector image (e.g., deformation field) input, where each output scalar at each pixel is the Jacobian determinant of the vector field at that location. This calculation is correct in the case where the vector image is a "displacement" from the current location. The computation for the jacobian determinant is: det[ dT/dx ] = det[ I + du/dx ].
-   * - `DivideFloorImageFilter <https://simpleitk.org/doxygen/latest/html/classitk_1_1simple_1_1BinaryFunctorImageFilter.html>`_
+   * - `DivideFloorImageFilter <https://simpleitk.org/doxygen/latest/html/classitk_1_1simple_1_1DivideFloorImageFilter.html>`_
      - Implements pixel-wise generic operation of two images, or of an image and a constant.
    * - `DivideImageFilter <https://simpleitk.org/doxygen/latest/html/classitk_1_1simple_1_1DivideImageFilter.html>`_
      - Pixel-wise division of two images.
@@ -194,7 +194,7 @@ SimpleITK Filters
      - Shift the zero-frequency components of a Fourier transform to the center of the image.
    * - `FastApproximateRankImageFilter <https://simpleitk.org/doxygen/latest/html/classitk_1_1simple_1_1FastApproximateRankImageFilter.html>`_
      - A separable rank filter.
-   * - `FastMarchingBaseImageFilter <https://simpleitk.org/doxygen/latest/html/classitk_1_1simple_1_1FastMarchingImageFilterBase.html>`_
+   * - `FastMarchingBaseImageFilter <https://simpleitk.org/doxygen/latest/html/classitk_1_1simple_1_1FastMarchingBaseImageFilter.html>`_
      - Apply the Fast Marching method to solve an Eikonal equation on an image.
    * - `FastMarchingImageFilter <https://simpleitk.org/doxygen/latest/html/classitk_1_1simple_1_1FastMarchingImageFilter.html>`_
      - Solve an Eikonal equation using Fast Marching.
@@ -296,7 +296,7 @@ SimpleITK Filters
      - Labels the pixels on the border of the objects in a labeled image.
    * - `LabelImageToLabelMapFilter <https://simpleitk.org/doxygen/latest/html/classitk_1_1simple_1_1LabelImageToLabelMapFilter.html>`_
      - convert a labeled image to a label collection image
-   * - `LabelIntensityStatisticsImageFilter <https://simpleitk.org/doxygen/latest/html/classitk_1_1simple_1_1LabelImageToStatisticsLabelMapFilter.html>`_
+   * - `LabelIntensityStatisticsImageFilter <https://simpleitk.org/doxygen/latest/html/classitk_1_1simple_1_1LabelIntensityStatisticsImageFilter.html>`_
      - a convenient class to convert a label image to a label map and valuate the statistics attributes at once
    * - `LabelMapContourOverlayImageFilter <https://simpleitk.org/doxygen/latest/html/classitk_1_1simple_1_1LabelMapContourOverlayImageFilter.html>`_
      - Apply a colormap to the contours (outlines) of each object in a label map and superimpose it on top of the feature image.
@@ -558,7 +558,7 @@ SimpleITK Filters
      - Generate a displacement field from a coordinate transform.
    * - `TriangleThresholdImageFilter <https://simpleitk.org/doxygen/latest/html/classitk_1_1simple_1_1TriangleThresholdImageFilter.html>`_
      - Threshold an image using the Triangle Threshold.
-   * - `UnaryMinusImageFilter <https://simpleitk.org/doxygen/latest/html/classitk_1_1simple_1_1UnaryFunctorImageFilter.html>`_
+   * - `UnaryMinusImageFilter <https://simpleitk.org/doxygen/latest/html/classitk_1_1simple_1_1UnaryMinusImageFilter.html>`_
      - Implements pixel-wise generic operation on one image.
    * - `UnsharpMaskImageFilter <https://simpleitk.org/doxygen/latest/html/classitk_1_1simple_1_1UnsharpMaskImageFilter.html>`_
      - Edge enhancement filter.

--- a/docs/source/gettingStarted.rst
+++ b/docs/source/gettingStarted.rst
@@ -176,7 +176,7 @@ SimpleITK has a built in function,
 which can be used for viewing images in an interactive session.
 By default this Show function searches for an installed
 `Fiji <https://fiji.sc>`__ to display images.  If Fiji is not found,
-then it searches for `ImageJ <http://imagej.nih.gov/ij/>`__. Fiji/ImageJ were
+then it searches for `ImageJ <https://imagej.net/ij/>`__. Fiji/ImageJ were
 chosen because they can handle all the image types that SimpleITK
 supports, including 3D vector images with n components per pixel.
 

--- a/docs/source/migrationGuide2.0.rst
+++ b/docs/source/migrationGuide2.0.rst
@@ -106,7 +106,7 @@ Behavior Changes
 ITKv5
 +++++
 
-SimpleITK 2.0 uses ITK version 5.0. This major version change to ITK includes numerous changes to the usage and behavior of ITK. The `ITK v5 Migration Guide <https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/ITK5MigrationGuide.md>`_ contains valuable information documenting changes.
+SimpleITK 2.0 uses ITK version 5.0. This major version change to ITK includes numerous changes to the usage and behavior of ITK. The `ITK v5 Migration Guide <https://github.com/InsightSoftwareConsortium/ITK/blob/master/Documentation/docs/migration_guides/itk_5_migration_guide.md>`_ contains valuable information documenting changes.
 
 
 Show Environment Variables
@@ -151,7 +151,7 @@ Changes to DICOM reading, due to SimpleITK's move from ITK 4.x to 5.x. Photometr
 Python Installation
 +++++++++++++++++++
 
-The Python installation procedure to use `setup.py` changed. To install see the updated `Python Installation <python_installation>`_ documentation.
+The Python installation procedure to use `setup.py` changed. To install see the updated :ref:`Python Installation <python_installation>` documentation.
 
 Multi-threading
 +++++++++++++++

--- a/docs/source/tutorialsAndCourses.rst
+++ b/docs/source/tutorialsAndCourses.rst
@@ -45,12 +45,12 @@ Past (in person)
 ++++++++++++++++
 .. admonition:: Canceled by ISBI organizers due to COVID-19
 
-  * International Symposium on Biomedical Imaging (ISBI)2020 Tutorial, Iowa City IA, USA: `SimpleITK: image analysis for all levels of programming expertise <https://simpleitk.org/ISBI2020_TUTORIAL/>`__ [`git repository <https://github.com/SimpleITK/ISBI2020_TUTORIAL>`__].
+  * International Symposium on Biomedical Imaging (ISBI)2020 Tutorial, Iowa City IA, USA: "SimpleITK: image analysis for all levels of programming expertise" [`git repository <https://github.com/SimpleITK/ISBI2020_TUTORIAL>`__].
 
-* IEEE Engineering in Medicine and Biology Conference (EMBC) 2019, Berlin Germany: `SimpleITK: A Tool for Biomedical Image Processing, from Cells to Anatomical Structures <https://embc.embs.org/2019/workshops/>`__ [`git repository <https://github.com/SimpleITK/EMBC2019_WORKSHOP>`__].
-* SPIE Medical Imaging 2019 Course, San Diego CA, USA: `SimpleITK Jupyter Notebooks: Biomedical Image Analysis in Python <https://simpleitk.org/SPIE2019_COURSE/>`__ [`git repository <https://github.com/SimpleITK/SPIE2019_COURSE>`__].
-* IEEE International Symposium on Biomedical Imaging (ISBI)2018 Tutorial, Washington DC, USA: `Biomedical Image Analysis in Python and R using SimpleITK Jupyter Notebooks <https://simpleitk.org/ISBI2018_TUTORIAL/>`__ [`git repository <https://github.com/SimpleITK/ISBI2018_TUTORIAL>`__].
-* SPIE Medical Imaging 2018 Course, Houston TX, USA: `SimpleITK Jupyter Notebooks: Biomedical Image Analysis in Python <https://simpleitk.org/SPIE2018_COURSE/>`__ [`git repository <https://github.com/SimpleITK/SPIE2018_COURSE>`__].
+* IEEE Engineering in Medicine and Biology Conference (EMBC) 2019, Berlin Germany: "SimpleITK: A Tool for Biomedical Image Processing, from Cells to Anatomical Structures" [`git repository <https://github.com/SimpleITK/EMBC2019_WORKSHOP>`__].
+* SPIE Medical Imaging 2019 Course, San Diego CA, USA: "SimpleITK Jupyter Notebooks: Biomedical Image Analysis in Python" [`git repository <https://github.com/SimpleITK/SPIE2019_COURSE>`__].
+* IEEE International Symposium on Biomedical Imaging (ISBI)2018 Tutorial, Washington DC, USA: "Biomedical Image Analysis in Python and R using SimpleITK Jupyter Notebooks" [`git repository <https://github.com/SimpleITK/ISBI2018_TUTORIAL>`__].
+* SPIE Medical Imaging 2018 Course, Houston TX, USA: "SimpleITK Jupyter Notebooks: Biomedical Image Analysis in Python" [`git repository <https://github.com/SimpleITK/SPIE2018_COURSE>`__].
 * The International Symposium on Biomedical Imaging (ISBI) 2016, Prague, Czech republic: `SimpleITK: An Interactive, Python-Based Introduction to SimpleITK with the Insight Segmentation and Registration Toolkit (ITK) <http://biomedicalimaging.org/2016/?page_id=572>`__.
 * SPIE Medical Imaging 2016, San Diego, USA: ITK in Biomedical Research and Commercial Applications [`git repository <https://github.com/InsightSoftwareConsortium/SimpleITKTutorialSPIE2016>`__ `, additional presentations <https://hdl.handle.net/10380/3542>`__].
 * Medical Image Computing and Computer Assisted Intervention (MICCAI) 2015, Munich, Germany: a Python based tutorial on the use of the ITKv4 registration framework via SimpleITK [`git repository <https://github.com/InsightSoftwareConsortium/SimpleITKTutorialMICCAI2015.git>`__].


### PR DESCRIPTION
msysGit is no longer maintained, replaced with reference to "Git For Windows". Links to ITK doxygen updated to point to current ITK doxygen location. Links to SimpleITK doxygen updated.
Link to ImageJ website updated to current site.
Removed links to old tutorial websites that were taken down.