### PR TITLE
Remove return self functionality

### DIFF
--- a/Code/BasicFilters/include/sitkBSplineTransformInitializerFilter.h
+++ b/Code/BasicFilters/include/sitkBSplineTransformInitializerFilter.h
@@ -65,11 +65,10 @@ public:
    * Allow the user to set the mesh size of the transform via the initializer even though the initializer does not do
    * anything with that information. Default = 1^ImageDimension.
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetTransformDomainMeshSize(const std::vector<uint32_t> & TransformDomainMeshSize)
   {
     this->m_TransformDomainMeshSize = TransformDomainMeshSize;
-    return *this;
   }
 
   /**
@@ -84,11 +83,10 @@ public:
    * The order of the bspline in the output BSplineTransform. This
    * value effects the number of control points.
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetOrder(unsigned int order)
   {
     this->m_Order = order;
-    return *this;
   }
   unsigned int
   GetOrder() const

--- a/Code/BasicFilters/include/sitkCastImageFilter.h
+++ b/Code/BasicFilters/include/sitkCastImageFilter.h
@@ -42,7 +42,7 @@ public:
   using Self = CastImageFilter;
 
   /** Set/Get the output pixel type */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetOutputPixelType(PixelIDValueEnum pixelID);
   PixelIDValueEnum
   GetOutputPixelType() const;

--- a/Code/BasicFilters/include/sitkCenteredTransformInitializerFilter.h
+++ b/Code/BasicFilters/include/sitkCenteredTransformInitializerFilter.h
@@ -87,11 +87,10 @@ public:
 
   /**
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetOperationMode(OperationModeType OperationMode)
   {
     this->m_OperationMode = OperationMode;
-    return *this;
   }
 
   /**
@@ -119,20 +118,18 @@ public:
 
   /** Select between using the geometrical center of the images or using the center of mass given by the image
    * intensities. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   MomentsOn()
   {
     this->SetOperationMode(MOMENTS);
-    return *this;
   }
 
   /** Select between using the geometrical center of the images or using the center of mass given by the image
    * intensities. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   GeometryOn()
   {
     this->SetOperationMode(GEOMETRY);
-    return *this;
   }
 
 

--- a/Code/BasicFilters/include/sitkCenteredVersorTransformInitializerFilter.h
+++ b/Code/BasicFilters/include/sitkCenteredVersorTransformInitializerFilter.h
@@ -65,18 +65,23 @@ public:
   /**
    * Enable the use of the principal axes of each image to compute an initial rotation that will align them.
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetComputeRotation(bool ComputeRotation)
   {
     this->m_ComputeRotation = ComputeRotation;
-    return *this;
   }
 
   /** Set the value of ComputeRotation to true or false respectfully. */
-  SITK_RETURN_SELF_TYPE_HEADER
-  ComputeRotationOn() { return this->SetComputeRotation(true); }
-  SITK_RETURN_SELF_TYPE_HEADER
-  ComputeRotationOff() { return this->SetComputeRotation(false); }
+  void
+  ComputeRotationOn()
+  {
+    return this->SetComputeRotation(true);
+  }
+  void
+  ComputeRotationOff()
+  {
+    return this->SetComputeRotation(false);
+  }
 
   /**
    * Enable the use of the principal axes of each image to compute an initial rotation that will align them.

--- a/Code/BasicFilters/include/sitkExtractImageFilter.h
+++ b/Code/BasicFilters/include/sitkExtractImageFilter.h
@@ -91,11 +91,10 @@ public:
    * collapsed. The number of non-zero sized determines the output
    * dimension.
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetSize(std::vector<unsigned int> Size)
   {
     this->m_Size = std::move(Size);
-    return *this;
   }
 
   /** \brief Get the size of the region to extract.
@@ -110,11 +109,10 @@ public:
    *
    * The index defaults to all zeros.
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetIndex(std::vector<int> Index)
   {
     this->m_Index = std::move(Index);
-    return *this;
   }
 
   /** \brief Get the starting index to extract.
@@ -157,11 +155,10 @@ public:
    * programmer knows that a 4D image is 3D+time, and that the 3D
    * sub-space is properly defined.
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetDirectionCollapseToStrategy(DirectionCollapseToStrategyType DirectionCollapseToStrategy)
   {
     this->m_DirectionCollapseToStrategy = DirectionCollapseToStrategy;
-    return *this;
   }
 
   /** Get the currently set strategy for collapsing directions of physical space.

--- a/Code/BasicFilters/include/sitkHashImageFilter.h
+++ b/Code/BasicFilters/include/sitkHashImageFilter.h
@@ -53,7 +53,7 @@ public:
     SHA1,
     MD5
   };
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetHashFunction(HashFunction hashFunction);
   HashFunction
   GetHashFunction() const;

--- a/Code/BasicFilters/include/sitkLandmarkBasedTransformInitializerFilter.h
+++ b/Code/BasicFilters/include/sitkLandmarkBasedTransformInitializerFilter.h
@@ -90,11 +90,10 @@ public:
   /**
    * Set the Fixed landmark point containers
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetFixedLandmarks(const std::vector<double> & FixedLandmarks)
   {
     this->m_FixedLandmarks = FixedLandmarks;
-    return *this;
   }
 
   /**
@@ -109,11 +108,10 @@ public:
   /**
    * Set the Moving landmark point containers
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetMovingLandmarks(const std::vector<double> & MovingLandmarks)
   {
     this->m_MovingLandmarks = MovingLandmarks;
-    return *this;
   }
 
   /**
@@ -128,11 +126,10 @@ public:
   /**
    * Set the landmark weight point containers Weight includes diagonal elements of weight matrix
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetLandmarkWeight(const std::vector<double> & LandmarkWeight)
   {
     this->m_LandmarkWeight = LandmarkWeight;
-    return *this;
   }
 
   /**
@@ -147,11 +144,10 @@ public:
   /**
    * Set the reference image to define the parametric domain for the BSpline transform
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetReferenceImage(const Image & ReferenceImage)
   {
     this->m_ReferenceImage = ReferenceImage;
-    return *this;
   }
 
   /**
@@ -165,11 +161,10 @@ public:
   /**
    * Set/Get the number of control points
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetBSplineNumberOfControlPoints(unsigned int BSplineNumberOfControlPoints)
   {
     this->m_BSplineNumberOfControlPoints = BSplineNumberOfControlPoints;
-    return *this;
   }
 
   /**

--- a/Code/BasicFilters/include/sitkPasteImageFilter.h
+++ b/Code/BasicFilters/include/sitkPasteImageFilter.h
@@ -70,11 +70,10 @@ public:
 
   /**
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetSourceSize(std::vector<unsigned int> SourceSize)
   {
     this->m_SourceSize = std::move(SourceSize);
-    return *this;
   }
 
   /**
@@ -87,11 +86,10 @@ public:
 
   /**
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetSourceIndex(std::vector<int> SourceIndex)
   {
     this->m_SourceIndex = std::move(SourceIndex);
-    return *this;
   }
 
   /**
@@ -105,11 +103,10 @@ public:
   /**
    * Set/Get the destination index (where in the first input the second input will be pasted.
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetDestinationIndex(std::vector<int> DestinationIndex)
   {
     this->m_DestinationIndex = std::move(DestinationIndex);
-    return *this;
   }
 
   /**
@@ -130,11 +127,10 @@ public:
    *
    * By default this array contains SourceImageDimension false values followed by true values for the remainder.
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetDestinationSkipAxes(std::vector<bool> DestinationSkipAxes)
   {
     this->m_DestinationSkipAxes = std::move(DestinationSkipAxes);
-    return *this;
   }
 
   /** Set/Get the array describing which axes in the destination image to skip

--- a/Code/BasicFilters/json/BinShrinkImageFilter.json
+++ b/Code/BasicFilters/json/BinShrinkImageFilter.json
@@ -4,7 +4,7 @@
   "template_test_filename" : "ImageFilter",
   "number_of_inputs" : 1,
   "pixel_types" : "NonLabelPixelIDTypeList",
-  "public_declarations" : "SITK_RETURN_SELF_TYPE_HEADER SetShrinkFactor( unsigned int s ) { this->m_ShrinkFactors = std::vector<unsigned int>(3, s ); return *this; }",
+  "public_declarations" : "void SetShrinkFactor( unsigned int s ) { this->m_ShrinkFactors = std::vector<unsigned int>(3, s );  }",
   "members" : [
     {
       "name" : "ShrinkFactors",

--- a/Code/BasicFilters/json/ExpandImageFilter.json
+++ b/Code/BasicFilters/json/ExpandImageFilter.json
@@ -5,7 +5,7 @@
   "number_of_inputs" : 1,
   "pixel_types" : "BasicPixelIDTypeList",
   "vector_pixel_types_by_component" : "VectorPixelIDTypeList",
-  "public_declarations" : "SITK_RETURN_SELF_TYPE_HEADER SetExpandFactor( unsigned int e ) { this->m_ExpandFactors = std::vector<unsigned int>(3, e ); return *this; }",
+  "public_declarations" : "void SetExpandFactor( unsigned int e ) { this->m_ExpandFactors = std::vector<unsigned int>(3, e );  }",
   "include_files" : [
     "sitkCreateInterpolator.hxx"
   ],

--- a/Code/BasicFilters/json/ShrinkImageFilter.json
+++ b/Code/BasicFilters/json/ShrinkImageFilter.json
@@ -5,7 +5,7 @@
   "number_of_inputs" : 1,
   "doc" : "\todo need single method to set all dims",
   "pixel_types" : "NonLabelPixelIDTypeList",
-  "public_declarations" : "SITK_RETURN_SELF_TYPE_HEADER SetShrinkFactor( unsigned int s ) { this->m_ShrinkFactors = std::vector<unsigned int>(3, s ); return *this; }",
+  "public_declarations" : "void SetShrinkFactor( unsigned int s ) { this->m_ShrinkFactors = std::vector<unsigned int>(3, s );  }",
   "members" : [
     {
       "name" : "ShrinkFactors",

--- a/Code/BasicFilters/json/UnsharpMaskImageFilter.json
+++ b/Code/BasicFilters/json/UnsharpMaskImageFilter.json
@@ -6,7 +6,7 @@
   "number_of_inputs" : 1,
   "pixel_types" : "RealPixelIDTypeList",
   "filter_type" : "itk::UnsharpMaskImageFilter<InputImageType, OutputImageType, typename InputImageType::PixelType>",
-  "public_declarations" : "SITK_RETURN_SELF_TYPE_HEADER SetSigmas(double s) { this->m_Sigmas = std::vector<double>(3, s ); return *this; }",
+  "public_declarations" : "void SetSigmas(double s) { this->m_Sigmas = std::vector<double>(3, s );  }",
   "members" : [
     {
       "name" : "Sigmas",

--- a/Code/BasicFilters/src/sitkCastImageFilter.cxx
+++ b/Code/BasicFilters/src/sitkCastImageFilter.cxx
@@ -63,11 +63,10 @@ CastImageFilter::ToString() const
 // Set/Get Methods for output pixel type
 //
 
-CastImageFilter::Self &
+void
 CastImageFilter::SetOutputPixelType(PixelIDValueEnum pixelID)
 {
   this->m_OutputPixelType = pixelID;
-  return *this;
 }
 
 PixelIDValueEnum

--- a/Code/BasicFilters/src/sitkHashImageFilter.cxx
+++ b/Code/BasicFilters/src/sitkHashImageFilter.cxx
@@ -70,11 +70,10 @@ HashImageFilter::GetHashFunction() const
   return this->m_HashFunction;
 }
 
-HashImageFilter &
+void
 HashImageFilter::SetHashFunction(HashImageFilter::HashFunction hashFunction)
 {
   this->m_HashFunction = hashFunction;
-  return *this;
 }
 
 std::string

--- a/Code/Common/include/sitkAffineTransform.h
+++ b/Code/Common/include/sitkAffineTransform.h
@@ -62,33 +62,33 @@ public:
   /** parameters */
   std::vector<double>
   GetTranslation() const;
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetTranslation(const std::vector<double> & translation);
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetMatrix(const std::vector<double> & matrix);
   std::vector<double>
   GetMatrix() const;
 
   /** fixed parameter */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetCenter(const std::vector<double> & params);
   std::vector<double>
   GetCenter() const;
 
   /** additional methods */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   Scale(const std::vector<double> & factor, bool pre = false);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   Scale(double factor, bool pre = false);
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   Shear(int axis1, int axis2, double coef, bool pre = false);
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   Translate(const std::vector<double> & offset, bool pre = false);
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   Rotate(int axis1, int axis2, double angle, bool pre = false);
 
 protected:

--- a/Code/Common/include/sitkBSplineTransform.h
+++ b/Code/Common/include/sitkBSplineTransform.h
@@ -68,19 +68,19 @@ public:
   /** parameters */
 
   /** fixed parameter */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetTransformDomainDirection(const std::vector<double> &);
   std::vector<double>
   GetTransformDomainDirection() const;
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetTransformDomainMeshSize(const std::vector<unsigned int> &);
   std::vector<unsigned int>
   GetTransformDomainMeshSize() const;
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetTransformDomainOrigin(const std::vector<double> &);
   std::vector<double>
   GetTransformDomainOrigin() const;
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetTransformDomainPhysicalDimensions(const std::vector<double> &);
   std::vector<double>
   GetTransformDomainPhysicalDimensions() const;

--- a/Code/Common/include/sitkComposeScaleSkewVersor3DTransform.h
+++ b/Code/Common/include/sitkComposeScaleSkewVersor3DTransform.h
@@ -75,37 +75,37 @@ public:
   }
 
   /** fixed parameter */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetCenter(const std::vector<double> & params);
   std::vector<double>
   GetCenter() const;
 
 
   /** parameter */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetRotation(const std::vector<double> & versor);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetRotation(const std::vector<double> & axis, double angle);
   std::vector<double>
   GetVersor() const;
 
   std::vector<double>
   GetTranslation() const;
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetTranslation(const std::vector<double> & translation);
 
   std::vector<double>
   GetScale() const;
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetScale(const std::vector<double> & scale);
 
   std::vector<double>
   GetSkew() const;
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetSkew(const std::vector<double> & skew);
 
   /** additional methods */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   Translate(const std::vector<double> & offset);
   std::vector<double>
   GetMatrix() const;

--- a/Code/Common/include/sitkCompositeTransform.h
+++ b/Code/Common/include/sitkCompositeTransform.h
@@ -117,7 +117,7 @@ public:
    *
    * Nested composite transform may not be written to a file.
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   FlattenTransform();
 
   /** \brief Add a transform to the back of the stack.
@@ -126,7 +126,7 @@ public:
    * the optimizable parameters, while the other parameters are part of the
    * fixed parameters.
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   AddTransform(Transform t);
 
   /** \brief The number of transforms in the stack */

--- a/Code/Common/include/sitkDisplacementFieldTransform.h
+++ b/Code/Common/include/sitkDisplacementFieldTransform.h
@@ -79,7 +79,7 @@ public:
    * components equal to the image dimension.
    *
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetDisplacementField(Image &);
 
   /** \todo The returned image should not directly modify the
@@ -91,7 +91,7 @@ public:
   /** fixed parameter */
 
   /* additional methods */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetInverseDisplacementField(Image &);
 
   /** \todo The returned image is should not directly modify the
@@ -101,15 +101,15 @@ public:
   GetInverseDisplacementField() const;
 
   /** Set the interpolator used between the field voxels. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetInterpolator(InterpolatorEnum interp);
   // InterpolatorEnum GetInterpolator() const; How to do this?
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetSmoothingOff();
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetSmoothingGaussianOnUpdate(double varianceForUpdateField = 1.75, double varianceForTotalField = 0.5);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetSmoothingBSplineOnUpdate(
     const std::vector<unsigned int> & numberOfControlPointsForUpdateField = std::vector<unsigned int>(3, 4),
     const std::vector<unsigned int> & numberOfControlPointsForTotalField = std::vector<unsigned int>(3, 4),

--- a/Code/Common/include/sitkEuler2DTransform.h
+++ b/Code/Common/include/sitkEuler2DTransform.h
@@ -60,26 +60,26 @@ public:
   }
 
   /** fixed parameter */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetCenter(const std::vector<double> & params);
   std::vector<double>
   GetCenter() const;
 
   /** parameter */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetAngle(double angle);
   double
   GetAngle() const;
 
   std::vector<double>
   GetTranslation() const;
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetTranslation(const std::vector<double> & translation);
 
   /** additional methods */
   std::vector<double>
   GetMatrix() const;
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetMatrix(const std::vector<double> & matrix, double tolerance = 1e-10);
 
 protected:

--- a/Code/Common/include/sitkEuler3DTransform.h
+++ b/Code/Common/include/sitkEuler3DTransform.h
@@ -62,7 +62,7 @@ public:
   }
 
   /** fixed parameter */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetCenter(const std::vector<double> & params);
   std::vector<double>
   GetCenter() const;
@@ -75,28 +75,34 @@ public:
   GetAngleZ() const;
 
   /** parameter */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetRotation(double angleX, double angleY, double angleZ);
 
   std::vector<double>
   GetTranslation() const;
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetTranslation(const std::vector<double> & translation);
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetComputeZYX(bool _arg);
   bool
   GetComputeZYX() const;
-  SITK_RETURN_SELF_TYPE_HEADER
-  ComputeZYXOn() { return this->SetComputeZYX(true); }
-  SITK_RETURN_SELF_TYPE_HEADER
-  ComputeZYXOff() { return this->SetComputeZYX(false); }
+  void
+  ComputeZYXOn()
+  {
+    return this->SetComputeZYX(true);
+  }
+  void
+  ComputeZYXOff()
+  {
+    return this->SetComputeZYX(false);
+  }
 
 
   /** additional methods */
   std::vector<double>
   GetMatrix() const;
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetMatrix(const std::vector<double> & matrix, double tolerance = 1e-10);
 
 protected:

--- a/Code/Common/include/sitkMacro.h
+++ b/Code/Common/include/sitkMacro.h
@@ -57,11 +57,6 @@
 #  define CLANG_TEMPLATE
 #endif
 
-
-#if !defined(SITK_RETURN_SELF_TYPE_HEADER)
-#  define SITK_RETURN_SELF_TYPE_HEADER Self &
-#endif
-
 namespace itk::simple
 {
 

--- a/Code/Common/include/sitkScaleSkewVersor3DTransform.h
+++ b/Code/Common/include/sitkScaleSkewVersor3DTransform.h
@@ -70,37 +70,37 @@ public:
   }
 
   /** fixed parameter */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetCenter(const std::vector<double> & params);
   std::vector<double>
   GetCenter() const;
 
 
   /** parameter */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetRotation(const std::vector<double> & versor);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetRotation(const std::vector<double> & axis, double angle);
   std::vector<double>
   GetVersor() const;
 
   std::vector<double>
   GetTranslation() const;
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetTranslation(const std::vector<double> & translation);
 
   std::vector<double>
   GetScale() const;
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetScale(const std::vector<double> & scale);
 
   std::vector<double>
   GetSkew() const;
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetSkew(const std::vector<double> & skew);
 
   /** additional methods */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   Translate(const std::vector<double> & offset);
   std::vector<double>
   GetMatrix() const;

--- a/Code/Common/include/sitkScaleTransform.h
+++ b/Code/Common/include/sitkScaleTransform.h
@@ -55,13 +55,13 @@ public:
   operator=(const ScaleTransform &);
 
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetScale(const std::vector<double> & params);
   std::vector<double>
   GetScale() const;
 
   /** fixed parameter */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetCenter(const std::vector<double> & params);
   std::vector<double>
   GetCenter() const;

--- a/Code/Common/include/sitkScaleVersor3DTransform.h
+++ b/Code/Common/include/sitkScaleVersor3DTransform.h
@@ -69,32 +69,32 @@ public:
   }
 
   /** fixed parameter */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetCenter(const std::vector<double> & params);
   std::vector<double>
   GetCenter() const;
 
 
   /** parameter */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetRotation(const std::vector<double> & versor);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetRotation(const std::vector<double> & axis, double angle);
   std::vector<double>
   GetVersor() const;
 
   std::vector<double>
   GetTranslation() const;
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetTranslation(const std::vector<double> & translation);
 
   std::vector<double>
   GetScale() const;
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetScale(const std::vector<double> & scale);
 
   /** additional methods */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   Translate(const std::vector<double> & offset);
   std::vector<double>
   GetMatrix() const;

--- a/Code/Common/include/sitkSimilarity2DTransform.h
+++ b/Code/Common/include/sitkSimilarity2DTransform.h
@@ -61,23 +61,23 @@ public:
   }
 
   /** fixed parameter */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetCenter(const std::vector<double> & params);
   std::vector<double>
   GetCenter() const;
 
   /** parameter */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetAngle(double angle);
   double
   GetAngle() const;
 
   std::vector<double>
   GetTranslation() const;
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetTranslation(const std::vector<double> & translation);
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetScale(double scale);
   double
   GetScale() const;
@@ -85,7 +85,7 @@ public:
   /** additional methods */
   std::vector<double>
   GetMatrix() const;
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetMatrix(const std::vector<double> & matrix, double tolerance = 1e-10);
 
 protected:

--- a/Code/Common/include/sitkSimilarity3DTransform.h
+++ b/Code/Common/include/sitkSimilarity3DTransform.h
@@ -67,37 +67,37 @@ public:
   }
 
   /** fixed parameter */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetCenter(const std::vector<double> & params);
   std::vector<double>
   GetCenter() const;
 
 
   /** parameter */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetRotation(const std::vector<double> & versor);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetRotation(const std::vector<double> & axis, double angle);
   std::vector<double>
   GetVersor() const;
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetScale(double scale);
   double
   GetScale() const;
 
   std::vector<double>
   GetTranslation() const;
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetTranslation(const std::vector<double> & translation);
 
 
   /** additional methods */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   Translate(const std::vector<double> & offset);
   std::vector<double>
   GetMatrix() const;
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetMatrix(const std::vector<double> & matrix, double tolerance = 1e-10);
 
 protected:

--- a/Code/Common/include/sitkTranslationTransform.h
+++ b/Code/Common/include/sitkTranslationTransform.h
@@ -55,7 +55,7 @@ public:
     return std::string("TranslationTransform");
   }
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetOffset(const std::vector<double> & params);
   std::vector<double>
   GetOffset() const;

--- a/Code/Common/include/sitkVersorRigid3DTransform.h
+++ b/Code/Common/include/sitkVersorRigid3DTransform.h
@@ -66,31 +66,31 @@ public:
   }
 
   /** fixed parameter */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetCenter(const std::vector<double> & params);
   std::vector<double>
   GetCenter() const;
 
 
   /** parameter */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetRotation(const std::vector<double> & versor);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetRotation(const std::vector<double> & axis, double angle);
   std::vector<double>
   GetVersor() const;
 
   std::vector<double>
   GetTranslation() const;
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetTranslation(const std::vector<double> & translation);
 
   /** additional methods */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   Translate(const std::vector<double> & offset);
   std::vector<double>
   GetMatrix() const;
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetMatrix(const std::vector<double> & matrix, double tolerance = 1e-10);
 
 protected:

--- a/Code/Common/include/sitkVersorTransform.h
+++ b/Code/Common/include/sitkVersorTransform.h
@@ -63,16 +63,16 @@ public:
   }
 
   /** fixed parameter */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetCenter(const std::vector<double> & params);
   std::vector<double>
   GetCenter() const;
 
 
   /** parameter */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetRotation(const std::vector<double> & versor);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetRotation(const std::vector<double> & axis, double angle);
   std::vector<double>
   GetVersor() const;
@@ -80,7 +80,7 @@ public:
   /** additional methods */
   std::vector<double>
   GetMatrix() const;
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetMatrix(const std::vector<double> & matrix, double tolerance = 1e-10);
 
 protected:

--- a/Code/Common/src/sitkAffineTransform.cxx
+++ b/Code/Common/src/sitkAffineTransform.cxx
@@ -64,12 +64,11 @@ AffineTransform::operator=(const AffineTransform & arg)
 }
 
 /** parameter */
-AffineTransform::Self &
+void
 AffineTransform::SetTranslation(const std::vector<double> & params)
 {
   this->MakeUnique();
   this->m_pfSetTranslation(params);
-  return *this;
 }
 
 std::vector<double>
@@ -79,12 +78,11 @@ AffineTransform::GetTranslation() const
 }
 
 
-AffineTransform::Self &
+void
 AffineTransform::SetMatrix(const std::vector<double> & params)
 {
   this->MakeUnique();
   this->m_pfSetMatrix(params);
-  return *this;
 }
 
 std::vector<double>
@@ -95,12 +93,11 @@ AffineTransform::GetMatrix() const
 
 
 /** fixed parameter */
-AffineTransform::Self &
+void
 AffineTransform::SetCenter(const std::vector<double> & params)
 {
   this->MakeUnique();
   this->m_pfSetCenter(params);
-  return *this;
 }
 
 std::vector<double>
@@ -109,44 +106,39 @@ AffineTransform::GetCenter() const
   return this->m_pfGetCenter();
 }
 
-AffineTransform::Self &
+void
 AffineTransform::Scale(const std::vector<double> & factor, bool pre)
 {
   this->MakeUnique();
   this->m_pfScale1(factor, pre);
-  return *this;
 }
 
-AffineTransform::Self &
+void
 AffineTransform::Scale(double factor, bool pre)
 {
   this->MakeUnique();
   this->m_pfScale2(factor, pre);
-  return *this;
 }
 
-AffineTransform::Self &
+void
 AffineTransform::Shear(int axis1, int axis2, double coef, bool pre)
 {
   this->MakeUnique();
   this->m_pfShear(axis1, axis2, coef, pre);
-  return *this;
 }
 
-AffineTransform::Self &
+void
 AffineTransform::Translate(const std::vector<double> & offset, bool pre)
 {
   this->MakeUnique();
   this->m_pfTranslate(offset, pre);
-  return *this;
 }
 
-AffineTransform::Self &
+void
 AffineTransform::Rotate(int axis1, int axis2, double angle, bool pre)
 {
   this->MakeUnique();
   this->m_pfRotate(axis1, axis2, angle, pre);
-  return *this;
 }
 
 void

--- a/Code/Common/src/sitkBSplineTransform.cxx
+++ b/Code/Common/src/sitkBSplineTransform.cxx
@@ -142,12 +142,11 @@ BSplineTransform::operator=(const BSplineTransform & arg)
 }
 
 
-BSplineTransform::Self &
+void
 BSplineTransform::SetTransformDomainDirection(const std::vector<double> & params)
 {
   this->MakeUnique();
   this->m_pfSetTransformDomainDirection(params);
-  return *this;
 }
 
 
@@ -158,12 +157,11 @@ BSplineTransform::GetTransformDomainDirection() const
 }
 
 
-BSplineTransform::Self &
+void
 BSplineTransform::SetTransformDomainMeshSize(const std::vector<unsigned int> & params)
 {
   this->MakeUnique();
   this->m_pfSetTransformDomainMeshSize(params);
-  return *this;
 }
 
 
@@ -174,12 +172,11 @@ BSplineTransform::GetTransformDomainMeshSize() const
 }
 
 
-BSplineTransform::Self &
+void
 BSplineTransform::SetTransformDomainOrigin(const std::vector<double> & params)
 {
   this->MakeUnique();
   this->m_pfSetTransformDomainOrigin(params);
-  return *this;
 }
 
 
@@ -190,12 +187,11 @@ BSplineTransform::GetTransformDomainOrigin() const
 }
 
 
-BSplineTransform::Self &
+void
 BSplineTransform::SetTransformDomainPhysicalDimensions(const std::vector<double> & params)
 {
   this->MakeUnique();
   this->m_pfSetTransformDomainPhysicalDimensions(params);
-  return *this;
 }
 
 

--- a/Code/Common/src/sitkComposeScaleSkewVersor3DTransform.cxx
+++ b/Code/Common/src/sitkComposeScaleSkewVersor3DTransform.cxx
@@ -87,12 +87,11 @@ ComposeScaleSkewVersor3DTransform::operator=(const ComposeScaleSkewVersor3DTrans
 
 
 /** fixed parameter */
-ComposeScaleSkewVersor3DTransform::Self &
+void
 ComposeScaleSkewVersor3DTransform::SetCenter(const std::vector<double> & params)
 {
   this->MakeUnique();
   this->m_pfSetCenter(params);
-  return *this;
 }
 
 std::vector<double>
@@ -102,20 +101,18 @@ ComposeScaleSkewVersor3DTransform::GetCenter() const
 }
 
 
-ComposeScaleSkewVersor3DTransform::Self &
+void
 ComposeScaleSkewVersor3DTransform::SetRotation(const std::vector<double> & versor)
 {
   this->MakeUnique();
   this->m_pfSetRotation1(versor);
-  return *this;
 }
 
-ComposeScaleSkewVersor3DTransform::Self &
+void
 ComposeScaleSkewVersor3DTransform::SetRotation(const std::vector<double> & axis, double angle)
 {
   this->MakeUnique();
   this->m_pfSetRotation2(axis, angle);
-  return *this;
 }
 
 std::vector<double>
@@ -124,12 +121,11 @@ ComposeScaleSkewVersor3DTransform::GetVersor() const
   return this->m_pfGetVersor();
 }
 
-ComposeScaleSkewVersor3DTransform::Self &
+void
 ComposeScaleSkewVersor3DTransform::SetTranslation(const std::vector<double> & params)
 {
   this->MakeUnique();
   this->m_pfSetTranslation(params);
-  return *this;
 }
 
 std::vector<double>
@@ -138,20 +134,18 @@ ComposeScaleSkewVersor3DTransform::GetTranslation() const
   return this->m_pfGetTranslation();
 }
 
-ComposeScaleSkewVersor3DTransform::Self &
+void
 ComposeScaleSkewVersor3DTransform::Translate(const std::vector<double> & offset)
 {
   this->MakeUnique();
   this->m_pfTranslate(offset);
-  return *this;
 }
 
-ComposeScaleSkewVersor3DTransform::Self &
+void
 ComposeScaleSkewVersor3DTransform::SetScale(const std::vector<double> & params)
 {
   this->MakeUnique();
   this->m_pfSetScale(params);
-  return *this;
 }
 
 std::vector<double>
@@ -160,12 +154,11 @@ ComposeScaleSkewVersor3DTransform::GetScale() const
   return this->m_pfGetScale();
 }
 
-ComposeScaleSkewVersor3DTransform::Self &
+void
 ComposeScaleSkewVersor3DTransform::SetSkew(const std::vector<double> & params)
 {
   this->MakeUnique();
   this->m_pfSetSkew(params);
-  return *this;
 }
 
 std::vector<double>

--- a/Code/Common/src/sitkCompositeTransform.cxx
+++ b/Code/Common/src/sitkCompositeTransform.cxx
@@ -106,21 +106,19 @@ CompositeTransform::InternalInitialization(itk::TransformBase * transform)
 }
 
 
-CompositeTransform &
+void
 CompositeTransform::AddTransform(Transform t)
 {
   this->MakeUnique();
   this->m_pfAddTransform(t);
-  return *this;
 }
 
 
-CompositeTransform &
+void
 CompositeTransform::FlattenTransform()
 {
   this->MakeUnique();
   this->m_pfFlattenTransform();
-  return *this;
 }
 
 unsigned int

--- a/Code/Common/src/sitkDisplacementFieldTransform.cxx
+++ b/Code/Common/src/sitkDisplacementFieldTransform.cxx
@@ -162,12 +162,11 @@ DisplacementFieldTransform::operator=(const DisplacementFieldTransform & arg)
 }
 
 
-DisplacementFieldTransform::Self &
+void
 DisplacementFieldTransform::SetDisplacementField(Image & img)
 {
   this->MakeUnique();
   this->m_pfSetDisplacementField(img);
-  return *this;
 }
 
 Image
@@ -177,12 +176,11 @@ DisplacementFieldTransform::GetDisplacementField() const
 }
 
 
-DisplacementFieldTransform::Self &
+void
 DisplacementFieldTransform::SetInverseDisplacementField(Image & img)
 {
   this->MakeUnique();
   this->m_pfSetInverseDisplacementField(img);
-  return *this;
 }
 
 
@@ -192,12 +190,11 @@ DisplacementFieldTransform::GetInverseDisplacementField() const
   return this->m_pfGetInverseDisplacementField();
 }
 
-DisplacementFieldTransform::Self &
+void
 DisplacementFieldTransform::SetInterpolator(InterpolatorEnum interp)
 {
   this->MakeUnique();
   this->m_pfSetInterpolator(interp);
-  return *this;
 }
 
 // InterpolatorEnum DisplacementFieldTransform::GetInterpolator() const
@@ -205,23 +202,21 @@ DisplacementFieldTransform::SetInterpolator(InterpolatorEnum interp)
 //   return this->m_pfGetInterpolator();
 // }
 
-DisplacementFieldTransform::Self &
+void
 DisplacementFieldTransform::SetSmoothingOff()
 {
   this->MakeUnique();
   this->m_pfSetSmoothingOff();
-  return *this;
 }
 
-DisplacementFieldTransform::Self &
+void
 DisplacementFieldTransform::SetSmoothingGaussianOnUpdate(double varianceForUpdateField, double varianceForTotalField)
 {
   this->MakeUnique();
   this->m_pfSetSmoothingGaussianOnUpdate(varianceForUpdateField, varianceForTotalField);
-  return *this;
 }
 
-DisplacementFieldTransform::Self &
+void
 DisplacementFieldTransform::SetSmoothingBSplineOnUpdate(
   const std::vector<unsigned int> & numberOfControlPointsForUpdateField,
   const std::vector<unsigned int> & numberOfControlPointsForTotalField,
@@ -231,7 +226,6 @@ DisplacementFieldTransform::SetSmoothingBSplineOnUpdate(
   this->MakeUnique();
   this->m_pfSetSmoothingBSplineOnUpdate(
     numberOfControlPointsForUpdateField, numberOfControlPointsForTotalField, enforceStationaryBoundary, order);
-  return *this;
 }
 
 

--- a/Code/Common/src/sitkEuler2DTransform.cxx
+++ b/Code/Common/src/sitkEuler2DTransform.cxx
@@ -69,12 +69,11 @@ Euler2DTransform::operator=(const Euler2DTransform & arg)
 
 
 /** fixed parameter */
-Euler2DTransform::Self &
+void
 Euler2DTransform::SetCenter(const std::vector<double> & params)
 {
   this->MakeUnique();
   this->m_pfSetCenter(params);
-  return *this;
 }
 
 std::vector<double>
@@ -90,20 +89,18 @@ Euler2DTransform::GetAngle() const
 }
 
 /** parameter */
-Euler2DTransform::Self &
+void
 Euler2DTransform::SetAngle(double angle)
 {
   this->MakeUnique();
   this->m_pfSetAngle(angle);
-  return *this;
 }
 
-Euler2DTransform::Self &
+void
 Euler2DTransform::SetTranslation(const std::vector<double> & params)
 {
   this->MakeUnique();
   this->m_pfSetTranslation(params);
-  return *this;
 }
 
 std::vector<double>
@@ -118,12 +115,11 @@ Euler2DTransform::GetMatrix() const
   return this->m_pfGetMatrix();
 }
 
-Euler2DTransform::Self &
+void
 Euler2DTransform::SetMatrix(const std::vector<double> & params, double tolerance)
 {
   this->MakeUnique();
   this->m_pfSetMatrix(params, tolerance);
-  return *this;
 }
 
 void

--- a/Code/Common/src/sitkEuler3DTransform.cxx
+++ b/Code/Common/src/sitkEuler3DTransform.cxx
@@ -69,12 +69,11 @@ Euler3DTransform::operator=(const Euler3DTransform & arg)
 
 
 /** fixed parameter */
-Euler3DTransform::Self &
+void
 Euler3DTransform::SetCenter(const std::vector<double> & params)
 {
   this->MakeUnique();
   this->m_pfSetCenter(params);
-  return *this;
 }
 
 std::vector<double>
@@ -102,20 +101,18 @@ Euler3DTransform::GetAngleZ() const
 }
 
 /** parameter */
-Euler3DTransform::Self &
+void
 Euler3DTransform::SetRotation(double angleX, double angleY, double angleZ)
 {
   this->MakeUnique();
   this->m_pfSetRotation(angleX, angleY, angleZ);
-  return *this;
 }
 
-Euler3DTransform::Self &
+void
 Euler3DTransform::SetTranslation(const std::vector<double> & params)
 {
   this->MakeUnique();
   this->m_pfSetTranslation(params);
-  return *this;
 }
 
 std::vector<double>
@@ -125,12 +122,11 @@ Euler3DTransform::GetTranslation() const
 }
 
 
-Euler3DTransform::Self &
+void
 Euler3DTransform::SetComputeZYX(bool _arg)
 {
   this->MakeUnique();
   this->m_pfSetComputeZYX(_arg);
-  return *this;
 }
 
 bool
@@ -145,12 +141,11 @@ Euler3DTransform::GetMatrix() const
   return this->m_pfGetMatrix();
 }
 
-Euler3DTransform::Self &
+void
 Euler3DTransform::SetMatrix(const std::vector<double> & params, double tolerance)
 {
   this->MakeUnique();
   this->m_pfSetMatrix(params, tolerance);
-  return *this;
 }
 
 void

--- a/Code/Common/src/sitkImage.hxx
+++ b/Code/Common/src/sitkImage.hxx
@@ -155,7 +155,6 @@ Image::ToVectorInternal(bool inPlace)
       // The pre-existing image must be destroyed before the new one is created.
       this->m_PimpleImage.reset();
       this->m_PimpleImage = std::make_unique<PimpleImage<VectorImageType>>(itkVectorImage);
-      return *this;
     }
 
     return Image(std::make_unique<PimpleImage<VectorImageType>>(itkVectorImage));
@@ -201,7 +200,6 @@ Image::ToScalarInternal(bool inPlace)
     {
       this->m_PimpleImage.reset();
       this->m_PimpleImage = std::make_unique<PimpleImage<ScalarImageType>>(itkScalarImage);
-      return *this;
     }
     return Image(std::make_unique<PimpleImage<ScalarImageType>>(itkScalarImage));
   }

--- a/Code/Common/src/sitkScaleSkewVersor3DTransform.cxx
+++ b/Code/Common/src/sitkScaleSkewVersor3DTransform.cxx
@@ -87,12 +87,11 @@ ScaleSkewVersor3DTransform::operator=(const ScaleSkewVersor3DTransform & arg)
 
 
 /** fixed parameter */
-ScaleSkewVersor3DTransform::Self &
+void
 ScaleSkewVersor3DTransform::SetCenter(const std::vector<double> & params)
 {
   this->MakeUnique();
   this->m_pfSetCenter(params);
-  return *this;
 }
 
 std::vector<double>
@@ -102,20 +101,18 @@ ScaleSkewVersor3DTransform::GetCenter() const
 }
 
 
-ScaleSkewVersor3DTransform::Self &
+void
 ScaleSkewVersor3DTransform::SetRotation(const std::vector<double> & versor)
 {
   this->MakeUnique();
   this->m_pfSetRotation1(versor);
-  return *this;
 }
 
-ScaleSkewVersor3DTransform::Self &
+void
 ScaleSkewVersor3DTransform::SetRotation(const std::vector<double> & axis, double angle)
 {
   this->MakeUnique();
   this->m_pfSetRotation2(axis, angle);
-  return *this;
 }
 
 std::vector<double>
@@ -124,12 +121,11 @@ ScaleSkewVersor3DTransform::GetVersor() const
   return this->m_pfGetVersor();
 }
 
-ScaleSkewVersor3DTransform::Self &
+void
 ScaleSkewVersor3DTransform::SetTranslation(const std::vector<double> & params)
 {
   this->MakeUnique();
   this->m_pfSetTranslation(params);
-  return *this;
 }
 
 std::vector<double>
@@ -138,20 +134,18 @@ ScaleSkewVersor3DTransform::GetTranslation() const
   return this->m_pfGetTranslation();
 }
 
-ScaleSkewVersor3DTransform::Self &
+void
 ScaleSkewVersor3DTransform::Translate(const std::vector<double> & offset)
 {
   this->MakeUnique();
   this->m_pfTranslate(offset);
-  return *this;
 }
 
-ScaleSkewVersor3DTransform::Self &
+void
 ScaleSkewVersor3DTransform::SetScale(const std::vector<double> & params)
 {
   this->MakeUnique();
   this->m_pfSetScale(params);
-  return *this;
 }
 
 std::vector<double>
@@ -160,12 +154,11 @@ ScaleSkewVersor3DTransform::GetScale() const
   return this->m_pfGetScale();
 }
 
-ScaleSkewVersor3DTransform::Self &
+void
 ScaleSkewVersor3DTransform::SetSkew(const std::vector<double> & params)
 {
   this->MakeUnique();
   this->m_pfSetSkew(params);
-  return *this;
 }
 
 std::vector<double>

--- a/Code/Common/src/sitkScaleTransform.cxx
+++ b/Code/Common/src/sitkScaleTransform.cxx
@@ -57,12 +57,11 @@ ScaleTransform::operator=(const ScaleTransform & arg)
 
 
 /** fixed parameter */
-ScaleTransform::Self &
+void
 ScaleTransform::SetCenter(const std::vector<double> & params)
 {
   this->MakeUnique();
   this->m_pfSetCenter(params);
-  return *this;
 }
 
 std::vector<double>
@@ -71,12 +70,11 @@ ScaleTransform::GetCenter() const
   return this->m_pfGetCenter();
 }
 
-ScaleTransform::Self &
+void
 ScaleTransform::SetScale(const std::vector<double> & params)
 {
   this->MakeUnique();
   this->m_pfSetScale(params);
-  return *this;
 }
 
 std::vector<double>

--- a/Code/Common/src/sitkScaleVersor3DTransform.cxx
+++ b/Code/Common/src/sitkScaleVersor3DTransform.cxx
@@ -83,12 +83,11 @@ ScaleVersor3DTransform::operator=(const ScaleVersor3DTransform & arg)
 
 
 /** fixed parameter */
-ScaleVersor3DTransform::Self &
+void
 ScaleVersor3DTransform::SetCenter(const std::vector<double> & params)
 {
   this->MakeUnique();
   this->m_pfSetCenter(params);
-  return *this;
 }
 
 std::vector<double>
@@ -98,20 +97,18 @@ ScaleVersor3DTransform::GetCenter() const
 }
 
 
-ScaleVersor3DTransform::Self &
+void
 ScaleVersor3DTransform::SetRotation(const std::vector<double> & versor)
 {
   this->MakeUnique();
   this->m_pfSetRotation1(versor);
-  return *this;
 }
 
-ScaleVersor3DTransform::Self &
+void
 ScaleVersor3DTransform::SetRotation(const std::vector<double> & axis, double angle)
 {
   this->MakeUnique();
   this->m_pfSetRotation2(axis, angle);
-  return *this;
 }
 
 std::vector<double>
@@ -120,12 +117,11 @@ ScaleVersor3DTransform::GetVersor() const
   return this->m_pfGetVersor();
 }
 
-ScaleVersor3DTransform::Self &
+void
 ScaleVersor3DTransform::SetTranslation(const std::vector<double> & params)
 {
   this->MakeUnique();
   this->m_pfSetTranslation(params);
-  return *this;
 }
 
 std::vector<double>
@@ -134,20 +130,18 @@ ScaleVersor3DTransform::GetTranslation() const
   return this->m_pfGetTranslation();
 }
 
-ScaleVersor3DTransform::Self &
+void
 ScaleVersor3DTransform::Translate(const std::vector<double> & offset)
 {
   this->MakeUnique();
   this->m_pfTranslate(offset);
-  return *this;
 }
 
-ScaleVersor3DTransform::Self &
+void
 ScaleVersor3DTransform::SetScale(const std::vector<double> & params)
 {
   this->MakeUnique();
   this->m_pfSetScale(params);
-  return *this;
 }
 
 std::vector<double>

--- a/Code/Common/src/sitkSimilarity2DTransform.cxx
+++ b/Code/Common/src/sitkSimilarity2DTransform.cxx
@@ -70,12 +70,11 @@ Similarity2DTransform::operator=(const Similarity2DTransform & arg)
 
 
 /** fixed parameter */
-Similarity2DTransform::Self &
+void
 Similarity2DTransform::SetCenter(const std::vector<double> & params)
 {
   this->MakeUnique();
   this->m_pfSetCenter(params);
-  return *this;
 }
 
 std::vector<double>
@@ -91,20 +90,18 @@ Similarity2DTransform::GetAngle() const
 }
 
 /** parameter */
-Similarity2DTransform::Self &
+void
 Similarity2DTransform::SetAngle(double angle)
 {
   this->MakeUnique();
   this->m_pfSetAngle(angle);
-  return *this;
 }
 
-Similarity2DTransform::Self &
+void
 Similarity2DTransform::SetTranslation(const std::vector<double> & params)
 {
   this->MakeUnique();
   this->m_pfSetTranslation(params);
-  return *this;
 }
 
 std::vector<double>
@@ -113,12 +110,11 @@ Similarity2DTransform::GetTranslation() const
   return this->m_pfGetTranslation();
 }
 
-Similarity2DTransform::Self &
+void
 Similarity2DTransform::SetScale(double scale)
 {
   this->MakeUnique();
   this->m_pfSetScale(scale);
-  return *this;
 }
 
 double
@@ -133,12 +129,11 @@ Similarity2DTransform::GetMatrix() const
   return this->m_pfGetMatrix();
 }
 
-Similarity2DTransform::Self &
+void
 Similarity2DTransform::SetMatrix(const std::vector<double> & params, double tolerance)
 {
   this->MakeUnique();
   this->m_pfSetMatrix(params, tolerance);
-  return *this;
 }
 
 void

--- a/Code/Common/src/sitkSimilarity3DTransform.cxx
+++ b/Code/Common/src/sitkSimilarity3DTransform.cxx
@@ -83,12 +83,11 @@ Similarity3DTransform::operator=(const Similarity3DTransform & arg)
 
 
 /** fixed parameter */
-Similarity3DTransform::Self &
+void
 Similarity3DTransform::SetCenter(const std::vector<double> & params)
 {
   this->MakeUnique();
   this->m_pfSetCenter(params);
-  return *this;
 }
 
 std::vector<double>
@@ -98,20 +97,18 @@ Similarity3DTransform::GetCenter() const
 }
 
 
-Similarity3DTransform::Self &
+void
 Similarity3DTransform::SetRotation(const std::vector<double> & versor)
 {
   this->MakeUnique();
   this->m_pfSetRotation1(versor);
-  return *this;
 }
 
-Similarity3DTransform::Self &
+void
 Similarity3DTransform::SetRotation(const std::vector<double> & axis, double angle)
 {
   this->MakeUnique();
   this->m_pfSetRotation2(axis, angle);
-  return *this;
 }
 
 std::vector<double>
@@ -120,12 +117,11 @@ Similarity3DTransform::GetVersor() const
   return this->m_pfGetVersor();
 }
 
-Similarity3DTransform::Self &
+void
 Similarity3DTransform::SetTranslation(const std::vector<double> & params)
 {
   this->MakeUnique();
   this->m_pfSetTranslation(params);
-  return *this;
 }
 
 std::vector<double>
@@ -134,12 +130,11 @@ Similarity3DTransform::GetTranslation() const
   return this->m_pfGetTranslation();
 }
 
-Similarity3DTransform::Self &
+void
 Similarity3DTransform::SetScale(double scale)
 {
   this->MakeUnique();
   this->m_pfSetScale(scale);
-  return *this;
 }
 
 double
@@ -148,12 +143,11 @@ Similarity3DTransform::GetScale() const
   return this->m_pfGetScale();
 }
 
-Similarity3DTransform::Self &
+void
 Similarity3DTransform::Translate(const std::vector<double> & offset)
 {
   this->MakeUnique();
   this->m_pfTranslate(offset);
-  return *this;
 }
 
 std::vector<double>
@@ -162,12 +156,11 @@ Similarity3DTransform::GetMatrix() const
   return this->m_pfGetMatrix();
 }
 
-Similarity3DTransform::Self &
+void
 Similarity3DTransform::SetMatrix(const std::vector<double> & params, double tolerance)
 {
   this->MakeUnique();
   this->m_pfSetMatrix(params, tolerance);
-  return *this;
 }
 
 void

--- a/Code/Common/src/sitkTranslationTransform.cxx
+++ b/Code/Common/src/sitkTranslationTransform.cxx
@@ -58,12 +58,11 @@ TranslationTransform::operator=(const TranslationTransform & arg)
 
 
 /** fixed parameter */
-TranslationTransform::Self &
+void
 TranslationTransform::SetOffset(const std::vector<double> & params)
 {
   this->MakeUnique();
   this->m_pfSetOffset(params);
-  return *this;
 }
 
 std::vector<double>

--- a/Code/Common/src/sitkVersorRigid3DTransform.cxx
+++ b/Code/Common/src/sitkVersorRigid3DTransform.cxx
@@ -78,12 +78,11 @@ VersorRigid3DTransform::operator=(const VersorRigid3DTransform & arg)
 
 
 /** fixed parameter */
-VersorRigid3DTransform::Self &
+void
 VersorRigid3DTransform::SetCenter(const std::vector<double> & params)
 {
   this->MakeUnique();
   this->m_pfSetCenter(params);
-  return *this;
 }
 
 std::vector<double>
@@ -93,20 +92,18 @@ VersorRigid3DTransform::GetCenter() const
 }
 
 
-VersorRigid3DTransform::Self &
+void
 VersorRigid3DTransform::SetRotation(const std::vector<double> & versor)
 {
   this->MakeUnique();
   this->m_pfSetRotation1(versor);
-  return *this;
 }
 
-VersorRigid3DTransform::Self &
+void
 VersorRigid3DTransform::SetRotation(const std::vector<double> & axis, double angle)
 {
   this->MakeUnique();
   this->m_pfSetRotation2(axis, angle);
-  return *this;
 }
 
 std::vector<double>
@@ -115,12 +112,11 @@ VersorRigid3DTransform::GetVersor() const
   return this->m_pfGetVersor();
 }
 
-VersorRigid3DTransform::Self &
+void
 VersorRigid3DTransform::SetTranslation(const std::vector<double> & params)
 {
   this->MakeUnique();
   this->m_pfSetTranslation(params);
-  return *this;
 }
 
 std::vector<double>
@@ -129,12 +125,11 @@ VersorRigid3DTransform::GetTranslation() const
   return this->m_pfGetTranslation();
 }
 
-VersorRigid3DTransform::Self &
+void
 VersorRigid3DTransform::Translate(const std::vector<double> & offset)
 {
   this->MakeUnique();
   this->m_pfTranslate(offset);
-  return *this;
 }
 
 std::vector<double>
@@ -143,12 +138,11 @@ VersorRigid3DTransform::GetMatrix() const
   return this->m_pfGetMatrix();
 }
 
-VersorRigid3DTransform::Self &
+void
 VersorRigid3DTransform::SetMatrix(const std::vector<double> & params, double tolerance)
 {
   this->MakeUnique();
   this->m_pfSetMatrix(params, tolerance);
-  return *this;
 }
 
 void

--- a/Code/Common/src/sitkVersorTransform.cxx
+++ b/Code/Common/src/sitkVersorTransform.cxx
@@ -73,12 +73,11 @@ VersorTransform::operator=(const VersorTransform & arg)
 
 
 /** fixed parameter */
-VersorTransform::Self &
+void
 VersorTransform::SetCenter(const std::vector<double> & params)
 {
   this->MakeUnique();
   this->m_pfSetCenter(params);
-  return *this;
 }
 
 std::vector<double>
@@ -88,20 +87,18 @@ VersorTransform::GetCenter() const
 }
 
 
-VersorTransform::Self &
+void
 VersorTransform::SetRotation(const std::vector<double> & versor)
 {
   this->MakeUnique();
   this->m_pfSetRotation1(versor);
-  return *this;
 }
 
-VersorTransform::Self &
+void
 VersorTransform::SetRotation(const std::vector<double> & axis, double angle)
 {
   this->MakeUnique();
   this->m_pfSetRotation2(axis, angle);
-  return *this;
 }
 
 std::vector<double>
@@ -116,12 +113,11 @@ VersorTransform::GetMatrix() const
   return this->m_pfGetMatrix();
 }
 
-VersorTransform::Self &
+void
 VersorTransform::SetMatrix(const std::vector<double> & params, double tolerance)
 {
   this->MakeUnique();
   this->m_pfSetMatrix(params, tolerance);
-  return *this;
 }
 
 void

--- a/Code/ElastixTransformixWrappers/include/sitkElastixImageFilter.h
+++ b/Code/ElastixTransformixWrappers/include/sitkElastixImageFilter.h
@@ -59,15 +59,15 @@ public:
   GetName() const;
 
   /** \brief Sets a fixed image. Stores the image into the container of fixed images. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetFixedImage(const Image & fixedImage);
 
   /** \brief Sets multiple fixed images. Stores the images into the container of fixed images. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetFixedImage(const VectorOfImage & fixedImages);
 
   /** \brief Adds an image to the end of the container of fixed images. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   AddFixedImage(const Image & fixedImage);
 
   /** \brief Retrieves a reference to the fixed image at the specified (zero-based) \p index. */
@@ -79,11 +79,11 @@ public:
   GetFixedImage();
 
   /** \brief Removes an image at the specified (zero-based) \p index from the container of fixed images. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   RemoveFixedImage(const unsigned long index);
 
   /** \brief Removes all fixed images. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   RemoveFixedImage();
 
   /** \brief Returns the number of fixed images. */
@@ -91,15 +91,15 @@ public:
   GetNumberOfFixedImages();
 
   /** \brief Sets a moving image. Stores the image into the container of moving images. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetMovingImage(const Image & movingImages);
 
   /** \brief Sets multiple moving images. Stores the images into the container of moving images. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetMovingImage(const VectorOfImage & movingImage);
 
   /** \brief Adds an image to the end of the container of moving images. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   AddMovingImage(const Image & movingImage);
 
   /** \brief Retrieves a reference to the moving image at the specified (zero-based) \p index. */
@@ -111,11 +111,11 @@ public:
   GetMovingImage();
 
   /** \brief Removes an image at the specified (zero-based) \p index from the container of moving images. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   RemoveMovingImage(const unsigned long index);
 
   /** \brief Removes all moving images. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   RemoveMovingImage();
 
   /** \brief Returns the number of moving images. */
@@ -123,15 +123,15 @@ public:
   GetNumberOfMovingImages();
 
   /** \brief Sets a fixed mask. Stores the image into the container of fixed masks. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetFixedMask(const Image & fixedMask);
 
   /** \brief Sets multiple fixed masks. Stores the images into the container of fixed masks. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetFixedMask(const VectorOfImage & fixedMasks);
 
   /** \brief Adds an image to the end of the container of fixed masks. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   AddFixedMask(const Image & fixedMask);
 
   /** \brief Retrieves a reference to the fixed mask at the specified (zero-based) \p index. */
@@ -143,11 +143,11 @@ public:
   GetFixedMask();
 
   /** \brief Removes an image at the specified (zero-based) \p index from the container of fixed masks. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   RemoveFixedMask(const unsigned long index);
 
   /** \brief Removes all fixed masks. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   RemoveFixedMask();
 
   /** \brief Returns the number of fixed masks. */
@@ -155,15 +155,15 @@ public:
   GetNumberOfFixedMasks();
 
   /** \brief Sets a moving mask. Stores the image into the container of moving masks. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetMovingMask(const Image & movingMask);
 
   /** \brief Sets multiple moving masks. Stores the images into the container of moving masks. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetMovingMask(const VectorOfImage & movingMasks);
 
   /** \brief Adds an image to the end of the container of moving masks. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   AddMovingMask(const Image & movingMask);
 
   /** \brief Retrieves a reference to the moving mask at the specified (zero-based) \p index. */
@@ -175,11 +175,11 @@ public:
   GetMovingMask();
 
   /** \brief Removes an image at the specified (zero-based) \p index from the container of moving masks. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   RemoveMovingMask(const unsigned long index);
 
   /** \brief Removes all moving masks. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   RemoveMovingMask();
 
   /** \brief Returns the number of moving masks. */
@@ -187,7 +187,7 @@ public:
   GetNumberOfMovingMasks();
 
   /** \brief Specifies a set of points from the fixed image by a point set file, \p fixedPointSetFileName. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetFixedPointSetFileName(const std::string fixedPointSetFileName);
 
   /** \brief Returns the name of the current point set file of points from the fixed image. */
@@ -195,11 +195,11 @@ public:
   GetFixedPointSetFileName();
 
   /** \brief Clears the current point set file name of points from the fixed image. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   RemoveFixedPointSetFileName();
 
   /** \brief Specifies a set of points from the moving image by a point set file, \p movingPointSetFileName. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetMovingPointSetFileName(const std::string movingPointSetFileName);
 
   /** \brief Returns the name of the current point set file of points from the moving image. */
@@ -207,11 +207,11 @@ public:
   GetMovingPointSetFileName();
 
   /** \brief Clears the current point set file name of points from the moving image. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   RemoveMovingPointSetFileName();
 
   /** \brief Sets the output directory. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetOutputDirectory(const std::string outputDirectory);
 
   /** \brief Returns the current output directory. */
@@ -219,11 +219,11 @@ public:
   GetOutputDirectory();
 
   /** \brief Clears the name of the current output directory. (Does not remove the actual directory.) */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   RemoveOutputDirectory();
 
   /** \brief Sets the name of the current log file. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetLogFileName(const std::string logFileName);
 
   /** \brief Returns the name of the current log file. */
@@ -231,11 +231,11 @@ public:
   GetLogFileName();
 
   /** \brief Clears the name of the current log file. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   RemoveLogFileName();
 
   /** \brief Switches logging to file on (`true`) or off (`false`), as specified by its function argument. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetLogToFile(const bool logToFile);
 
   /** \brief Returns whether logging to file is switched on. */
@@ -243,15 +243,15 @@ public:
   GetLogToFile();
 
   /** \brief Switches logging to file on */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   LogToFileOn();
 
   /** \brief Switches logging to file off. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   LogToFileOff();
 
   /** \brief Switches logging to console on (`true`) or off (`false`), as specified by its function argument. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetLogToConsole(bool);
 
   /** \brief Returns whether logging to console is switched on. */
@@ -259,17 +259,17 @@ public:
   GetLogToConsole();
 
   /** \brief Switches logging to console on */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   LogToConsoleOn();
 
   /** \brief Switches logging to console off */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   LogToConsoleOff();
 
   /** \brief Sets the maximum number of threads to the specified number \p n.
    * \note As a side effect, it may modify the *global* maximum number of threads, as it internally calls ITK's
    * `MultiThreaderBase.SetGlobalMaximumNumberOfThreads`. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetNumberOfThreads(int n);
 
   /** \brief Returns the current maximum number of threads. */
@@ -278,26 +278,26 @@ public:
 
   /** \brief Specifies the parameter map by a \p transformName ("translation", "rigid" , "affine", "nonrigid", or
    * "bspline"), and optionally \p numberOfResolutions and \p finalGridSpacingInPhysicalUnits. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetParameterMap(const std::string  transformName,
                   const unsigned int numberOfResolutions = 4u,
                   const double       finalGridSpacingInPhysicalUnits = 10.0);
 
   /** \brief Specifies multiple parameter maps. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetParameterMap(const std::vector<std::map<std::string, std::vector<std::string>>> parameterMapVector);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetParameterMaps(const std::vector<std::map<std::string, std::vector<std::string>>> parameterMapVector)
   {
     return SetParameterMap(parameterMapVector);
   }
 
   /** \brief Specifies a single parameter map. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetParameterMap(const std::map<std::string, std::vector<std::string>> parameterMap);
 
   /** \brief Adds a parameter map to the container of parameter maps. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   AddParameterMap(const std::map<std::string, std::vector<std::string>> parameterMap);
 
   /** \brief Returns a copy of the parameter maps. */
@@ -321,39 +321,39 @@ public:
   GetNumberOfParameterMaps();
 
   /** \brief Sets the value of the parameter specified by \p key, in all parameter maps. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetParameter(const std::string key, const std::string value);
 
   /** \brief Sets the values of the parameter specified by \p key, in all parameter maps. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetParameter(const std::string key, const std::vector<std::string> value);
 
   /** \brief Sets the value of the parameter specified by \p key, in the parameter map at the specified (zero-based) \p
    * index. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetParameter(const unsigned int index, const std::string key, const std::string value);
 
   /** \brief Sets the values of the parameter specified by \p key, in the parameter map at the specified (zero-based) \p
    * index. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetParameter(const unsigned int index, const std::string key, const std::vector<std::string> value);
 
   /** \brief Adds a parameter specified by \p key, with the specified value to all parameter maps. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   AddParameter(const std::string key, const std::string value);
 
   /** \brief Adds a parameter specified by \p key, with the specified value to the parameter map at the specified
    * (zero-based) \p index. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   AddParameter(const unsigned int index, const std::string key, const std::string value);
 
   /** \brief Adds a parameter specified by \p key, with the specified values to all parameter maps. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   AddParameter(const std::string key, const std::vector<std::string> value);
 
   /** \brief Adds a parameter specified by \p key, with the specified values to the parameter map at the specified
    * (zero-based) \p index. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   AddParameter(const unsigned int index, const std::string key, const std::vector<std::string> value);
 
   /** \brief Retrieves the values of the parameter specified by \p key, when there is only one parameter map. */
@@ -366,15 +366,15 @@ public:
   GetParameter(const unsigned int index, const std::string key);
 
   /** \brief Removes the parameter specified by \p key from all parameter maps. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   RemoveParameter(const std::string key);
 
   /** \brief Removes the parameter specified by \p key from the parameter map at the specified (zero-based) \p index. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   RemoveParameter(const unsigned int index, const std::string key);
 
   /** \brief Specifies the initial transformation by the specified transform parameter file name. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetInitialTransformParameterFileName(const std::string initialTransformParmaterFileName);
 
   /** \brief Returns the initial transform parameter file name. */
@@ -382,7 +382,7 @@ public:
   GetInitialTransformParameterFileName();
 
   /** \brief Clears the initial transform parameter file name. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   RemoveInitialTransformParameterFileName();
 
   /** \brief Reads the parameter file specified by \p filename, and returns its content as a parameter map. */
@@ -390,7 +390,7 @@ public:
   ReadParameterFile(const std::string filename);
 
   /** \brief Writes a parameter map to the file, specified by \p filename. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   WriteParameterFile(const std::map<std::string, std::vector<std::string>> parameterMap, const std::string filename);
 
   /** \brief Executes the registration, and returns the result image.
@@ -414,15 +414,15 @@ public:
   GetResultImage();
 
   /** \brief Prints all parameter maps to standard output. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   PrintParameterMap();
 
   /** \brief Prints the specified parameter map to standard output. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   PrintParameterMap(const ParameterMapType parameterMapVector);
 
   /** \brief Prints the specified parameter maps to standard output. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   PrintParameterMap(const ParameterMapVectorType parameterMapVector);
 
 private:

--- a/Code/ElastixTransformixWrappers/include/sitkTransformixImageFilter.h
+++ b/Code/ElastixTransformixWrappers/include/sitkTransformixImageFilter.h
@@ -50,89 +50,89 @@ public:
   std::string
   GetName() const;
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetMovingImage(const Image & movingImage);
   Image &
   GetMovingImage();
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   RemoveMovingImage();
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetFixedPointSetFileName(const std::string movingPointSetFileName);
   std::string
   GetFixedPointSetFileName();
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   RemoveFixedPointSetFileName();
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetComputeSpatialJacobian(const bool);
   bool
   GetComputeSpatialJacobian();
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   ComputeSpatialJacobianOn();
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   ComputeSpatialJacobianOff();
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetComputeDeterminantOfSpatialJacobian(const bool);
   bool
   GetComputeDeterminantOfSpatialJacobian();
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   ComputeDeterminantOfSpatialJacobianOn();
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   ComputeDeterminantOfSpatialJacobianOff();
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetComputeDeformationField(bool);
   bool
   GetComputeDeformationField();
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   ComputeDeformationFieldOn();
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   ComputeDeformationFieldOff();
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetOutputDirectory(const std::string outputDirectory);
   std::string
   GetOutputDirectory();
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   RemoveOutputDirectory();
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetLogFileName(const std::string logFileName);
   std::string
   GetLogFileName();
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   RemoveLogFileName();
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetLogToFile(const bool logToFile);
   bool
   GetLogToFile();
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   LogToFileOn();
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   LogToFileOff();
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetLogToConsole(const bool logToConsole);
   bool
   GetLogToConsole();
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   LogToConsoleOn();
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   LogToConsoleOff();
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetTransformParameterMap(const std::vector<std::map<std::string, std::vector<std::string>>> parameterMapVector);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetTransformParameterMaps(const std::vector<std::map<std::string, std::vector<std::string>>> parameterMapVector)
   {
     return SetTransformParameterMap(parameterMapVector);
   }
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetTransformParameterMap(const std::map<std::string, std::vector<std::string>> parameterMap);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   AddTransformParameterMap(const std::map<std::string, std::vector<std::string>> parameterMap);
   std::vector<std::map<std::string, std::vector<std::string>>>
   GetTransformParameterMap();
@@ -144,38 +144,38 @@ public:
   unsigned int
   GetNumberOfTransformParameterMaps();
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetTransformParameter(const std::string key, const std::string value);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetTransformParameter(const std::string key, const std::vector<std::string> value);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetTransformParameter(const unsigned int index, const std::string key, const std::string value);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetTransformParameter(const unsigned int index, const std::string key, const std::vector<std::string> value);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   AddTransformParameter(const std::string key, const std::string value);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   AddTransformParameter(const unsigned int index, const std::string key, const std::string value);
   std::vector<std::string>
   GetTransformParameter(const std::string key);
   std::vector<std::string>
   GetTransformParameter(const unsigned int index, const std::string key);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   RemoveTransformParameter(const std::string key);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   RemoveTransformParameter(const unsigned int index, const std::string key);
 
   std::map<std::string, std::vector<std::string>>
   ReadParameterFile(const std::string parameterFileName);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   WriteParameterFile(const std::map<std::string, std::vector<std::string>> parameterMap,
                      const std::string                                     parameterFileName);
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   PrintParameterMap();
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   PrintParameterMap(const std::map<std::string, std::vector<std::string>> parameterMap);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   PrintParameterMap(const std::vector<std::map<std::string, std::vector<std::string>>> parameterMapVector);
 
   Image

--- a/Code/ElastixTransformixWrappers/src/sitkElastixImageFilter.cxx
+++ b/Code/ElastixTransformixWrappers/src/sitkElastixImageFilter.cxx
@@ -16,25 +16,22 @@ ElastixImageFilter ::GetName() const
   return this->m_Pimple->GetName();
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::SetFixedImage(const Image & fixedImage)
 {
   this->m_Pimple->SetFixedImage(fixedImage);
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::SetFixedImage(const VectorOfImage & fixedImages)
 {
   this->m_Pimple->SetFixedImage(fixedImages);
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::AddFixedImage(const Image & fixedImage)
 {
   this->m_Pimple->AddFixedImage(fixedImage);
-  return *this;
 }
 
 Image &
@@ -49,18 +46,16 @@ ElastixImageFilter ::GetFixedImage()
   return this->m_Pimple->GetFixedImage();
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::RemoveFixedImage(const unsigned long index)
 {
   this->m_Pimple->RemoveFixedImage(index);
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::RemoveFixedImage()
 {
   this->m_Pimple->RemoveFixedImage();
-  return *this;
 }
 
 unsigned int
@@ -69,25 +64,22 @@ ElastixImageFilter ::GetNumberOfFixedImages()
   return this->m_Pimple->GetNumberOfFixedImages();
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::SetMovingImage(const Image & movingImage)
 {
   this->m_Pimple->SetMovingImage(movingImage);
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::SetMovingImage(const VectorOfImage & movingImages)
 {
   this->m_Pimple->SetMovingImage(movingImages);
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::AddMovingImage(const Image & movingImage)
 {
   this->m_Pimple->AddMovingImage(movingImage);
-  return *this;
 }
 
 Image &
@@ -102,18 +94,16 @@ ElastixImageFilter ::GetMovingImage()
   return this->m_Pimple->GetMovingImage();
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::RemoveMovingImage(const unsigned long index)
 {
   this->m_Pimple->RemoveMovingImage(index);
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::RemoveMovingImage()
 {
   this->m_Pimple->RemoveMovingImage();
-  return *this;
 }
 
 unsigned int
@@ -122,25 +112,22 @@ ElastixImageFilter ::GetNumberOfMovingImages()
   return this->m_Pimple->GetNumberOfMovingImages();
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::SetFixedMask(const Image & fixedMask)
 {
   this->m_Pimple->SetFixedMask(fixedMask);
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::SetFixedMask(const VectorOfImage & fixedMasks)
 {
   this->m_Pimple->SetFixedMask(fixedMasks);
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::AddFixedMask(const Image & fixedMask)
 {
   this->m_Pimple->AddFixedMask(fixedMask);
-  return *this;
 }
 
 Image &
@@ -155,18 +142,16 @@ ElastixImageFilter ::GetFixedMask()
   return this->m_Pimple->GetFixedMask();
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::RemoveFixedMask(const unsigned long index)
 {
   this->m_Pimple->RemoveFixedMask(index);
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::RemoveFixedMask()
 {
   this->m_Pimple->RemoveFixedMask();
-  return *this;
 }
 
 unsigned int
@@ -175,25 +160,22 @@ ElastixImageFilter ::GetNumberOfFixedMasks()
   return this->m_Pimple->GetNumberOfFixedMasks();
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::SetMovingMask(const Image & movingMask)
 {
   this->m_Pimple->SetMovingMask(movingMask);
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::SetMovingMask(const VectorOfImage & movingMasks)
 {
   this->m_Pimple->SetMovingMask(movingMasks);
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::AddMovingMask(const Image & movingMask)
 {
   this->m_Pimple->AddMovingMask(movingMask);
-  return *this;
 }
 
 Image &
@@ -208,18 +190,16 @@ ElastixImageFilter ::GetMovingMask()
   return this->m_Pimple->GetMovingMask();
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::RemoveMovingMask(const unsigned long index)
 {
   this->m_Pimple->RemoveMovingMask(index);
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::RemoveMovingMask()
 {
   this->m_Pimple->RemoveMovingMask();
-  return *this;
 }
 
 unsigned int
@@ -228,11 +208,10 @@ ElastixImageFilter ::GetNumberOfMovingMasks()
   return this->m_Pimple->GetNumberOfMovingMasks();
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::SetFixedPointSetFileName(const std::string fixedPointSetFileName)
 {
   this->m_Pimple->SetFixedPointSetFileName(fixedPointSetFileName);
-  return *this;
 }
 
 std::string
@@ -241,18 +220,16 @@ ElastixImageFilter ::GetFixedPointSetFileName()
   return this->m_Pimple->GetFixedPointSetFileName();
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::RemoveFixedPointSetFileName()
 {
   this->m_Pimple->RemoveFixedPointSetFileName();
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::SetMovingPointSetFileName(const std::string movingPointSetFileName)
 {
   this->m_Pimple->SetMovingPointSetFileName(movingPointSetFileName);
-  return *this;
 }
 
 std::string
@@ -261,18 +238,16 @@ ElastixImageFilter ::GetMovingPointSetFileName()
   return this->m_Pimple->GetMovingPointSetFileName();
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::RemoveMovingPointSetFileName()
 {
   this->m_Pimple->RemoveMovingImage();
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::SetOutputDirectory(const std::string outputDirectory)
 {
   this->m_Pimple->SetOutputDirectory(outputDirectory);
-  return *this;
 }
 
 std::string
@@ -281,18 +256,16 @@ ElastixImageFilter ::GetOutputDirectory()
   return this->m_Pimple->GetOutputDirectory();
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::RemoveOutputDirectory()
 {
   this->m_Pimple->RemoveOutputDirectory();
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::SetLogFileName(std::string logFileName)
 {
   this->m_Pimple->SetLogFileName(logFileName);
-  return *this;
 }
 
 std::string
@@ -301,18 +274,16 @@ ElastixImageFilter ::GetLogFileName()
   return this->m_Pimple->GetLogFileName();
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::RemoveLogFileName()
 {
   this->m_Pimple->RemoveLogFileName();
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::SetLogToFile(bool logToFile)
 {
   this->m_Pimple->SetLogToFile(logToFile);
-  return *this;
 }
 
 bool
@@ -321,25 +292,22 @@ ElastixImageFilter ::GetLogToFile()
   return this->m_Pimple->GetLogToFile();
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::LogToFileOn()
 {
   this->m_Pimple->LogToFileOn();
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::LogToFileOff()
 {
   this->m_Pimple->LogToFileOff();
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::SetLogToConsole(bool logToConsole)
 {
   this->m_Pimple->SetLogToConsole(logToConsole);
-  return *this;
 }
 
 bool
@@ -348,25 +316,22 @@ ElastixImageFilter ::GetLogToConsole()
   return this->m_Pimple->GetLogToConsole();
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::LogToConsoleOn()
 {
   this->m_Pimple->LogToConsoleOn();
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::LogToConsoleOff()
 {
   this->m_Pimple->LogToConsoleOff();
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::SetNumberOfThreads(int n)
 {
   this->m_Pimple->SetNumberOfThreads(n);
-  return *this;
 }
 
 int
@@ -375,34 +340,30 @@ ElastixImageFilter ::GetNumberOfThreads()
   return this->m_Pimple->GetNumberOfThreads();
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::SetParameterMap(const std::string  transformName,
                                      const unsigned int numberOfResolutions,
                                      const double       finalGridSpacingInPhysicalUnits)
 {
   this->m_Pimple->SetParameterMap(transformName, numberOfResolutions, finalGridSpacingInPhysicalUnits);
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::SetParameterMap(const ParameterMapType parameterMap)
 {
   this->m_Pimple->SetParameterMap(parameterMap);
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::SetParameterMap(const ParameterMapVectorType parameterMapVector)
 {
   this->m_Pimple->SetParameterMap(parameterMapVector);
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::AddParameterMap(const ParameterMapType parameterMap)
 {
   this->m_Pimple->AddParameterMap(parameterMap);
-  return *this;
 }
 
 ElastixImageFilter::ParameterMapVectorType
@@ -417,11 +378,10 @@ ElastixImageFilter ::GetNumberOfParameterMaps()
   return this->m_Pimple->GetNumberOfParameterMaps();
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::SetInitialTransformParameterFileName(const std::string initialTransformParameterFileName)
 {
   this->m_Pimple->SetInitialTransformParameterFileName(initialTransformParameterFileName);
-  return *this;
 }
 
 std::string
@@ -430,71 +390,62 @@ ElastixImageFilter ::GetInitialTransformParameterFileName()
   return this->m_Pimple->GetInitialTransformParameterFileName();
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::RemoveInitialTransformParameterFileName()
 {
   this->m_Pimple->RemoveInitialTransformParameterFileName();
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::SetParameter(const ParameterKeyType key, const ParameterValueType value)
 {
   this->m_Pimple->SetParameter(key, value);
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::SetParameter(const ParameterKeyType key, const ParameterValueVectorType value)
 {
   this->m_Pimple->SetParameter(key, value);
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::SetParameter(const unsigned int index, const ParameterKeyType key, const ParameterValueType value)
 {
   this->m_Pimple->SetParameter(index, key, value);
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::SetParameter(const unsigned int             index,
                                   const ParameterKeyType         key,
                                   const ParameterValueVectorType value)
 {
   this->m_Pimple->SetParameter(index, key, value);
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::AddParameter(const ParameterKeyType key, const ParameterValueType value)
 {
   this->m_Pimple->AddParameter(key, value);
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::AddParameter(const ParameterKeyType key, const ParameterValueVectorType value)
 {
   this->m_Pimple->AddParameter(key, value);
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::AddParameter(const unsigned int index, const ParameterKeyType key, const ParameterValueType value)
 {
   this->m_Pimple->AddParameter(index, key, value);
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::AddParameter(const unsigned int             index,
                                   const ParameterKeyType         key,
                                   const ParameterValueVectorType value)
 {
   this->m_Pimple->AddParameter(index, key, value);
-  return *this;
 }
 
 ElastixImageFilter::ParameterValueVectorType
@@ -509,18 +460,16 @@ ElastixImageFilter ::GetParameter(const unsigned int index, const ParameterKeyTy
   return this->m_Pimple->GetParameter(index, key);
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::RemoveParameter(const ParameterKeyType key)
 {
   this->m_Pimple->RemoveParameter(key);
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::RemoveParameter(const unsigned int index, const ParameterKeyType key)
 {
   this->m_Pimple->RemoveParameter(index, key);
-  return *this;
 }
 
 ElastixImageFilter::ParameterMapType
@@ -529,11 +478,10 @@ ElastixImageFilter ::ReadParameterFile(const std::string fileName)
   return this->m_Pimple->ReadParameterFile(fileName);
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::WriteParameterFile(const ParameterMapType parameterMap, const std::string parameterFileName)
 {
   this->m_Pimple->WriteParameterFile(parameterMap, parameterFileName);
-  return *this;
 }
 
 ElastixImageFilter::ParameterMapType
@@ -568,25 +516,22 @@ ElastixImageFilter ::GetResultImage()
   return this->m_Pimple->GetResultImage();
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::PrintParameterMap()
 {
   this->m_Pimple->PrintParameterMap();
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::PrintParameterMap(const ParameterMapType parameterMap)
 {
   this->m_Pimple->PrintParameterMap(parameterMap);
-  return *this;
 }
 
-ElastixImageFilter::Self &
+void
 ElastixImageFilter ::PrintParameterMap(const ParameterMapVectorType parameterMapVector)
 {
   this->m_Pimple->PrintParameterMap(parameterMapVector);
-  return *this;
 }
 
 /**

--- a/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilter.cxx
+++ b/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilter.cxx
@@ -16,11 +16,10 @@ TransformixImageFilter ::GetName() const
   return this->m_Pimple->GetName();
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::SetMovingImage(const Image & movingImage)
 {
   this->m_Pimple->SetMovingImage(movingImage);
-  return *this;
 }
 
 Image &
@@ -29,18 +28,16 @@ TransformixImageFilter ::GetMovingImage()
   return this->m_Pimple->GetMovingImage();
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::RemoveMovingImage()
 {
   this->m_Pimple->RemoveMovingImage();
-  return *this;
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::SetFixedPointSetFileName(const std::string movingPointSetFileName)
 {
   this->m_Pimple->SetFixedPointSetFileName(movingPointSetFileName);
-  return *this;
 }
 
 std::string
@@ -49,18 +46,16 @@ TransformixImageFilter ::GetFixedPointSetFileName()
   return this->m_Pimple->GetFixedPointSetFileName();
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::RemoveFixedPointSetFileName()
 {
   this->m_Pimple->RemoveFixedPointSetFileName();
-  return *this;
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::SetComputeSpatialJacobian(const bool computeSpatialJacobian)
 {
   this->m_Pimple->SetComputeSpatialJacobian(computeSpatialJacobian);
-  return *this;
 }
 
 bool
@@ -69,25 +64,22 @@ TransformixImageFilter ::GetComputeSpatialJacobian()
   return this->m_Pimple->GetComputeSpatialJacobian();
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::ComputeSpatialJacobianOn()
 {
   this->m_Pimple->SetComputeSpatialJacobian(true);
-  return *this;
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::ComputeSpatialJacobianOff()
 {
   this->m_Pimple->SetComputeSpatialJacobian(false);
-  return *this;
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::SetComputeDeterminantOfSpatialJacobian(const bool computeDeterminantOfSpatialJacobian)
 {
   this->m_Pimple->SetComputeDeterminantOfSpatialJacobian(computeDeterminantOfSpatialJacobian);
-  return *this;
 }
 
 bool
@@ -96,25 +88,22 @@ TransformixImageFilter ::GetComputeDeterminantOfSpatialJacobian()
   return this->m_Pimple->GetComputeDeterminantOfSpatialJacobian();
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::ComputeDeterminantOfSpatialJacobianOn()
 {
   this->m_Pimple->SetComputeDeterminantOfSpatialJacobian(true);
-  return *this;
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::ComputeDeterminantOfSpatialJacobianOff()
 {
   this->m_Pimple->SetComputeDeterminantOfSpatialJacobian(false);
-  return *this;
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::SetComputeDeformationField(const bool computeDeformationField)
 {
   this->m_Pimple->SetComputeDeformationField(computeDeformationField);
-  return *this;
 }
 
 bool
@@ -123,25 +112,22 @@ TransformixImageFilter ::GetComputeDeformationField()
   return this->m_Pimple->GetComputeDeformationField();
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::ComputeDeformationFieldOn()
 {
   this->m_Pimple->SetComputeDeformationField(true);
-  return *this;
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::ComputeDeformationFieldOff()
 {
   this->m_Pimple->SetComputeDeformationField(false);
-  return *this;
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::SetOutputDirectory(const std::string outputDirectory)
 {
   this->m_Pimple->SetOutputDirectory(outputDirectory);
-  return *this;
 }
 
 std::string
@@ -150,18 +136,16 @@ TransformixImageFilter ::GetOutputDirectory()
   return this->m_Pimple->GetOutputDirectory();
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::RemoveOutputDirectory()
 {
   this->m_Pimple->RemoveOutputDirectory();
-  return *this;
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::SetLogFileName(std::string logFileName)
 {
   this->m_Pimple->SetLogFileName(logFileName);
-  return *this;
 }
 
 std::string
@@ -170,18 +154,16 @@ TransformixImageFilter ::GetLogFileName()
   return this->m_Pimple->GetLogFileName();
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::RemoveLogFileName()
 {
   this->m_Pimple->RemoveLogFileName();
-  return *this;
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::SetLogToFile(bool logToFile)
 {
   this->m_Pimple->SetLogToFile(logToFile);
-  return *this;
 }
 
 bool
@@ -190,25 +172,22 @@ TransformixImageFilter ::GetLogToFile()
   return this->m_Pimple->GetLogToFile();
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::LogToFileOn()
 {
   this->m_Pimple->SetLogToFile(true);
-  return *this;
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::LogToFileOff()
 {
   this->m_Pimple->SetLogToFile(false);
-  return *this;
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::SetLogToConsole(bool logToConsole)
 {
   this->m_Pimple->SetLogToConsole(logToConsole);
-  return *this;
 }
 
 bool
@@ -217,39 +196,34 @@ TransformixImageFilter ::GetLogToConsole()
   return this->m_Pimple->GetLogToConsole();
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::LogToConsoleOn()
 {
   this->m_Pimple->SetLogToConsole(true);
-  return *this;
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::LogToConsoleOff()
 {
   this->m_Pimple->SetLogToConsole(false);
-  return *this;
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::SetTransformParameterMap(const ParameterMapVectorType transformParameterMapVector)
 {
   this->m_Pimple->SetTransformParameterMap(transformParameterMapVector);
-  return *this;
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::SetTransformParameterMap(const ParameterMapType transformParameterMap)
 {
   this->m_Pimple->SetTransformParameterMap(transformParameterMap);
-  return *this;
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::AddTransformParameterMap(const ParameterMapType transformParameterMap)
 {
   this->m_Pimple->AddTransformParameterMap(transformParameterMap);
-  return *this;
 }
 
 TransformixImageFilter::ParameterMapVectorType
@@ -264,52 +238,46 @@ TransformixImageFilter ::GetNumberOfTransformParameterMaps()
   return this->m_Pimple->GetNumberOfTransformParameterMaps();
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::SetTransformParameter(const ParameterKeyType key, const ParameterValueType value)
 {
   this->m_Pimple->SetTransformParameter(key, value);
-  return *this;
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::SetTransformParameter(const ParameterKeyType key, const ParameterValueVectorType value)
 {
   this->m_Pimple->SetTransformParameter(key, value);
-  return *this;
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::SetTransformParameter(const unsigned int       index,
                                                const ParameterKeyType   key,
                                                const ParameterValueType value)
 {
   this->m_Pimple->SetTransformParameter(index, key, value);
-  return *this;
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::SetTransformParameter(const unsigned int             index,
                                                const ParameterKeyType         key,
                                                const ParameterValueVectorType value)
 {
   this->m_Pimple->SetTransformParameter(index, key, value);
-  return *this;
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::AddTransformParameter(const ParameterKeyType key, const ParameterValueType value)
 {
   this->m_Pimple->AddTransformParameter(key, value);
-  return *this;
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::AddTransformParameter(const unsigned int       index,
                                                const ParameterKeyType   key,
                                                const ParameterValueType value)
 {
   this->m_Pimple->AddTransformParameter(index, key, value);
-  return *this;
 }
 
 TransformixImageFilter::ParameterValueVectorType
@@ -324,18 +292,16 @@ TransformixImageFilter ::GetTransformParameter(const unsigned int index, const P
   return this->m_Pimple->GetTransformParameter(index, key);
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::RemoveTransformParameter(const ParameterKeyType key)
 {
   this->m_Pimple->RemoveTransformParameter(key);
-  return *this;
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::RemoveTransformParameter(const unsigned int index, const ParameterKeyType key)
 {
   this->m_Pimple->RemoveTransformParameter(index, key);
-  return *this;
 }
 
 TransformixImageFilter::ParameterMapType
@@ -344,32 +310,28 @@ TransformixImageFilter ::ReadParameterFile(const std::string parameterFileName)
   return this->m_Pimple->ReadParameterFile(parameterFileName);
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::WriteParameterFile(const ParameterMapType parameterMap, const std::string parameterFileName)
 {
   this->m_Pimple->WriteParameterFile(parameterMap, parameterFileName);
-  return *this;
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::PrintParameterMap()
 {
   this->m_Pimple->PrintParameterMap();
-  return *this;
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::PrintParameterMap(const ParameterMapType parameterMap)
 {
   this->m_Pimple->PrintParameterMap(parameterMap);
-  return *this;
 }
 
-TransformixImageFilter::Self &
+void
 TransformixImageFilter ::PrintParameterMap(const ParameterMapVectorType parameterMapVector)
 {
   this->m_Pimple->PrintParameterMap(parameterMapVector);
-  return *this;
 }
 
 Image

--- a/Code/IO/include/sitkImageFileReader.h
+++ b/Code/IO/include/sitkImageFileReader.h
@@ -91,7 +91,7 @@ public:
     return std::string("ImageFileReader");
   }
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetFileName(const PathType & fn);
   PathType
   GetFileName() const;
@@ -201,7 +201,7 @@ public:
    *
    * \sa ExtractImageFilter
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetExtractSize(const std::vector<unsigned int> & size);
   const std::vector<unsigned int> &
   GetExtractSize() const;
@@ -213,7 +213,7 @@ public:
    *
    * \sa ExtractImageFilter
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetExtractIndex(const std::vector<int> & index);
   const std::vector<int> &
   GetExtractIndex() const;

--- a/Code/IO/include/sitkImageFileWriter.h
+++ b/Code/IO/include/sitkImageFileWriter.h
@@ -83,15 +83,21 @@ public:
    * gets passed to image file's itk::ImageIO object. This is
    * only a request as not all file formats support compression.
    * @{ */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetUseCompression(bool UseCompression);
   bool
   GetUseCompression() const;
 
-  SITK_RETURN_SELF_TYPE_HEADER
-  UseCompressionOn() { return this->SetUseCompression(true); }
-  SITK_RETURN_SELF_TYPE_HEADER
-  UseCompressionOff() { return this->SetUseCompression(false); }
+  void
+  UseCompressionOn()
+  {
+    return this->SetUseCompression(true);
+  }
+  void
+  UseCompressionOff()
+  {
+    return this->SetUseCompression(false);
+  }
   /** @} */
 
 
@@ -101,7 +107,7 @@ public:
    * is dependent upon the compression algorithm used. It is generally 0-100 for JPEG like lossy compression and 0-9 for
    * lossless zip or LZW like compression algorithms.  Please see the specific itk::ImageIO for details.
    * @{ */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetCompressionLevel(int);
   int
   GetCompressionLevel() const;
@@ -113,7 +119,7 @@ public:
    * If the string identifier is not known a warning is produced and the default compressor is used. Please see the
    * itk::ImageIO for details.
    * @{ */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetCompressor(const std::string &);
   std::string
   GetCompressor();
@@ -131,7 +137,7 @@ public:
    * ImageIO factory mechanism.
    * @{
    */
-  virtual SITK_RETURN_SELF_TYPE_HEADER
+  virtual void
   SetImageIO(const std::string & imageio);
   virtual std::string
   GetImageIO() const;
@@ -146,25 +152,31 @@ public:
    * to use the information in the image's meta-data dictionary or
    * to create new study/series/frame of reference values.
    * @{ */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetKeepOriginalImageUID(bool KeepOriginalImageUID);
   bool
   GetKeepOriginalImageUID() const;
 
-  SITK_RETURN_SELF_TYPE_HEADER
-  KeepOriginalImageUIDOn() { return this->SetKeepOriginalImageUID(true); }
-  SITK_RETURN_SELF_TYPE_HEADER
-  KeepOriginalImageUIDOff() { return this->SetKeepOriginalImageUID(false); }
+  void
+  KeepOriginalImageUIDOn()
+  {
+    return this->SetKeepOriginalImageUID(true);
+  }
+  void
+  KeepOriginalImageUIDOff()
+  {
+    return this->SetKeepOriginalImageUID(false);
+  }
   /** @} */
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetFileName(const PathType & fileName);
   PathType
   GetFileName() const;
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   Execute(const Image &);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   Execute(const Image &, const PathType & inFileName, bool useCompression, int compressionLevel);
 
 private:
@@ -172,7 +184,7 @@ private:
   GetImageIOBase(const PathType & fileName);
 
   template <class T>
-  Self &
+  void
   ExecuteInternal(const Image &);
 
   bool        m_UseCompression;
@@ -184,7 +196,7 @@ private:
   std::string m_ImageIOName;
 
   // function pointer type
-  typedef Self & (Self::*MemberFunctionType)(const Image &);
+  typedef void (Self::*MemberFunctionType)(const Image &);
 
   // friend to get access to executeInternal member
   friend struct detail::MemberFunctionAddressor<MemberFunctionType>;

--- a/Code/IO/include/sitkImageReaderBase.h
+++ b/Code/IO/include/sitkImageReaderBase.h
@@ -57,7 +57,7 @@ public:
    * convert the pixels.
    * @{
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetOutputPixelType(PixelIDValueEnum pixelID);
   PixelIDValueEnum
   GetOutputPixelType() const;
@@ -85,7 +85,7 @@ public:
    * Unknown private tags may be encoded with Base64 encoding.
    * @{
    */
-  virtual SITK_RETURN_SELF_TYPE_HEADER
+  virtual void
   SetLoadPrivateTags(bool loadPrivateTags);
   virtual bool
   GetLoadPrivateTags() const;
@@ -109,7 +109,7 @@ public:
    * ImageIO factory mechanism.
    * @{
    */
-  virtual SITK_RETURN_SELF_TYPE_HEADER
+  virtual void
   SetImageIO(const std::string & imageio);
   virtual std::string
   GetImageIO() const;

--- a/Code/IO/include/sitkImageSeriesReader.h
+++ b/Code/IO/include/sitkImageSeriesReader.h
@@ -91,11 +91,10 @@ public:
    * should be read. Default value is false, because of the
    * additional computation time.
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetMetaDataDictionaryArrayUpdate(bool metaDataDictionaryArrayUpdate)
   {
     this->m_MetaDataDictionaryArrayUpdate = metaDataDictionaryArrayUpdate;
-    return *this;
   }
   bool
   GetMetaDataDictionaryArrayUpdate()
@@ -105,10 +104,16 @@ public:
 
 
   /** Set the value of MetaDataDictionaryArrayUpdate to true or false respectively. */
-  SITK_RETURN_SELF_TYPE_HEADER
-  MetaDataDictionaryArrayUpdateOn() { return this->SetMetaDataDictionaryArrayUpdate(true); }
-  SITK_RETURN_SELF_TYPE_HEADER
-  MetaDataDictionaryArrayUpdateOff() { return this->SetMetaDataDictionaryArrayUpdate(false); }
+  void
+  MetaDataDictionaryArrayUpdateOn()
+  {
+    return this->SetMetaDataDictionaryArrayUpdate(true);
+  }
+  void
+  MetaDataDictionaryArrayUpdateOff()
+  {
+    return this->SetMetaDataDictionaryArrayUpdate(false);
+  }
 
 
   /** \brief Generate a sequence of filenames from a directory with a DICOM data set and a series ID.
@@ -158,13 +163,13 @@ public:
   static std::vector<std::string>
   GetGDCMSeriesIDs(const PathType & directory, bool useSeriesDetails = false);
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetFileNames(const std::vector<PathType> & fileNames);
   const std::vector<PathType> &
   GetFileNames() const;
 
   /** Set the relative threshold for issuing warnings about non-uniform sampling. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetSpacingWarningRelThreshold(double spacingWarningRelThreshold);
   double
   GetSpacingWarningRelThreshold() const;
@@ -174,26 +179,26 @@ public:
    * Do we want to force orthogonal direction cosines? On by default. Turning it off enables proper reading of DICOM
    * series with gantry tilt.
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetForceOrthogonalDirection(bool forceOrthogonalDirection);
   bool
   GetForceOrthogonalDirection() const;
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   ForceOrthogonalDirectionOn();
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   ForceOrthogonalDirectionOff();
 
   /** Set/Get/OnOff whether to reverse the order of the input files.
    *
    * If true, the order of the input file names will be reversed before reading. Defaults to false.
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetReverseOrder(bool reverseOrder);
   bool
   GetReverseOrder() const;
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   ReverseOrderOn();
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   ReverseOrderOff();
 
   Image

--- a/Code/IO/include/sitkImageSeriesWriter.h
+++ b/Code/IO/include/sitkImageSeriesWriter.h
@@ -79,7 +79,7 @@ public:
    * ImageIO factory mechanism.
    * @{
    */
-  virtual SITK_RETURN_SELF_TYPE_HEADER
+  virtual void
   SetImageIO(const std::string & imageio);
   virtual std::string
   GetImageIO() const;
@@ -98,15 +98,21 @@ public:
    * gets passed to image file's itk::ImageIO object. This is
    * only a request as not all file formats support compression.
    * @{ */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetUseCompression(bool UseCompression);
   bool
   GetUseCompression() const;
 
-  SITK_RETURN_SELF_TYPE_HEADER
-  UseCompressionOn() { return this->SetUseCompression(true); }
-  SITK_RETURN_SELF_TYPE_HEADER
-  UseCompressionOff() { return this->SetUseCompression(false); }
+  void
+  UseCompressionOn()
+  {
+    return this->SetUseCompression(true);
+  }
+  void
+  UseCompressionOff()
+  {
+    return this->SetUseCompression(false);
+  }
   /** @} */
 
   /** \brief A hint for the amount of compression to be applied during writing.
@@ -115,7 +121,7 @@ public:
    * is dependent upon the compression algorithm used. It is generally 0-100 for JPEG like lossy compression and 0-9 for
    * lossless zip or LZW like compression algorithms.  Please see the specific itk::ImageIO for details.
    * @{ */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetCompressionLevel(int);
   int
   GetCompressionLevel() const;
@@ -127,7 +133,7 @@ public:
    * If the string identifier is not known a warning is produced and the default compressor is used. Please see the
    * itk::ImageIO for details.
    * @{ */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetCompressor(const std::string &);
   std::string
   GetCompressor();
@@ -138,21 +144,21 @@ public:
    * The number of filenames must match the number of slices in
    * the image.
    * @{ */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetFileNames(const std::vector<PathType> & fileNames);
   const std::vector<PathType> &
   GetFileNames() const;
   /** @} */
 
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   Execute(const Image &);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   Execute(const Image & image, const std::vector<PathType> & inFileNames, bool useCompression, int compressionLevel);
 
 protected:
   template <class TImageType>
-  Self &
+  void
   ExecuteInternal(const Image & inImage);
 
 private:
@@ -160,7 +166,7 @@ private:
   GetImageIOBase(const PathType & fileName);
 
   // function pointer type
-  typedef Self & (Self::*MemberFunctionType)(const Image &);
+  typedef void (Self::*MemberFunctionType)(const Image &);
 
   // friend to get access to executeInternal member
   friend struct detail::MemberFunctionAddressor<MemberFunctionType>;

--- a/Code/IO/include/sitkImportImageFilter.h
+++ b/Code/IO/include/sitkImportImageFilter.h
@@ -64,45 +64,45 @@ public:
     return std::string("ImportImageFilter");
   }
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetSize(const std::vector<unsigned int> & size);
   const std::vector<unsigned int> &
   GetSize() const;
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetSpacing(const std::vector<double> & spacing);
   const std::vector<double> &
   GetSpacing() const;
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetOrigin(const std::vector<double> & origin);
   const std::vector<double> &
   GetOrigin() const;
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetDirection(const std::vector<double> & direction);
   const std::vector<double> &
   GetDirection() const;
 
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetBufferAsInt8(int8_t * buffer, unsigned int numberOfComponents = 1);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetBufferAsUInt8(uint8_t * buffer, unsigned int numberOfComponents = 1);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetBufferAsInt16(int16_t * buffer, unsigned int numberOfComponents = 1);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetBufferAsUInt16(uint16_t * buffer, unsigned int numberOfComponents = 1);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetBufferAsInt32(int32_t * buffer, unsigned int numberOfComponents = 1);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetBufferAsUInt32(uint32_t * buffer, unsigned int numberOfComponents = 1);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetBufferAsInt64(int64_t * buffer, unsigned int numberOfComponents = 1);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetBufferAsUInt64(uint64_t * buffer, unsigned int numberOfComponents = 1);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetBufferAsFloat(float * buffer, unsigned int numberOfComponents = 1);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetBufferAsDouble(double * buffer, unsigned int numberOfComponents = 1);
 
   Image

--- a/Code/IO/src/sitkImageFileReader.cxx
+++ b/Code/IO/src/sitkImageFileReader.cxx
@@ -118,11 +118,10 @@ ImageFileReader::ToString() const
   return out.str();
 }
 
-ImageFileReader &
+void
 ImageFileReader::SetFileName(const PathType & fn)
 {
   this->m_FileName = fn;
-  return *this;
 }
 
 PathType
@@ -259,11 +258,10 @@ ImageFileReader ::GetMetaData(const std::string & key) const
   return this->m_pfGetMetaData(key);
 }
 
-ImageFileReader &
+void
 ImageFileReader::SetExtractSize(const std::vector<unsigned int> & size)
 {
   this->m_ExtractSize = size;
-  return *this;
 }
 
 const std::vector<unsigned int> &
@@ -272,11 +270,10 @@ ImageFileReader::GetExtractSize() const
   return this->m_ExtractSize;
 }
 
-ImageFileReader &
+void
 ImageFileReader::SetExtractIndex(const std::vector<int> & index)
 {
   this->m_ExtractIndex = index;
-  return *this;
 }
 
 

--- a/Code/IO/src/sitkImageFileWriter.cxx
+++ b/Code/IO/src/sitkImageFileWriter.cxx
@@ -94,11 +94,10 @@ ImageFileWriter::GetRegisteredImageIOs() const
   return ioutils::GetRegisteredImageIOs();
 }
 
-ImageFileWriter::Self &
+void
 ImageFileWriter::SetUseCompression(bool UseCompression)
 {
   this->m_UseCompression = UseCompression;
-  return *this;
 }
 
 bool
@@ -107,11 +106,10 @@ ImageFileWriter::GetUseCompression() const
   return this->m_UseCompression;
 }
 
-ImageFileWriter::Self &
+void
 ImageFileWriter::SetCompressionLevel(int CompressionLevel)
 {
   this->m_CompressionLevel = CompressionLevel;
-  return *this;
 }
 
 int
@@ -120,11 +118,10 @@ ImageFileWriter::GetCompressionLevel() const
   return m_CompressionLevel;
 }
 
-ImageFileWriter::Self &
+void
 ImageFileWriter::SetCompressor(const std::string & Compressor)
 {
   this->m_Compressor = Compressor;
-  return *this;
 }
 
 std::string
@@ -134,11 +131,10 @@ ImageFileWriter::GetCompressor()
 }
 
 
-ImageFileWriter::Self &
+void
 ImageFileWriter::SetKeepOriginalImageUID(bool KeepOriginalImageUID)
 {
   this->m_KeepOriginalImageUID = KeepOriginalImageUID;
-  return *this;
 }
 
 bool
@@ -147,11 +143,10 @@ ImageFileWriter::GetKeepOriginalImageUID() const
   return this->m_KeepOriginalImageUID;
 }
 
-ImageFileWriter &
+void
 ImageFileWriter::SetFileName(const PathType & fn)
 {
   this->m_FileName = fn;
-  return *this;
 }
 
 PathType
@@ -160,7 +155,7 @@ ImageFileWriter::GetFileName() const
   return this->m_FileName;
 }
 
-ImageFileWriter &
+void
 ImageFileWriter::Execute(const Image & image, const PathType & inFileName, bool useCompression, int compressionLevel)
 {
   this->SetFileName(inFileName);
@@ -169,7 +164,7 @@ ImageFileWriter::Execute(const Image & image, const PathType & inFileName, bool 
   return this->Execute(image);
 }
 
-ImageFileWriter &
+void
 ImageFileWriter::Execute(const Image & image)
 {
   PixelIDValueType type = image.GetPixelIDValue();
@@ -179,11 +174,10 @@ ImageFileWriter::Execute(const Image & image)
 }
 
 
-ImageFileWriter::Self &
+void
 ImageFileWriter ::SetImageIO(const std::string & imageio)
 {
   this->m_ImageIOName = imageio;
-  return *this;
 }
 
 
@@ -223,7 +217,7 @@ ImageFileWriter ::GetImageIOBase(const PathType & fileName)
 
 //-----------------------------------------------------------------------------
 template <class InputImageType>
-ImageFileWriter &
+void
 ImageFileWriter::ExecuteInternal(const Image & inImage)
 {
   typename InputImageType::ConstPointer image = dynamic_cast<const InputImageType *>(inImage.GetITKBase());
@@ -249,8 +243,6 @@ ImageFileWriter::ExecuteInternal(const Image & inImage)
   this->PreUpdate(writer.GetPointer());
 
   writer->Update();
-
-  return *this;
 }
 
 } // namespace itk::simple

--- a/Code/IO/src/sitkImageReaderBase.cxx
+++ b/Code/IO/src/sitkImageReaderBase.cxx
@@ -114,11 +114,10 @@ ImageReaderBase ::GetImageIOBase(const PathType & fileName)
   return iobase;
 }
 
-ImageReaderBase::Self &
+void
 ImageReaderBase ::SetOutputPixelType(PixelIDValueEnum pixelID)
 {
   this->m_OutputPixelType = pixelID;
-  return *this;
 }
 
 PixelIDValueEnum
@@ -128,11 +127,10 @@ ImageReaderBase ::GetOutputPixelType() const
 }
 
 
-ImageReaderBase::Self &
+void
 ImageReaderBase ::SetLoadPrivateTags(bool loadPrivateTags)
 {
   this->m_LoadPrivateTags = loadPrivateTags;
-  return *this;
 }
 
 bool
@@ -153,11 +151,10 @@ ImageReaderBase ::LoadPrivateTagsOff()
   this->SetLoadPrivateTags(false);
 }
 
-ImageReaderBase::Self &
+void
 ImageReaderBase ::SetImageIO(const std::string & imageio)
 {
   this->m_ImageIOName = imageio;
-  return *this;
 }
 
 

--- a/Code/IO/src/sitkImageSeriesReader.cxx
+++ b/Code/IO/src/sitkImageSeriesReader.cxx
@@ -82,18 +82,16 @@ ImageSeriesReader::GetSpacingWarningRelThreshold() const
   return m_SpacingWarningRelThreshold;
 }
 
-ImageSeriesReader &
+void
 ImageSeriesReader::SetSpacingWarningRelThreshold(double spacingWarningRelThreshold)
 {
   m_SpacingWarningRelThreshold = spacingWarningRelThreshold;
-  return *this;
 }
 
-ImageSeriesReader &
+void
 ImageSeriesReader::SetForceOrthogonalDirection(bool forceOrthogonalDirection)
 {
   this->m_ForceOrthogonalDirection = forceOrthogonalDirection;
-  return *this;
 }
 
 bool
@@ -102,23 +100,22 @@ ImageSeriesReader::GetForceOrthogonalDirection() const
   return this->m_ForceOrthogonalDirection;
 }
 
-ImageSeriesReader &
+void
 ImageSeriesReader::ForceOrthogonalDirectionOn()
 {
-  return this->SetForceOrthogonalDirection(true);
+  this->SetForceOrthogonalDirection(true);
 }
 
-ImageSeriesReader &
+void
 ImageSeriesReader::ForceOrthogonalDirectionOff()
 {
-  return this->SetForceOrthogonalDirection(false);
+  this->SetForceOrthogonalDirection(false);
 }
 
-ImageSeriesReader &
+void
 ImageSeriesReader::SetReverseOrder(bool reverseOrder)
 {
   this->m_ReverseOrder = reverseOrder;
-  return *this;
 }
 
 bool
@@ -127,16 +124,16 @@ ImageSeriesReader::GetReverseOrder() const
   return this->m_ReverseOrder;
 }
 
-ImageSeriesReader &
+void
 ImageSeriesReader::ReverseOrderOn()
 {
-  return this->SetReverseOrder(true);
+  this->SetReverseOrder(true);
 }
 
-ImageSeriesReader &
+void
 ImageSeriesReader::ReverseOrderOff()
 {
-  return this->SetReverseOrder(false);
+  this->SetReverseOrder(false);
 }
 
 ImageSeriesReader::ImageSeriesReader()
@@ -185,11 +182,10 @@ ImageSeriesReader::ToString() const
   return out.str();
 }
 
-ImageSeriesReader &
+void
 ImageSeriesReader::SetFileNames(const std::vector<PathType> & filenames)
 {
   this->m_FileNames = filenames;
-  return *this;
 }
 
 const std::vector<PathType> &

--- a/Code/IO/src/sitkImageSeriesWriter.cxx
+++ b/Code/IO/src/sitkImageSeriesWriter.cxx
@@ -99,11 +99,10 @@ ImageSeriesWriter::GetRegisteredImageIOs() const
   return ioutils::GetRegisteredImageIOs();
 }
 
-ImageSeriesWriter::Self &
+void
 ImageSeriesWriter ::SetImageIO(const std::string & imageio)
 {
   this->m_ImageIOName = imageio;
-  return *this;
 }
 
 
@@ -135,11 +134,10 @@ ImageSeriesWriter ::GetImageIOBase(const PathType & fileName)
 }
 
 
-ImageSeriesWriter::Self &
+void
 ImageSeriesWriter::SetUseCompression(bool UseCompression)
 {
   this->m_UseCompression = UseCompression;
-  return *this;
 }
 
 bool
@@ -148,11 +146,10 @@ ImageSeriesWriter::GetUseCompression() const
   return this->m_UseCompression;
 }
 
-ImageSeriesWriter::Self &
+void
 ImageSeriesWriter::SetCompressionLevel(int CompressionLevel)
 {
   this->m_CompressionLevel = CompressionLevel;
-  return *this;
 }
 
 int
@@ -161,11 +158,10 @@ ImageSeriesWriter::GetCompressionLevel() const
   return m_CompressionLevel;
 }
 
-ImageSeriesWriter::Self &
+void
 ImageSeriesWriter::SetCompressor(const std::string & Compressor)
 {
   this->m_Compressor = Compressor;
-  return *this;
 }
 
 std::string
@@ -175,11 +171,10 @@ ImageSeriesWriter::GetCompressor()
 }
 
 
-ImageSeriesWriter &
+void
 ImageSeriesWriter::SetFileNames(const std::vector<PathType> & filenames)
 {
   this->m_FileNames = filenames;
-  return *this;
 }
 
 const std::vector<PathType> &
@@ -189,7 +184,7 @@ ImageSeriesWriter::GetFileNames() const
 }
 
 
-ImageSeriesWriter &
+void
 ImageSeriesWriter::Execute(const Image &                 image,
                            const std::vector<PathType> & inFileNames,
                            bool                          useCompression,
@@ -201,7 +196,7 @@ ImageSeriesWriter::Execute(const Image &                 image,
   return this->Execute(image);
 }
 
-ImageSeriesWriter &
+void
 ImageSeriesWriter::Execute(const Image & image)
 {
 
@@ -209,11 +204,11 @@ ImageSeriesWriter::Execute(const Image & image)
   PixelIDValueType type = image.GetPixelIDValue();
   unsigned int     dimension = image.GetDimension();
 
-  return this->m_MemberFactory->GetMemberFunction(type, dimension)(image);
+  this->m_MemberFactory->GetMemberFunction(type, dimension)(image);
 }
 
 template <class TImageType>
-ImageSeriesWriter &
+void
 ImageSeriesWriter::ExecuteInternal(const Image & inImage)
 {
   // Define the input and output image types
@@ -270,8 +265,6 @@ ImageSeriesWriter::ExecuteInternal(const Image & inImage)
   this->PreUpdate(writer.GetPointer());
 
   writer->Update();
-
-  return *this;
 }
 
 } // namespace itk::simple

--- a/Code/IO/src/sitkImportImageFilter.cxx
+++ b/Code/IO/src/sitkImportImageFilter.cxx
@@ -228,11 +228,10 @@ ImportImageFilter::ImportImageFilter()
   this->m_MemberFactory->RegisterMemberFunctions<PixelIDTypeList, 2>();
 }
 
-ImportImageFilter::Self &
+void
 ImportImageFilter::SetSpacing(const std::vector<double> & spacing)
 {
   this->m_Spacing = spacing;
-  return *this;
 }
 
 const std::vector<double> &
@@ -241,11 +240,10 @@ ImportImageFilter::GetSpacing() const
   return this->m_Spacing;
 }
 
-ImportImageFilter::Self &
+void
 ImportImageFilter::SetOrigin(const std::vector<double> & origin)
 {
   this->m_Origin = origin;
-  return *this;
 }
 
 const std::vector<double> &
@@ -254,11 +252,10 @@ ImportImageFilter::GetOrigin() const
   return this->m_Origin;
 }
 
-ImportImageFilter::Self &
+void
 ImportImageFilter::SetSize(const std::vector<unsigned int> & size)
 {
   this->m_Size = size;
-  return *this;
 }
 
 const std::vector<unsigned int> &
@@ -267,11 +264,10 @@ ImportImageFilter::GetSize() const
   return this->m_Size;
 }
 
-ImportImageFilter::Self &
+void
 ImportImageFilter::SetDirection(const std::vector<double> & direction)
 {
   this->m_Direction = direction;
-  return *this;
 }
 
 const std::vector<double> &
@@ -280,7 +276,7 @@ ImportImageFilter::GetDirection() const
   return this->m_Direction;
 }
 
-ImportImageFilter::Self &
+void
 ImportImageFilter::SetBufferAsInt8(int8_t * buffer, unsigned int numberOfComponents)
 {
   this->m_Buffer = buffer;
@@ -293,9 +289,8 @@ ImportImageFilter::SetBufferAsInt8(int8_t * buffer, unsigned int numberOfCompone
   {
     this->m_PixelIDValue = ImageTypeToPixelIDValue<itk::VectorImage<int8_t, UnusedDimension>>::Result;
   }
-  return *this;
 }
-ImportImageFilter::Self &
+void
 ImportImageFilter::SetBufferAsUInt8(uint8_t * buffer, unsigned int numberOfComponents)
 {
   this->m_Buffer = buffer;
@@ -308,9 +303,8 @@ ImportImageFilter::SetBufferAsUInt8(uint8_t * buffer, unsigned int numberOfCompo
   {
     this->m_PixelIDValue = ImageTypeToPixelIDValue<itk::VectorImage<uint8_t, UnusedDimension>>::Result;
   }
-  return *this;
 }
-ImportImageFilter::Self &
+void
 ImportImageFilter::SetBufferAsInt16(int16_t * buffer, unsigned int numberOfComponents)
 {
   this->m_Buffer = buffer;
@@ -323,9 +317,8 @@ ImportImageFilter::SetBufferAsInt16(int16_t * buffer, unsigned int numberOfCompo
   {
     this->m_PixelIDValue = ImageTypeToPixelIDValue<itk::VectorImage<int16_t, UnusedDimension>>::Result;
   }
-  return *this;
 }
-ImportImageFilter::Self &
+void
 ImportImageFilter::SetBufferAsUInt16(uint16_t * buffer, unsigned int numberOfComponents)
 {
   this->m_Buffer = buffer;
@@ -338,9 +331,8 @@ ImportImageFilter::SetBufferAsUInt16(uint16_t * buffer, unsigned int numberOfCom
   {
     this->m_PixelIDValue = ImageTypeToPixelIDValue<itk::VectorImage<uint16_t, UnusedDimension>>::Result;
   }
-  return *this;
 }
-ImportImageFilter::Self &
+void
 ImportImageFilter::SetBufferAsInt32(int32_t * buffer, unsigned int numberOfComponents)
 {
   this->m_Buffer = buffer;
@@ -353,9 +345,8 @@ ImportImageFilter::SetBufferAsInt32(int32_t * buffer, unsigned int numberOfCompo
   {
     this->m_PixelIDValue = ImageTypeToPixelIDValue<itk::VectorImage<int32_t, UnusedDimension>>::Result;
   }
-  return *this;
 }
-ImportImageFilter::Self &
+void
 ImportImageFilter::SetBufferAsUInt32(uint32_t * buffer, unsigned int numberOfComponents)
 {
   this->m_Buffer = buffer;
@@ -368,9 +359,8 @@ ImportImageFilter::SetBufferAsUInt32(uint32_t * buffer, unsigned int numberOfCom
   {
     this->m_PixelIDValue = ImageTypeToPixelIDValue<itk::VectorImage<uint32_t, UnusedDimension>>::Result;
   }
-  return *this;
 }
-ImportImageFilter::Self &
+void
 ImportImageFilter::SetBufferAsInt64(int64_t * buffer, unsigned int numberOfComponents)
 {
   this->m_Buffer = buffer;
@@ -383,9 +373,8 @@ ImportImageFilter::SetBufferAsInt64(int64_t * buffer, unsigned int numberOfCompo
   {
     this->m_PixelIDValue = ImageTypeToPixelIDValue<itk::VectorImage<int64_t, UnusedDimension>>::Result;
   }
-  return *this;
 }
-ImportImageFilter::Self &
+void
 ImportImageFilter::SetBufferAsUInt64(uint64_t * buffer, unsigned int numberOfComponents)
 {
   this->m_Buffer = buffer;
@@ -398,10 +387,9 @@ ImportImageFilter::SetBufferAsUInt64(uint64_t * buffer, unsigned int numberOfCom
   {
     this->m_PixelIDValue = ImageTypeToPixelIDValue<itk::VectorImage<uint64_t, UnusedDimension>>::Result;
   }
-  return *this;
 }
 
-ImportImageFilter::Self &
+void
 ImportImageFilter::SetBufferAsFloat(float * buffer, unsigned int numberOfComponents)
 {
   this->m_Buffer = buffer;
@@ -414,9 +402,8 @@ ImportImageFilter::SetBufferAsFloat(float * buffer, unsigned int numberOfCompone
   {
     this->m_PixelIDValue = ImageTypeToPixelIDValue<itk::VectorImage<float, UnusedDimension>>::Result;
   }
-  return *this;
 }
-ImportImageFilter::Self &
+void
 ImportImageFilter::SetBufferAsDouble(double * buffer, unsigned int numberOfComponents)
 {
   this->m_Buffer = buffer;
@@ -429,7 +416,6 @@ ImportImageFilter::SetBufferAsDouble(double * buffer, unsigned int numberOfCompo
   {
     this->m_PixelIDValue = ImageTypeToPixelIDValue<itk::VectorImage<double, UnusedDimension>>::Result;
   }
-  return *this;
 }
 
 

--- a/Code/Registration/include/sitkImageRegistrationMethod.h
+++ b/Code/Registration/include/sitkImageRegistrationMethod.h
@@ -118,11 +118,10 @@ public:
   {
     return this->m_Interpolator;
   }
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetInterpolator(InterpolatorEnum Interpolator)
   {
     this->m_Interpolator = Interpolator;
-    return *this;
   }
   /** @} */
 
@@ -144,10 +143,10 @@ public:
    */
 #if !defined(SWIG) || defined(JAVASWIG) || defined(CSHARPSWIG)
   // Only wrap this method if the wrapping language is strongly typed
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetInitialTransform(const Transform & transform);
 #endif
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetInitialTransform(Transform & transform, bool inPlace = true);
   Transform
   GetInitialTransform()
@@ -194,11 +193,10 @@ public:
    * \sa itk::ImageRegistrationMethodv4::SetMovingInitialTransform
    * @{
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetMovingInitialTransform(const Transform & transform)
   {
     this->m_MovingInitialTransform = transform;
-    return *this;
   }
   Transform
   GetMovingInitialTransform() const
@@ -217,11 +215,10 @@ public:
    * \sa itk::ImageRegistrationMethodv4::SetFixedInitialTransform
    * @{
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetFixedInitialTransform(const Transform & transform)
   {
     this->m_FixedInitialTransform = transform;
-    return *this;
   }
   Transform
   GetFixedInitialTransform() const
@@ -235,12 +232,12 @@ public:
    *
    * @{
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetVirtualDomain(const std::vector<uint32_t> & virtualSize,
                    const std::vector<double> &   virtualOrigin,
                    const std::vector<double> &   virtualSpacing,
                    const std::vector<double> &   virtualDirection);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetVirtualDomainFromImage(const Image & virtualImage);
   /**@}*/
 
@@ -250,28 +247,28 @@ public:
    *
    * \sa itk::ANTSNeighborhoodCorrelationImageToImageMetricv4
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetMetricAsANTSNeighborhoodCorrelation(unsigned int radius);
 
   /** \brief Use negative normalized cross correlation image metric.
    *
    * \sa itk::CorrelationImageToImageMetricv4
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetMetricAsCorrelation();
 
   /** \brief Use demons image metric.
    *
    * \sa itk::DemonsImageToImageMetricv4
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetMetricAsDemons(double intensityDifferenceThreshold = 0.001);
 
   /** \brief Use mutual information between two images.
    *
    * \sa itk::JointHistogramMutualInformationImageToImageMetricv4
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetMetricAsJointHistogramMutualInformation(unsigned int numberOfHistogramBins = 20,
                                              double       varianceForJointPDFSmoothing = 1.5);
 
@@ -279,7 +276,7 @@ public:
    *
    * \sa itk::MeanSquaresImageToImageMetricv4
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetMetricAsMeanSquares();
 
   /** \brief Use the mutual information between two images to be
@@ -287,7 +284,7 @@ public:
    *
    * \sa itk::MattesMutualInformationImageToImageMetricv4
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetMetricAsMattesMutualInformation(unsigned int numberOfHistogramBins = 50);
 
 
@@ -302,7 +299,7 @@ public:
    *
    * \sa itk::ConjugateGradientLineSearchOptimizerv4Template
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetOptimizerAsConjugateGradientLineSearch(double                   learningRate,
                                             unsigned int             numberOfIterations,
                                             double                   convergenceMinimumValue = 1e-6,
@@ -318,7 +315,7 @@ public:
    *
    * \sa itk::RegularStepGradientDescentOptimizerv4
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetOptimizerAsRegularStepGradientDescent(double                   learningRate,
                                            double                   minStep,
                                            unsigned int             numberOfIterations,
@@ -331,7 +328,7 @@ public:
    *
    * \sa itk::GradientDescentOptimizerv4Template
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetOptimizerAsGradientDescent(double                   learningRate,
                                 unsigned int             numberOfIterations,
                                 double                   convergenceMinimumValue = 1e-6,
@@ -343,7 +340,7 @@ public:
    *
    * \sa itk::GradientDescentLineSearchOptimizerv4Template
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetOptimizerAsGradientDescentLineSearch(double                   learningRate,
                                           unsigned int             numberOfIterations,
                                           double                   convergenceMinimumValue = 1e-6,
@@ -361,7 +358,7 @@ public:
    *
    * \sa itk::LBFGSBOptimizerv4
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetOptimizerAsLBFGSB(double       gradientConvergenceTolerance = 1e-5,
                        unsigned int numberOfIterations = 500,
                        unsigned int maximumNumberOfCorrections = 5,
@@ -383,7 +380,7 @@ public:
    *
    * \sa itk::LBFGS2Optimizerv4
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetOptimizerAsLBFGS2(double       solutionAccuracy = 1e-5,
                        unsigned int numberOfIterations = 0,
                        unsigned int hessianApproximateAccuracy = 6,
@@ -411,7 +408,7 @@ public:
    *
    * \sa itk::ExhaustiveOptimizerv4
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetOptimizerAsExhaustive(const std::vector<unsigned int> & numberOfSteps, double stepLength = 1.0);
 
   /** \brief Set optimizer to Nelder-Mead downhill simplex algorithm.
@@ -423,7 +420,7 @@ public:
    * \sa ImageRegistrationMethod::SetOptimizerScales
    * \sa itk::AmoebaOptimizerv4
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetOptimizerAsAmoeba(double       simplexDelta,
                        unsigned int numberOfIterations,
                        double       parametersConvergenceTolerance = 1e-8,
@@ -441,7 +438,7 @@ public:
    * be used to apply another kind of prior knowledge.
    * @{
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetOptimizerWeights(const std::vector<double> & weights);
   std::vector<double>
   GetOptimizerWeights() const;
@@ -451,7 +448,7 @@ public:
    *
    * \sa itk::PowellOptimizerv4
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetOptimizerAsPowell(unsigned int numberOfIterations = 100,
                        unsigned int maximumLineIterations = 100,
                        double       stepLength = 1,
@@ -466,7 +463,7 @@ public:
    *
    * \sa itk::OnePlusOneEvolutionaryOptimizerv4
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetOptimizerAsOnePlusOneEvolutionary(unsigned int numberOfIterations = 100,
                                        double       epsilon = 1.5e-4,
                                        double       initialRadius = 1.01,
@@ -476,7 +473,7 @@ public:
 
 
   /** \brief Manually set per parameter weighting for the transform parameters. */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetOptimizerScales(const std::vector<double> & scales);
 
   /** \brief Estimate scales from Jacobian norms.
@@ -485,7 +482,7 @@ public:
    *
    * \sa  itk::RegistrationParameterScalesFromJacobian
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetOptimizerScalesFromJacobian(unsigned int centralRegionRadius = 5);
 
   /** \brief Estimate scales from maximum voxel shift in index space
@@ -493,7 +490,7 @@ public:
    *
    * \sa itk::RegistrationParameterScalesFromIndexShift
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetOptimizerScalesFromIndexShift(unsigned int centralRegionRadius = 5, double smallParameterVariation = 0.01);
 
   /** \brief Estimating scales of transform parameters a step sizes,
@@ -502,7 +499,7 @@ public:
    *
    * \sa itk::RegistrationParameterScalesFromPhysicalShift
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetOptimizerScalesFromPhysicalShift(unsigned int centralRegionRadius = 5, double smallParameterVariation = 0.01);
 
 
@@ -515,7 +512,7 @@ public:
    *
    * \sa itk::ImageToImageMetricv4::SetFixedImageMask
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetMetricFixedMask(const Image & binaryMask);
 
   /** \brief Set an image mask in order to restrict the sampled points
@@ -527,7 +524,7 @@ public:
    *
    * \sa itk::ImageToImageMetricv4::SetMovingImageMask
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetMetricMovingMask(const Image & binaryMask);
 
   /** \brief Set percentage of pixels sampled for metric evaluation.
@@ -548,9 +545,9 @@ public:
    * \sa itk::ImageRegistrationMethodv4::SetMetricSamplingPercentage
    * @{
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetMetricSamplingPercentage(double percentage, unsigned int seed = sitkWallClock);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetMetricSamplingPercentagePerLevel(const std::vector<double> & percentage, unsigned int seed = sitkWallClock);
   /** @} */
 
@@ -579,7 +576,7 @@ public:
    *
    * \sa itk::ImageRegistrationMethodv4::SetMetricSamplingStrategy
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetMetricSamplingStrategy(MetricSamplingStrategyType strategy);
 
   /** \brief Enable image gradient computation by a filter.
@@ -591,12 +588,18 @@ public:
    * \sa itk::ImageToImageMetricv4::SetUseFixedImageGradientFilter
    * @{
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetMetricUseFixedImageGradientFilter(bool);
-  SITK_RETURN_SELF_TYPE_HEADER
-  MetricUseFixedImageGradientFilterOn() { return this->SetMetricUseFixedImageGradientFilter(true); }
-  SITK_RETURN_SELF_TYPE_HEADER
-  MetricUseFixedImageGradientFilterOff() { return this->SetMetricUseFixedImageGradientFilter(false); }
+  void
+  MetricUseFixedImageGradientFilterOn()
+  {
+    return this->SetMetricUseFixedImageGradientFilter(true);
+  }
+  void
+  MetricUseFixedImageGradientFilterOff()
+  {
+    return this->SetMetricUseFixedImageGradientFilter(false);
+  }
   /** @} */
 
 
@@ -610,12 +613,18 @@ public:
    * \sa itk::ImageToImageMetricv4::SetUseMovingImageGradientFilter
    * @{
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetMetricUseMovingImageGradientFilter(bool);
-  SITK_RETURN_SELF_TYPE_HEADER
-  MetricUseMovingImageGradientFilterOn() { return this->SetMetricUseMovingImageGradientFilter(true); }
-  SITK_RETURN_SELF_TYPE_HEADER
-  MetricUseMovingImageGradientFilterOff() { return this->SetMetricUseMovingImageGradientFilter(false); }
+  void
+  MetricUseMovingImageGradientFilterOn()
+  {
+    return this->SetMetricUseMovingImageGradientFilter(true);
+  }
+  void
+  MetricUseMovingImageGradientFilterOff()
+  {
+    return this->SetMetricUseMovingImageGradientFilter(false);
+  }
   /** @} */
 
 
@@ -626,7 +635,7 @@ public:
    *
    * \sa  itk::ImageRegistrationMethodv4::SetShrinkFactorsPerLevel
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetShrinkFactorsPerLevel(const std::vector<unsigned int> & shrinkFactors);
 
   /** \brief Set the sigmas of Gaussian used for smoothing.
@@ -637,7 +646,7 @@ public:
    *
    * \sa  itk::ImageRegistrationMethodv4::SetSmoothingSigmasPerLevel
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetSmoothingSigmasPerLevel(const std::vector<double> & smoothingSigmas);
 
   /** \brief Enable the smoothing sigmas for each level in physical
@@ -646,19 +655,17 @@ public:
    * \sa   itk::ImageRegistrationMethodv4::SetSmoothingSigmasAreSpecifiedInPhysicalUnits
    * @{
    */
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SetSmoothingSigmasAreSpecifiedInPhysicalUnits(bool arg);
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SmoothingSigmasAreSpecifiedInPhysicalUnitsOn()
   {
     this->SetSmoothingSigmasAreSpecifiedInPhysicalUnits(true);
-    return *this;
   }
-  SITK_RETURN_SELF_TYPE_HEADER
+  void
   SmoothingSigmasAreSpecifiedInPhysicalUnitsOff()
   {
     this->SetSmoothingSigmasAreSpecifiedInPhysicalUnits(false);
-    return *this;
   }
   /** @} */
 

--- a/Code/Registration/src/sitkImageRegistrationMethod.cxx
+++ b/Code/Registration/src/sitkImageRegistrationMethod.cxx
@@ -125,14 +125,13 @@ ImageRegistrationMethod::ToString() const
 }
 
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetInitialTransform(const Transform & transform)
 {
   this->m_InitialTransform = transform;
   this->m_InitialTransform.MakeUnique();
   this->m_InitialTransformInPlace = true;
   this->m_TransformBSplineScaleFactors = std::vector<unsigned int>();
-  return *this;
 }
 
 
@@ -147,7 +146,7 @@ ImageRegistrationMethod::SetInitialTransformAsBSpline(BSplineTransform &        
 }
 
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetInitialTransform(Transform & transform, bool inPlace)
 {
 
@@ -166,10 +165,9 @@ ImageRegistrationMethod::SetInitialTransform(Transform & transform, bool inPlace
   this->m_InitialTransform = transform;
   this->m_InitialTransformInPlace = inPlace;
   this->m_TransformBSplineScaleFactors = std::vector<unsigned int>();
-  return *this;
 }
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetVirtualDomain(const std::vector<uint32_t> & virtualSize,
                                           const std::vector<double> &   virtualOrigin,
                                           const std::vector<double> &   virtualSpacing,
@@ -196,71 +194,62 @@ ImageRegistrationMethod::SetVirtualDomain(const std::vector<uint32_t> & virtualS
   this->m_VirtualDomainOrigin = virtualOrigin;
   this->m_VirtualDomainSpacing = virtualSpacing;
   this->m_VirtualDomainDirection = virtualDirection;
-  return *this;
 }
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetVirtualDomainFromImage(const Image & virtualImage)
 {
   this->m_VirtualDomainSize = virtualImage.GetSize();
   this->m_VirtualDomainOrigin = virtualImage.GetOrigin();
   this->m_VirtualDomainSpacing = virtualImage.GetSpacing();
   this->m_VirtualDomainDirection = virtualImage.GetDirection();
-
-  return *this;
 }
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetMetricAsANTSNeighborhoodCorrelation(unsigned int radius)
 {
   m_MetricRadius = radius;
   m_MetricType = ANTSNeighborhoodCorrelation;
-  return *this;
 }
 
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetMetricAsCorrelation()
 {
   m_MetricType = Correlation;
-  return *this;
 }
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetMetricAsDemons(double intensityDifferenceThreshold)
 {
   m_MetricType = Demons;
   m_MetricIntensityDifferenceThreshold = intensityDifferenceThreshold;
-  return *this;
 }
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetMetricAsJointHistogramMutualInformation(unsigned int numberOfHistogramBins,
                                                                     double       varianceForJointPDFSmoothing)
 {
   m_MetricType = JointHistogramMutualInformation;
   m_MetricNumberOfHistogramBins = numberOfHistogramBins;
   m_MetricVarianceForJointPDFSmoothing = varianceForJointPDFSmoothing;
-  return *this;
 }
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetMetricAsMeanSquares()
 {
   m_MetricType = MeanSquares;
-  return *this;
 }
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetMetricAsMattesMutualInformation(unsigned int numberOfHistogramBins)
 {
   m_MetricType = MattesMutualInformation;
   m_MetricNumberOfHistogramBins = numberOfHistogramBins;
-  return *this;
 }
 
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetOptimizerAsConjugateGradientLineSearch(double                   learningRate,
                                                                    unsigned int             numberOfIterations,
                                                                    double                   convergenceMinimumValue,
@@ -283,10 +272,9 @@ ImageRegistrationMethod::SetOptimizerAsConjugateGradientLineSearch(double       
   m_OptimizerLineSearchMaximumIterations = lineSearchMaximumIterations;
   m_OptimizerEstimateLearningRate = estimateLearningRate;
   m_OptimizerMaximumStepSizeInPhysicalUnits = maximumStepSizeInPhysicalUnits;
-  return *this;
 }
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetOptimizerAsRegularStepGradientDescent(double                   learningRate,
                                                                   double                   minStep,
                                                                   unsigned int             numberOfIteratons,
@@ -303,10 +291,9 @@ ImageRegistrationMethod::SetOptimizerAsRegularStepGradientDescent(double        
   m_OptimizerGradientMagnitudeTolerance = gradientMagnitudeTolerance;
   m_OptimizerEstimateLearningRate = estimateLearningRate;
   m_OptimizerMaximumStepSizeInPhysicalUnits = maximumStepSizeInPhysicalUnits;
-  return *this;
 }
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetOptimizerAsGradientDescent(double                   learningRate,
                                                        unsigned int             numberOfIteratons,
                                                        double                   convergenceMinimumValue,
@@ -321,10 +308,9 @@ ImageRegistrationMethod::SetOptimizerAsGradientDescent(double                   
   m_OptimizerConvergenceWindowSize = convergenceWindowSize;
   m_OptimizerEstimateLearningRate = estimateLearningRate;
   m_OptimizerMaximumStepSizeInPhysicalUnits = maximumStepSizeInPhysicalUnits;
-  return *this;
 }
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetOptimizerAsGradientDescentLineSearch(double                   learningRate,
                                                                  unsigned int             numberOfIterations,
                                                                  double                   convergenceMinimumValue,
@@ -347,11 +333,10 @@ ImageRegistrationMethod::SetOptimizerAsGradientDescentLineSearch(double         
   m_OptimizerLineSearchMaximumIterations = lineSearchMaximumIterations;
   m_OptimizerEstimateLearningRate = estimateLearningRate;
   m_OptimizerMaximumStepSizeInPhysicalUnits = maximumStepSizeInPhysicalUnits;
-  return *this;
 }
 
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetOptimizerAsLBFGSB(double       gradientConvergenceTolerance,
                                               unsigned int numberOfIterations,
                                               unsigned int maximumNumberOfCorrections,
@@ -370,11 +355,10 @@ ImageRegistrationMethod::SetOptimizerAsLBFGSB(double       gradientConvergenceTo
   m_OptimizerLowerBound = lowerBound;
   m_OptimizerUpperBound = upperBound;
   m_OptimizerTrace = trace;
-  return *this;
 }
 
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetOptimizerAsLBFGS2(double       solutionAccuracy,
                                               unsigned int numberOfIterations,
                                               unsigned int hessianApproximateAccuracy,
@@ -395,15 +379,13 @@ ImageRegistrationMethod::SetOptimizerAsLBFGS2(double       solutionAccuracy,
   m_OptimizerLineSearchMinimumStep = lineSearchMinimumStep;
   m_OptimizerLineSearchMaximumStep = lineSearchMaximumStep;
   m_OptimizerLineSearchAccuracy = lineSearchAccuracy;
-  return *this;
 }
 
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetOptimizerWeights(const std::vector<double> & weights)
 {
   this->m_OptimizerWeights = weights;
-  return *this;
 }
 
 std::vector<double>
@@ -412,16 +394,15 @@ ImageRegistrationMethod::GetOptimizerWeights() const
   return this->m_OptimizerWeights;
 }
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetOptimizerAsExhaustive(const std::vector<unsigned int> & numberOfSteps, double stepLength)
 {
   m_OptimizerType = Exhaustive;
   m_OptimizerStepLength = stepLength;
   m_OptimizerNumberOfSteps = numberOfSteps;
-  return *this;
 }
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetOptimizerAsAmoeba(double       simplexDelta,
                                               unsigned int numberOfIterations,
                                               double       parametersConvergenceTolerance,
@@ -434,10 +415,9 @@ ImageRegistrationMethod::SetOptimizerAsAmoeba(double       simplexDelta,
   m_OptimizerParametersConvergenceTolerance = parametersConvergenceTolerance;
   m_OptimizerFunctionConvergenceTolerance = functionConvergenceTolerance;
   m_OptimizerWithRestarts = withRestarts;
-  return *this;
 }
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetOptimizerAsPowell(unsigned int numberOfIterations,
                                               unsigned int maximumLineIterations,
                                               double       stepLength,
@@ -450,10 +430,9 @@ ImageRegistrationMethod::SetOptimizerAsPowell(unsigned int numberOfIterations,
   m_OptimizerStepLength = stepLength;
   m_OptimizerStepTolerance = stepTolerance;
   m_OptimizerValueTolerance = valueTolerance;
-  return *this;
 }
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetOptimizerAsOnePlusOneEvolutionary(unsigned int numberOfIterations,
                                                               double       epsilon,
                                                               double       initialRadius,
@@ -468,46 +447,40 @@ ImageRegistrationMethod::SetOptimizerAsOnePlusOneEvolutionary(unsigned int numbe
   m_OptimizerGrowthFactor = growthFactor;
   m_OptimizerShrinkFactor = shrinkFactor;
   m_OptimizerSeed = seed;
-
-  return *this;
 }
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetOptimizerScales(const std::vector<double> & scales)
 {
   this->m_OptimizerScalesType = Manual;
   this->m_OptimizerScales = scales;
-  return *this;
 }
 
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetMetricFixedMask(const Image & binaryMask)
 {
   // todo
   m_MetricFixedMaskImage = binaryMask;
   // m_MetricFixedMaskRegion.clear();
-  return *this;
 }
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetMetricMovingMask(const Image & binaryMask)
 {
   m_MetricMovingMaskImage = binaryMask;
   // m_MetricMovingMaskRegion.clear();
-  return *this;
 }
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetOptimizerScalesFromJacobian(unsigned int centralRegionRadius)
 {
   this->m_OptimizerScalesType = Jacobian;
   this->m_OptimizerScalesCentralRegionRadius = centralRegionRadius;
   this->m_OptimizerScales = std::vector<double>();
-  return *this;
 }
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetOptimizerScalesFromIndexShift(unsigned int centralRegionRadius,
                                                           double       smallParameterVariation)
 {
@@ -515,10 +488,9 @@ ImageRegistrationMethod::SetOptimizerScalesFromIndexShift(unsigned int centralRe
   this->m_OptimizerScalesCentralRegionRadius = centralRegionRadius;
   this->m_OptimizerScalesSmallParameterVariation = smallParameterVariation;
   this->m_OptimizerScales = std::vector<double>();
-  return *this;
 }
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetOptimizerScalesFromPhysicalShift(unsigned int centralRegionRadius,
                                                              double       smallParameterVariation)
 {
@@ -526,24 +498,21 @@ ImageRegistrationMethod::SetOptimizerScalesFromPhysicalShift(unsigned int centra
   this->m_OptimizerScalesCentralRegionRadius = centralRegionRadius;
   this->m_OptimizerScalesSmallParameterVariation = smallParameterVariation;
   this->m_OptimizerScales = std::vector<double>();
-  return *this;
 }
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetMetricSamplingPercentage(double percentage, unsigned int seed)
 {
   m_MetricSamplingPercentage.resize(1);
   m_MetricSamplingPercentage[0] = percentage;
   m_MetricSamplingSeed = seed;
-  return *this;
 }
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetMetricSamplingPercentagePerLevel(const std::vector<double> & percentage, unsigned int seed)
 {
   m_MetricSamplingPercentage = percentage;
   m_MetricSamplingSeed = seed;
-  return *this;
 }
 
 
@@ -553,47 +522,41 @@ ImageRegistrationMethod::GetMetricSamplingPercentagePerLevel() const
   return m_MetricSamplingPercentage;
 }
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetMetricSamplingStrategy(MetricSamplingStrategyType strategy)
 {
   m_MetricSamplingStrategy = strategy;
-  return *this;
 }
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetMetricUseFixedImageGradientFilter(bool arg)
 {
   m_MetricUseFixedImageGradientFilter = arg;
-  return *this;
 }
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetMetricUseMovingImageGradientFilter(bool arg)
 {
   m_MetricUseMovingImageGradientFilter = arg;
-  return *this;
 }
 
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetShrinkFactorsPerLevel(const std::vector<unsigned int> & shrinkFactors)
 {
   this->m_ShrinkFactorsPerLevel = shrinkFactors;
-  return *this;
 }
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetSmoothingSigmasPerLevel(const std::vector<double> & smoothingSigmas)
 {
   this->m_SmoothingSigmasPerLevel = smoothingSigmas;
-  return *this;
 }
 
-ImageRegistrationMethod::Self &
+void
 ImageRegistrationMethod::SetSmoothingSigmasAreSpecifiedInPhysicalUnits(bool arg)
 {
   m_SmoothingSigmasAreSpecifiedInPhysicalUnits = arg;
-  return *this;
 }
 
 std::string

--- a/ExpandTemplateGenerator/Components/MemberGetSetDeclarations.h.in
+++ b/ExpandTemplateGenerator/Components/MemberGetSetDeclarations.h.in
@@ -28,7 +28,7 @@ end)$(if (not no_set_method) or (no_set_method == 0) then
       end
       OUT= OUT .. '\
        */\
-      SITK_RETURN_SELF_TYPE_HEADER Set${name} ('
+      void Set${name} ('
       if not type and enum then
         OUT=OUT..' ${name}Type'
       elseif dim_vec and (dim_vec == 1) then
@@ -41,22 +41,22 @@ end)$(if (not no_set_method) or (no_set_method == 0) then
       OUT=OUT..' ${name} ) '
       if (dim_vec and (dim_vec == 1)) or
          (point_vec and (point_vec == 1)) then
-        OUT = OUT..'{ this->m_${name} = std::move(${name}); return *this; }'
+        OUT = OUT..'{ this->m_${name} = std::move(${name});  }'
       else
-        OUT=OUT..'{ this->m_${name} = ${name}; return *this; }'
+        OUT=OUT..'{ this->m_${name} = ${name};  }'
       end
   if dim_vec and ( set_as_scalar == 1 ) then
     OUT = OUT .. '\
 \
       /** Set the values of the ${name} vector all to value */\
-      SITK_RETURN_SELF_TYPE_HEADER Set${name}( ${type} value ) { this->m_${name} = std::vector<${type}>(3, value); return *this; }'
+      void Set${name}( ${type} value ) { this->m_${name} = std::vector<${type}>(3, value);  }'
   end
   if type == "bool" and ( not dim_vec or not dim_vec == 1 ) then
       OUT = OUT .. '\
 \
       /** Set the value of ${name} to true or false respectfully. */\
-      SITK_RETURN_SELF_TYPE_HEADER ${name}On() { return this->Set${name}(true); }\
-      SITK_RETURN_SELF_TYPE_HEADER ${name}Off() { return this->Set${name}(false); }'
+      void ${name}On() { return this->Set${name}(true); }\
+      void ${name}Off() { return this->Set${name}(false); }'
   end
 end)
 $(if (not no_get_method) or (no_get_method == 0) then
@@ -87,9 +87,9 @@ end)$(if point_vec and (point_vec == 1) then
       OUT=[[
 
       /** \brief Add ${name} point */
-      SITK_RETURN_SELF_TYPE_HEADER Add${name:gsub("List", ""):gsub("s(%d?)$","%1")}( std::vector< ${type} > point ) { this->m_${name}.push_back(std::move(point)); return *this;}
+      void Add${name:gsub("List", ""):gsub("s(%d?)$","%1")}( std::vector< ${type} > point ) { this->m_${name}.push_back(std::move(point)); }
       /** \brief Remove all ${name} points */
-      SITK_RETURN_SELF_TYPE_HEADER Clear${name:gsub("List", "s")}( ) { this->m_${name}.clear(); return *this;}
+      void Clear${name:gsub("List", "s")}( ) { this->m_${name}.clear(); }
 ]]
 end))$(when measurements $(foreach measurements
 

--- a/Testing/Unit/TestBase/sitkImageCompare.cxx
+++ b/Testing/Unit/TestBase/sitkImageCompare.cxx
@@ -20,6 +20,7 @@
 #include <itksys/SystemTools.hxx>
 
 #include "sitkImageCompare.h"
+#include "sitkImageFileReader.h"
 
 namespace sitk = itk::simple;
 
@@ -159,8 +160,10 @@ ImageCompare::testImages(const itk::simple::Image & testImage,
     std::cout << "<DartMeasurement name=\"Tolerance\" type=\"numeric/float\">" << mTolerance << "</DartMeasurement>"
               << std::endl;
 
-    std::string volumeName = OutputDir + "/" + shortFilename + ".nrrd";
-    sitk::ImageFileWriter().SetFileName(volumeName).Execute(testImage);
+    std::string           volumeName = OutputDir + "/" + shortFilename + ".nrrd";
+    sitk::ImageFileWriter writer;
+    writer.SetFileName(volumeName);
+    writer.Execute(testImage);
 
     // Save pngs
     std::string ExpectedImageFilename = OutputDir + "/" + shortFilename + "_Expected.png";
@@ -260,7 +263,7 @@ ImageCompare::compare(const sitk::Image & image, std::string inTestCase, std::st
     itksys::SystemTools::MakeDirectory(newBaselineDir.c_str());
     std::cout << "Making directory " << newBaselineDir << std::endl;
     std::string newBaseline = newBaselineDir + name + extension;
-    sitk::ImageFileWriter().SetFileName(newBaseline).Execute(centerSlice);
+    sitk::WriteImage(centerSlice, newBaseline);
     mMessage = "Baseline does not exist, wrote " + newBaseline + "\ncp " + newBaseline + " " + baselineFileName;
     return false;
   }
@@ -301,7 +304,7 @@ ImageCompare::compare(const sitk::Image & image, std::string inTestCase, std::st
 
     try
     {
-      baseline = sitk::ImageFileReader().SetFileName(*iterName).Execute();
+      baseline = sitk::ReadImage(*iterName);
     }
     catch (std::exception & e)
     {
@@ -321,7 +324,7 @@ ImageCompare::compare(const sitk::Image & image, std::string inTestCase, std::st
 
   if (bestRMS > fabs(mTolerance))
   {
-    sitk::Image baseline = sitk::ImageFileReader().SetFileName(bestBaselineName).Execute();
+    sitk::Image baseline = sitk::ReadImage(baselineFileName);
     testImages(centerSlice, baseline, true, bestBaselineName);
     return false;
   }

--- a/Testing/Unit/sitkBasicFiltersTests.cxx
+++ b/Testing/Unit/sitkBasicFiltersTests.cxx
@@ -484,7 +484,8 @@ TEST(BasicFilters, Cast_Float32)
     try
     {
       itk::simple::CastImageFilter caster;
-      itk::simple::Image           test = caster.SetOutputPixelType(pixelID).Execute(image);
+      caster.SetOutputPixelType(pixelID);
+      itk::simple::Image test = caster.Execute(image);
 
       hasher.SetHashFunction(itk::simple::HashImageFilter::MD5);
       EXPECT_EQ(hash, hasher.Execute(test)) << "Cast to " << itk::simple::GetPixelIDValueAsString(pixelID);
@@ -568,7 +569,8 @@ TEST(BasicFilters, Cast_UInt8)
     try
     {
       itk::simple::CastImageFilter caster;
-      itk::simple::Image           test = caster.SetOutputPixelType(pixelID).Execute(image);
+      caster.SetOutputPixelType(pixelID);
+      itk::simple::Image test = caster.Execute(image);
 
       hasher.SetHashFunction(itk::simple::HashImageFilter::MD5);
       EXPECT_EQ(hash, hasher.Execute(test)) << "Cast to " << itk::simple::GetPixelIDValueAsString(pixelID);
@@ -601,10 +603,10 @@ TEST(BasicFilters, HashImageFilter)
   EXPECT_TRUE(out.find("HashFunction: SHA1") != std::string::npos);
   EXPECT_TRUE(out.find("Debug:") != std::string::npos);
   EXPECT_TRUE(out.find("NumberOfThreads:") != std::string::npos);
-  EXPECT_EQ(itk::simple::HashImageFilter::SHA1,
-            hasher.SetHashFunction(itk::simple::HashImageFilter::SHA1).GetHashFunction());
-  EXPECT_EQ(itk::simple::HashImageFilter::MD5,
-            hasher.SetHashFunction(itk::simple::HashImageFilter::MD5).GetHashFunction());
+  hasher.SetHashFunction(itk::simple::HashImageFilter::SHA1);
+  EXPECT_EQ(itk::simple::HashImageFilter::SHA1, hasher.GetHashFunction());
+  hasher.SetHashFunction(itk::simple::HashImageFilter::MD5);
+  EXPECT_EQ(itk::simple::HashImageFilter::MD5, hasher.GetHashFunction());
 }
 
 
@@ -616,8 +618,8 @@ TEST(BasicFilters, BSplineTransformInitializer)
 
   EXPECT_EQ("BSplineTransformInitializerFilter", filter.GetName());
   EXPECT_EQ(std::vector<uint32_t>(3, 1u), filter.GetTransformDomainMeshSize());
-  EXPECT_EQ(std::vector<uint32_t>(3, 10u),
-            filter.SetTransformDomainMeshSize(std::vector<uint32_t>(3, 10u)).GetTransformDomainMeshSize());
+  filter.SetTransformDomainMeshSize(std::vector<uint32_t>(3, 10u));
+  EXPECT_EQ(std::vector<uint32_t>(3, 10u), filter.GetTransformDomainMeshSize());
 
   const double cs = 0.5 * itk::Math::sqrt2; // cos(pi/4) = sin(pi/4)
   sitk::Image  img(100, 100, sitk::sitkUInt32);
@@ -734,8 +736,10 @@ TEST(BasicFilters, CenteredVersorTransformInitializer)
 
   EXPECT_EQ("CenteredVersorTransformInitializerFilter", filter.GetName());
   EXPECT_EQ(filter.GetComputeRotation(), false);
-  EXPECT_EQ(filter.ComputeRotationOn().GetComputeRotation(), true);
-  EXPECT_EQ(filter.ComputeRotationOff().GetComputeRotation(), false);
+  filter.ComputeRotationOn();
+  EXPECT_EQ(filter.GetComputeRotation(), true);
+  filter.ComputeRotationOff();
+  EXPECT_EQ(filter.GetComputeRotation(), false);
 
   // generate a few basic test images from gaussian blobs
 

--- a/Testing/Unit/sitkImage4DTests.cxx
+++ b/Testing/Unit/sitkImage4DTests.cxx
@@ -189,7 +189,9 @@ TEST_F(Image4D, ImageDataType)
 TEST_F(Image4D, Constructors)
 {
   itk::simple::HashImageFilter hasher;
-  int                          result;
+  hasher.SetHashFunction(itk::simple::HashImageFilter::SHA1);
+
+  int result;
 
   {
     itk::simple::Image image;
@@ -205,9 +207,7 @@ TEST_F(Image4D, Constructors)
   s4d6[2] = 66;
   s4d6[3] = 67;
   itk::simple::Image image(s4d6, itk::simple::sitkUInt8);
-  EXPECT_EQ("d2ed3a9bceae811402dcb5223fb16990cd89537d",
-            hasher.SetHashFunction(itk::simple::HashImageFilter::SHA1).Execute(image))
-    << " SHA1 hash value sitkUInt8";
+  EXPECT_EQ("d2ed3a9bceae811402dcb5223fb16990cd89537d", hasher.Execute(image)) << " SHA1 hash value sitkUInt8";
   result = typelist2::index_of<InstantiatedPixelIDTypeList, itk::simple::BasicPixelID<unsigned char>>::value;
   EXPECT_EQ(image.GetPixelIDValue(), result);
   EXPECT_EQ(image.GetPixelIDTypeAsString(), "8-bit unsigned integer");
@@ -219,9 +219,7 @@ TEST_F(Image4D, Constructors)
   EXPECT_EQ(image.GetDirection(), directionI4D);
 
   image = itk::simple::Image(s4d6, itk::simple::sitkInt16);
-  EXPECT_EQ("0e444ec26123b59643b58f84dd8f685a991dfb4b",
-            hasher.SetHashFunction(itk::simple::HashImageFilter::SHA1).Execute(image))
-    << " SHA1 hash value sitkUInt16";
+  EXPECT_EQ("0e444ec26123b59643b58f84dd8f685a991dfb4b", hasher.Execute(image)) << " SHA1 hash value sitkUInt16";
   result = typelist2::index_of<InstantiatedPixelIDTypeList, itk::simple::BasicPixelID<short>>::value;
   EXPECT_EQ(image.GetPixelIDValue(), result);
   EXPECT_EQ(image.GetPixelIDTypeAsString(), "16-bit signed integer");

--- a/Testing/Unit/sitkImageFilterTestTemplate.cxx.in
+++ b/Testing/Unit/sitkImageFilterTestTemplate.cxx.in
@@ -161,7 +161,8 @@ end)
 
   for ( unsigned int i = 0; i < inputFileNames.size(); ++i )
     {
-    ASSERT_NO_THROW ( inputs.push_back( reader.SetFileName ( dataFinder.GetFile ( inputFileNames[i]  ) ).Execute() ) ) << "Failed to load " << inputFileNames[i] << " from " << dataFinder.GetFile ( inputFileNames[i]  );
+    reader.SetFileName ( dataFinder.GetFile ( inputFileNames[i]  ) );
+    ASSERT_NO_THROW ( inputs.push_back( reader.Execute() ) ) << "Failed to load " << inputFileNames[i] << " from " << dataFinder.GetFile ( inputFileNames[i]  );
 
 $(if inputA_cast then
       OUT=[[

--- a/Testing/Unit/sitkImageIOTests.cxx
+++ b/Testing/Unit/sitkImageIOTests.cxx
@@ -289,7 +289,8 @@ TEST(IO, ReadWrite)
   reader.AddCommand(sitk::sitkUserEvent, userCmd);
 
 
-  sitk::Image image = reader.SetFileName(dataFinder.GetFile("Input/RA-Short.nrrd")).Execute();
+  reader.SetFileName(dataFinder.GetFile("Input/RA-Short.nrrd"));
+  sitk::Image image = reader.Execute();
   ASSERT_NE(image.GetITKBase(), nullptr);
   hasher.SetHashFunction(sitk::HashImageFilter::MD5);
   EXPECT_EQ(md5, hasher.Execute(image));
@@ -307,10 +308,12 @@ TEST(IO, ReadWrite)
 
   // Write it out
   std::string filename = dataFinder.GetOutputFile("IO.ReadWrite.nrrd");
-  writer.SetFileName(filename).Execute(image);
+  writer.SetFileName(filename);
+  writer.Execute(image);
   ASSERT_TRUE(dataFinder.FileExists(filename));
 
-  image = reader.SetFileName(filename).Execute();
+  reader.SetFileName(filename);
+  image = reader.Execute();
   ASSERT_NE(image.GetITKBase(), nullptr);
 
   // Make sure we wrote and read the file correctly
@@ -324,7 +327,8 @@ TEST(IO, ReadWrite)
   sitk::WriteImage(image, filename);
   ASSERT_TRUE(dataFinder.FileExists(filename));
 
-  image = reader.SetFileName(filename).Execute();
+  reader.SetFileName(filename);
+  image = reader.Execute();
   ASSERT_NE(image.GetITKBase(), nullptr);
 
   // Make sure we wrote and read the file correctly
@@ -338,9 +342,8 @@ TEST(IO, ReadWrite)
 TEST(IO, 2DFormats)
 {
   itk::simple::HashImageFilter hasher;
-  itk::simple::ImageFileReader reader;
 
-  itk::simple::Image image = reader.SetFileName(dataFinder.GetFile("Input/RA-Slice-Short.png")).Execute();
+  itk::simple::Image image = itk::simple::ReadImage(dataFinder.GetFile("Input/RA-Slice-Short.png"));
   ASSERT_NE(image.GetITKBase(), nullptr);
   hasher.SetHashFunction(itk::simple::HashImageFilter::SHA1);
   EXPECT_EQ("bf0f7bae60b0322222e224941c31f37a981901aa", hasher.Execute(image));
@@ -388,7 +391,8 @@ TEST(IO, SeriesReader)
   CountCommand userCmd(reader);
   reader.AddCommand(sitk::sitkUserEvent, userCmd);
 
-  sitk::Image image = reader.SetFileNames(fileNames).Execute();
+  reader.SetFileNames(fileNames);
+  sitk::Image image = reader.Execute();
   EXPECT_EQ("b13c0a17109e3a5058e8f225c9ef2dbcf79ac240", sitk::Hash(image));
   EXPECT_EQ(3u, reader.GetFileNames().size());
   EXPECT_EQ(3u, image.GetDimension());

--- a/Testing/Unit/sitkImageTests.cxx
+++ b/Testing/Unit/sitkImageTests.cxx
@@ -230,6 +230,8 @@ TEST_F(Image, Constructors)
   sitk::HashImageFilter hasher;
   int                   result;
 
+  hasher.SetHashFunction(sitk::HashImageFilter::SHA1);
+
   {
     sitk::Image image;
     EXPECT_EQ(0u, image.GetWidth());
@@ -239,9 +241,7 @@ TEST_F(Image, Constructors)
   }
 
   sitk::Image image(64, 65, 66, sitk::sitkUInt8);
-  EXPECT_EQ("08183e1b0c50fd2cf6f070b58e218443fb7d5317",
-            hasher.SetHashFunction(sitk::HashImageFilter::SHA1).Execute(image))
-    << " SHA1 hash value sitkUInt8";
+  EXPECT_EQ("08183e1b0c50fd2cf6f070b58e218443fb7d5317", hasher.Execute(image)) << " SHA1 hash value sitkUInt8";
   result = typelist2::index_of<InstantiatedPixelIDTypeList, sitk::BasicPixelID<unsigned char>>::value;
   EXPECT_EQ(image.GetPixelIDValue(), result);
   EXPECT_EQ(image.GetPixelIDTypeAsString(), "8-bit unsigned integer");
@@ -254,9 +254,7 @@ TEST_F(Image, Constructors)
   EXPECT_EQ(image.GetDirection(), directionI3D);
 
   image = sitk::Image(64, 65, 66, sitk::sitkInt16);
-  EXPECT_EQ("645b71695b94923c868e16b943d8acf8f6788617",
-            hasher.SetHashFunction(sitk::HashImageFilter::SHA1).Execute(image))
-    << " SHA1 hash value sitkUInt16";
+  EXPECT_EQ("645b71695b94923c868e16b943d8acf8f6788617", hasher.Execute(image)) << " SHA1 hash value sitkUInt16";
   result = typelist2::index_of<InstantiatedPixelIDTypeList, sitk::BasicPixelID<short>>::value;
   EXPECT_EQ(image.GetPixelIDValue(), result);
   EXPECT_EQ(image.GetPixelIDTypeAsString(), "16-bit signed integer");
@@ -269,9 +267,7 @@ TEST_F(Image, Constructors)
   EXPECT_EQ(image.GetDirection(), directionI3D);
 
   image = sitk::Image(64, 65, sitk::sitkUInt16);
-  EXPECT_EQ("e3c464cc1b73df3f48bacf238a80f88b5ab0d3e6",
-            hasher.SetHashFunction(sitk::HashImageFilter::SHA1).Execute(image))
-    << " SHA1 hash value sitkUInt16";
+  EXPECT_EQ("e3c464cc1b73df3f48bacf238a80f88b5ab0d3e6", hasher.Execute(image)) << " SHA1 hash value sitkUInt16";
   result = typelist2::index_of<InstantiatedPixelIDTypeList, sitk::BasicPixelID<unsigned short>>::value;
   EXPECT_EQ(image.GetPixelIDValue(), result);
   EXPECT_EQ(image.GetPixelIDTypeAsString(), "16-bit unsigned integer");
@@ -355,17 +351,15 @@ TEST_F(Image, Constructors)
 TEST_F(Image, Hash)
 {
   sitk::HashImageFilter hasher;
-  EXPECT_EQ("a998ea8b4999b4db9cbad033a52fe6d654211ff9",
-            hasher.SetHashFunction(sitk::HashImageFilter::SHA1).Execute(*shortImage))
-    << " SHA1 hash value";
-  EXPECT_EQ("8cdd56962c5b3aabbfac56cd4dce1c7e", hasher.SetHashFunction(sitk::HashImageFilter::MD5).Execute(*shortImage))
-    << " MD5 hash value";
+  hasher.SetHashFunction(sitk::HashImageFilter::SHA1);
+  EXPECT_EQ("a998ea8b4999b4db9cbad033a52fe6d654211ff9", hasher.Execute(*shortImage)) << " SHA1 hash value";
+  hasher.SetHashFunction(sitk::HashImageFilter::MD5);
+  EXPECT_EQ("8cdd56962c5b3aabbfac56cd4dce1c7e", hasher.Execute(*shortImage)) << " MD5 hash value";
 
-  EXPECT_EQ("3b6bfcb1922bf8b29b171062ad722c82f8aa3f50",
-            hasher.SetHashFunction(sitk::HashImageFilter::SHA1).Execute(*floatImage))
-    << " SHA1 hash value";
-  EXPECT_EQ("e5eba8af943d7911220c9f2fb9b5b9c8", hasher.SetHashFunction(sitk::HashImageFilter::MD5).Execute(*floatImage))
-    << " MD5 hash value";
+  hasher.SetHashFunction(sitk::HashImageFilter::SHA1);
+  EXPECT_EQ("3b6bfcb1922bf8b29b171062ad722c82f8aa3f50", hasher.Execute(*floatImage)) << " SHA1 hash value";
+  hasher.SetHashFunction(sitk::HashImageFilter::MD5);
+  EXPECT_EQ("e5eba8af943d7911220c9f2fb9b5b9c8", hasher.Execute(*floatImage)) << " MD5 hash value";
 }
 
 TEST_F(Image, Transforms)

--- a/Testing/Unit/sitkLabelStatisticsTest.cxx
+++ b/Testing/Unit/sitkLabelStatisticsTest.cxx
@@ -24,11 +24,9 @@
 
 TEST(LabelStatistics, Simple)
 {
-  itk::simple::ImageFileReader reader;
-
   // By using the same image, the label min/max values should equal the label itself.
-  itk::simple::Image intensityImage = reader.SetFileName(dataFinder.GetFile("Input/2th_cthead1.png")).Execute();
-  itk::simple::Image labelImage = reader.SetFileName(dataFinder.GetFile("Input/2th_cthead1.png")).Execute();
+  itk::simple::Image intensityImage = itk::simple::ReadImage(dataFinder.GetFile("Input/2th_cthead1.png"));
+  itk::simple::Image labelImage = itk::simple::ReadImage(dataFinder.GetFile("Input/2th_cthead1.png"));
 
   itk::simple::LabelStatisticsImageFilter lsFilter;
 

--- a/Testing/Unit/sitkTransformGeometryImageFilterTest.cxx
+++ b/Testing/Unit/sitkTransformGeometryImageFilterTest.cxx
@@ -82,7 +82,7 @@ TEST(BasicFilters, TransformGeometryImageFilter_defaults)
   inputFileNames.push_back("Input/RA-Float.nrrd");
   inputFileNames.push_back("Input/xforms/affine_i_3.txt");
 
-  itk::simple::Image     input1 = reader.SetFileName(dataFinder.GetFile(inputFileNames[0])).Execute();
+  itk::simple::Image     input1 = itk::simple::ReadImage(dataFinder.GetFile(inputFileNames[0]));
   itk::simple::Transform input2 = itk::simple::ReadTransform(dataFinder.GetFile(inputFileNames[1]));
 
   inputSHA1hash = itk::simple::Hash(input1);

--- a/Testing/Unit/sitkTransformTests.cxx
+++ b/Testing/Unit/sitkTransformTests.cxx
@@ -625,9 +625,10 @@ TEST(TransformTest, AffineTransform)
   EXPECT_EQ(tx->GetFixedParameters().size(), 2u);
   EXPECT_EQ(tx->GetNumberOfFixedParameters(), 2u);
   EXPECT_EQ(tx->GetMatrix(), v4(1.0, 0.0, 0.0, 1.0));
-
-  EXPECT_EQ(tx->SetTranslation(trans2d).GetTranslation(), trans2d);
-  EXPECT_EQ(tx->SetCenter(center2d).GetCenter(), center2d);
+  tx->SetTranslation(trans2d);
+  EXPECT_EQ(tx->GetTranslation(), trans2d);
+  tx->SetCenter(center2d);
+  EXPECT_EQ(tx->GetCenter(), center2d);
 
   tx = std::make_unique<sitk::AffineTransform>(2);
   tx->Scale(v2(1, 2));
@@ -668,8 +669,10 @@ TEST(TransformTest, AffineTransform)
   EXPECT_EQ(tx->GetFixedParameters().size(), 3u);
   EXPECT_EQ(tx->GetNumberOfFixedParameters(), 3u);
 
-  EXPECT_EQ(tx->SetTranslation(trans3d).GetTranslation(), trans3d);
-  EXPECT_EQ(tx->SetCenter(center3d).GetCenter(), center3d);
+  tx->SetTranslation(trans3d);
+  EXPECT_EQ(tx->GetTranslation(), trans3d);
+  tx->SetCenter(center3d);
+  EXPECT_EQ(tx->GetCenter(), center3d);
 
   sitk::AffineTransform tx00(v9(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0), v3(10.0, 11.0, 12.0));
   EXPECT_EQ(tx00.GetMatrix(), v9(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0));
@@ -716,19 +719,22 @@ TEST(TransformTest, AffineTransform_3DPoints)
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(1.0, 1.0, 1.0)), v3(2.0, 3.0, 4.0), 1e-15);
 
   // apply transform after and inverse before
-  tx.Scale(v3(2.0, 2.0, 2.0), false).Scale(.5, true);
+  tx.Scale(v3(2.0, 2.0, 2.0), false);
+  tx.Scale(.5, true);
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(0.0, 0.0, 0.0)), v3(2.0, 4.0, 6.0), 1e-15);
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(1.0, 1.0, 1.0)), v3(3.0, 5.0, 7.0), 1e-15);
 
   tx = sitk::AffineTransform(3);
   tx.Translate(v3(1.0, 2.0, 3.0));
-  tx.Shear(0, 1, 1.0, false).Shear(0, 1, -1.0, true);
+  tx.Shear(0, 1, 1.0, false);
+  tx.Shear(0, 1, -1.0, true);
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(0.0, 0.0, 0.0)), v3(3.0, 2.0, 3.0), 1e-15);
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(1.0, 1.0, 1.0)), v3(4.0, 3.0, 4.0), 1e-15);
 
   tx = sitk::AffineTransform(3);
   tx.Translate(v3(1.0, 2.0, 3.0));
-  tx.Rotate(0, 1, 1.0, false).Rotate(0, 1, -1.0);
+  tx.Rotate(0, 1, 1.0, false);
+  tx.Rotate(0, 1, -1.0);
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(0.0, 0.0, 0.0)), v3(1.0, 2.0, 3.0), 1e-15);
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(1.0, 0.0, 1.0)), v3(2.0, 2.0, 4.0), 1e-15);
 
@@ -784,9 +790,10 @@ TEST(TransformTest, BSplineTransform)
   EXPECT_EQ(tx->GetNumberOfFixedParameters(), 18u);
 
   tx = std::make_unique<sitk::BSplineTransform>(2);
-  EXPECT_EQ(tx->SetTransformDomainDirection(v4(-1.0, 0.0, 0.0, -1.0)).GetTransformDomainDirection(),
-            v4(-1.0, 0.0, 0.0, -1.0));
-  EXPECT_VECTOR_DOUBLE_NEAR(tx->SetTransformDomainOrigin(v2(1.1, 1.2)).GetTransformDomainOrigin(), v2(1.1, 1.2), 1e-15);
+  tx->SetTransformDomainDirection(v4(-1.0, 0.0, 0.0, -1.0));
+  EXPECT_EQ(tx->GetTransformDomainDirection(), v4(-1.0, 0.0, 0.0, -1.0));
+  tx->SetTransformDomainOrigin(v2(1.1, 1.2));
+  EXPECT_VECTOR_DOUBLE_NEAR(tx->GetTransformDomainOrigin(), v2(1.1, 1.2), 1e-15);
 
   // copy constructor
   sitk::BSplineTransform tx1(*(tx.get()));
@@ -835,13 +842,14 @@ TEST(TransformTest, BSplineTransform)
   tx = std::make_unique<sitk::BSplineTransform>(2);
 
   // test member setters/getters
-  EXPECT_EQ(tx->SetTransformDomainDirection(v4(0.0, 1.0, 1.0, 0.0)).GetTransformDomainDirection(),
-            v4(0.0, 1.0, 1.0, 0.0));
-  EXPECT_EQ(tx->SetTransformDomainMeshSize(std::vector<unsigned int>(2, 4u)).GetTransformDomainMeshSize(),
-            std::vector<unsigned int>(2, 4u));
-  EXPECT_EQ(tx->SetTransformDomainOrigin(v2(2.0, 2.0)).GetTransformDomainOrigin(), v2(2.0, 2.0));
-  EXPECT_EQ(tx->SetTransformDomainPhysicalDimensions(v2(4.0, 4.0)).GetTransformDomainPhysicalDimensions(),
-            v2(4.0, 4.0));
+  tx->SetTransformDomainDirection(v4(0.0, 1.0, 1.0, 0.0));
+  EXPECT_EQ(tx->GetTransformDomainDirection(), v4(0.0, 1.0, 1.0, 0.0));
+  tx->SetTransformDomainMeshSize(std::vector<unsigned int>(2, 4u));
+  EXPECT_EQ(tx->GetTransformDomainMeshSize(), std::vector<unsigned int>(2, 4u));
+  tx->SetTransformDomainOrigin(v2(2.0, 2.0));
+  EXPECT_EQ(tx->GetTransformDomainOrigin(), v2(2.0, 2.0));
+  tx->SetTransformDomainPhysicalDimensions(v2(4.0, 4.0));
+  EXPECT_EQ(tx->GetTransformDomainPhysicalDimensions(), v2(4.0, 4.0));
 
   std::vector<sitk::Image> coefficientImages = tx->GetCoefficientImages();
   ASSERT_EQ(2u, coefficientImages.size());
@@ -1247,10 +1255,12 @@ TEST(TransformTest, Euler2DTransform)
 
   // test member setters/getters
   EXPECT_EQ(tx->GetCenter(), zeros);
-  EXPECT_EQ(tx->SetCenter(center).GetCenter(), center);
+  tx->SetCenter(center);
+  EXPECT_EQ(tx->GetCenter(), center);
 
   EXPECT_EQ(tx->GetAngle(), 0.0);
-  EXPECT_EQ(tx->SetAngle(1.0).GetAngle(), 1.0);
+  tx->SetAngle(1.0);
+  EXPECT_EQ(tx->GetAngle(), 1.0);
 
   sitk::Euler2DTransform etx;
   etx.SetCenter(v2(1.0, 1.0));
@@ -1457,10 +1467,14 @@ TEST(TransformTest, Similarity2DTransform)
   EXPECT_THROW(sitk::Similarity2DTransform(1.0, -1.0, std::vector<double>(1, 0.0), center), sitk::GenericException);
 
 
-  EXPECT_EQ(tx->SetScale(2.0).GetScale(), 2.0);
-  EXPECT_EQ(tx->SetTranslation(trans).GetTranslation(), trans);
-  EXPECT_EQ(tx->SetCenter(center).GetCenter(), center);
-  EXPECT_EQ(tx->SetAngle(1.0).GetAngle(), 1.0);
+  tx->SetScale(2.0);
+  EXPECT_EQ(tx->GetScale(), 2.0);
+  tx->SetTranslation(trans);
+  EXPECT_EQ(tx->GetTranslation(), trans);
+  tx->SetCenter(center);
+  EXPECT_EQ(tx->GetCenter(), center);
+  tx->SetAngle(1.0);
+  EXPECT_EQ(tx->GetAngle(), 1.0);
 
 
   // copy constructor
@@ -1564,8 +1578,10 @@ TEST(TransformTest, ScaleTransform)
   EXPECT_EQ(tx->GetCenter(), v2(0.0, 0.0));
   EXPECT_EQ(tx->GetMatrix(), v4(1.0, 0.0, 0.0, 1.0));
 
-  EXPECT_EQ(tx->SetScale(v2(2.0, 3.0)).GetScale(), v2(2.0, 3.0));
-  EXPECT_EQ(tx->SetCenter(v2(1.2, 1.2)).GetCenter(), v2(1.2, 1.2));
+  tx->SetScale(v2(2.0, 3.0));
+  EXPECT_EQ(tx->GetScale(), v2(2.0, 3.0));
+  tx->SetCenter(v2(1.2, 1.2));
+  EXPECT_EQ(tx->GetCenter(), v2(1.2, 1.2));
 
   // copy constructor
   sitk::ScaleTransform tx1(*(tx.get()));
@@ -1665,10 +1681,13 @@ TEST(TransformTest, ScaleSkewVersor3DTransform)
   EXPECT_EQ(tx->GetVersor(), v4(0.0, 0.0, 0.0, 1.0));
   EXPECT_EQ(tx->GetMatrix(), v9(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0));
 
-  EXPECT_EQ(tx->SetScale(v3(1.0, 2.0, 3.0)).GetScale(), v3(1.0, 2.0, 3.0));
-  EXPECT_EQ(tx->SetTranslation(trans).GetTranslation(), trans);
+  tx->SetScale(v3(1.0, 2.0, 3.0));
+  EXPECT_EQ(tx->GetScale(), v3(1.0, 2.0, 3.0));
+  tx->SetTranslation(trans);
+  EXPECT_EQ(tx->GetTranslation(), trans);
 
-  EXPECT_EQ(tx->SetCenter(center).GetCenter(), center);
+  tx->SetCenter(center);
+  EXPECT_EQ(tx->GetCenter(), center);
 
   sitk::ScaleSkewVersor3DTransform tx0(v3(0.4, 0.5, 0.6), skew, v4(0.0, 0.0, 0.0, 1.0), trans);
   EXPECT_EQ(tx0.GetCenter(), v3(0.0, 0.0, 0.0));
@@ -1764,8 +1783,9 @@ TEST(TransformTest, ScaleSkewVersor3DTransform)
   tx->SetCenter(center);
   EXPECT_EQ(tx->GetCenter(), center);
 
-  EXPECT_EQ(tx->SetRotation(v4(0.0, 1.0, 0.0, 0.0)).GetVersor(), v4(0.0, 1.0, 0.0, 0.0));
-  EXPECT_THROW(tx->SetRotation(v3(1.0, 0.0, 0.0)).GetVersor(), sitk::GenericException);
+  tx->SetRotation(v4(0.0, 1.0, 0.0, 0.0));
+  EXPECT_EQ(tx->GetVersor(), v4(0.0, 1.0, 0.0, 0.0));
+  EXPECT_THROW(tx->SetRotation(v3(1.0, 0.0, 0.0)), sitk::GenericException);
 
   EXPECT_EQ(tx->GetTranslation(), zeros);
   tx->SetTranslation(trans);
@@ -1793,10 +1813,13 @@ TEST(TransformTest, ComposeScaleSkewVersor3DTransform)
   EXPECT_EQ(tx->GetVersor(), v4(0.0, 0.0, 0.0, 1.0));
   EXPECT_EQ(tx->GetMatrix(), v9(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0));
 
-  EXPECT_EQ(tx->SetScale(v3(1.0, 2.0, 3.0)).GetScale(), v3(1.0, 2.0, 3.0));
-  EXPECT_EQ(tx->SetTranslation(trans).GetTranslation(), trans);
+  tx->SetScale(v3(1.0, 2.0, 3.0));
+  EXPECT_EQ(tx->GetScale(), v3(1.0, 2.0, 3.0));
+  tx->SetTranslation(trans);
+  EXPECT_EQ(tx->GetTranslation(), trans);
 
-  EXPECT_EQ(tx->SetCenter(center).GetCenter(), center);
+  tx->SetCenter(center);
+  EXPECT_EQ(tx->GetCenter(), center);
 
   sitk::ComposeScaleSkewVersor3DTransform tx0(v3(0.4, 0.5, 0.6), skew, v4(0.0, 0.0, 0.0, 1.0), trans);
   EXPECT_EQ(tx0.GetCenter(), v3(0.0, 0.0, 0.0));
@@ -1892,8 +1915,9 @@ TEST(TransformTest, ComposeScaleSkewVersor3DTransform)
   tx->SetCenter(center);
   EXPECT_EQ(tx->GetCenter(), center);
 
-  EXPECT_EQ(tx->SetRotation(v4(0.0, 1.0, 0.0, 0.0)).GetVersor(), v4(0.0, 1.0, 0.0, 0.0));
-  EXPECT_THROW(tx->SetRotation(v3(1.0, 0.0, 0.0)).GetVersor(), sitk::GenericException);
+  tx->SetRotation(v4(0.0, 1.0, 0.0, 0.0));
+  EXPECT_EQ(tx->GetVersor(), v4(0.0, 1.0, 0.0, 0.0));
+  EXPECT_THROW(tx->SetRotation(v3(1.0, 0.0, 0.0)), sitk::GenericException);
 
   EXPECT_EQ(tx->GetTranslation(), zeros);
   tx->SetTranslation(trans);
@@ -1919,9 +1943,12 @@ TEST(TransformTest, ScaleVersor3DTransform)
   EXPECT_EQ(tx->GetVersor(), v4(0.0, 0.0, 0.0, 1.0));
   EXPECT_EQ(tx->GetMatrix(), v9(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0));
 
-  EXPECT_EQ(tx->SetScale(v3(1.0, 2.0, 3.0)).GetScale(), v3(1.0, 2.0, 3.0));
-  EXPECT_EQ(tx->SetTranslation(trans).GetTranslation(), trans);
-  EXPECT_EQ(tx->SetCenter(center).GetCenter(), center);
+  tx->SetScale(v3(1.0, 2.0, 3.0));
+  EXPECT_EQ(tx->GetScale(), v3(1.0, 2.0, 3.0));
+  tx->SetTranslation(trans);
+  EXPECT_EQ(tx->GetTranslation(), trans);
+  tx->SetCenter(center);
+  EXPECT_EQ(tx->GetCenter(), center);
 
   sitk::ScaleVersor3DTransform tx0(v3(0.4, 0.5, 0.6), v4(0.0, 0.0, 0.0, 1.0), trans);
   EXPECT_EQ(tx0.GetCenter(), v3(0.0, 0.0, 0.0));
@@ -2015,8 +2042,9 @@ TEST(TransformTest, ScaleVersor3DTransform)
   tx->SetCenter(center);
   EXPECT_EQ(tx->GetCenter(), center);
 
-  EXPECT_EQ(tx->SetRotation(v4(0.0, 1.0, 0.0, 0.0)).GetVersor(), v4(0.0, 1.0, 0.0, 0.0));
-  EXPECT_THROW(tx->SetRotation(v3(1.0, 0.0, 0.0)).GetVersor(), sitk::GenericException);
+  tx->SetRotation(v4(0.0, 1.0, 0.0, 0.0));
+  EXPECT_EQ(tx->GetVersor(), v4(0.0, 1.0, 0.0, 0.0));
+  EXPECT_THROW(tx->SetRotation(v3(1.0, 0.0, 0.0)), sitk::GenericException);
 
   EXPECT_EQ(tx->GetTranslation(), zeros);
   tx->SetTranslation(trans);
@@ -2034,16 +2062,19 @@ TEST(TransformTest, ScaleSkewVersor3DTransform_Points)
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(0.0, 0.0, 0.0)), v3(0.0, 0.0, 0.0), 1e-15);
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(1.0, 1.0, 1.0)), v3(1.0, 1.0, 1.0), 1e-15);
 
-  EXPECT_EQ(tx.Translate(v3(1.0, 2.0, 3.0)).GetTranslation(), v3(1.0, 2.0, 3.0));
+  tx.Translate(v3(1.0, 2.0, 3.0));
+  EXPECT_EQ(tx.GetTranslation(), v3(1.0, 2.0, 3.0));
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(0.0, 0.0, 0.0)), v3(1.0, 2.0, 3.0), 1e-15);
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(1.0, 1.0, 1.0)), v3(2.0, 3.0, 4.0), 1e-15);
 
   tx = sitk::ScaleSkewVersor3DTransform();
-  EXPECT_EQ(tx.SetRotation(v4(0.0, 1.0, 0.0, 0.0)).GetVersor(), v4(0.0, 1.0, 0.0, 0.0));
+  tx.SetRotation(v4(0.0, 1.0, 0.0, 0.0));
+  EXPECT_EQ(tx.GetVersor(), v4(0.0, 1.0, 0.0, 0.0));
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(0.0, 0.0, 0.0)), v3(0.0, 0.0, 0.0), 1e-15);
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(1.0, 0.0, 0.0)), v3(-1.0, 0.0, 0.0), 1e-15);
 
-  EXPECT_EQ(tx.Translate(v3(1.0, 2.0, 3.0)).GetTranslation(), v3(1.0, 2.0, 3.0));
+  tx.Translate(v3(1.0, 2.0, 3.0));
+  EXPECT_EQ(tx.GetTranslation(), v3(1.0, 2.0, 3.0));
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(0.0, 0.0, 0.0)), v3(1.0, 2.0, 3.0), 1e-15);
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(1.0, 0.0, 0.0)), v3(0.0, 2.0, 3.0), 1e-15);
 
@@ -2053,7 +2084,8 @@ TEST(TransformTest, ScaleSkewVersor3DTransform_Points)
 
   std::vector<double> skew = zeroSkew;
   skew[0] = 1.0;
-  EXPECT_EQ(tx.SetSkew(skew).GetSkew(), skew);
+  tx.SetSkew(skew);
+  EXPECT_EQ(tx.GetSkew(), skew);
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(0.0, 0.0, 0.0)), v3(0.0, 0.0, 0.0), 1e-17);
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(1.0, 0.0, 0.0)), v3(1.0, 0.0, 0.0), 1e-17);
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(1.0, 1.0, 0.0)), v3(2.0, 1.0, 0.0), 1e-17);
@@ -2061,7 +2093,8 @@ TEST(TransformTest, ScaleSkewVersor3DTransform_Points)
 
   skew = zeroSkew;
   skew[3] = 1.0;
-  EXPECT_EQ(tx.SetSkew(skew).GetSkew(), skew);
+  tx.SetSkew(skew);
+  EXPECT_EQ(tx.GetSkew(), skew);
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(0.0, 0.0, 0.0)), v3(0.0, 0.0, 0.0), 1e-17);
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(1.0, 0.0, 0.0)), v3(1.0, 0.0, 0.0), 1e-17);
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(1.0, 1.0, 0.0)), v3(1.0, 1.0, 0.0), 1e-17);
@@ -2089,10 +2122,13 @@ TEST(TransformTest, Similarity3DTransform)
   EXPECT_EQ(tx->GetVersor(), v4(0.0, 0.0, 0.0, 1.0));
   EXPECT_EQ(tx->GetMatrix(), v9(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0));
 
-  EXPECT_EQ(tx->SetScale(2.0).GetScale(), 2.0);
-  EXPECT_EQ(tx->SetTranslation(trans).GetTranslation(), trans);
+  tx->SetScale(2.0);
+  EXPECT_EQ(tx->GetScale(), 2.0);
+  tx->SetTranslation(trans);
+  EXPECT_EQ(tx->GetTranslation(), trans);
 
-  EXPECT_EQ(tx->SetCenter(center).GetCenter(), center);
+  tx->SetCenter(center);
+  EXPECT_EQ(tx->GetCenter(), center);
 
   sitk::Similarity3DTransform tx0(0.5, v4(1.0, 0.0, 0.0, 0.0), trans);
   EXPECT_EQ(tx0.GetCenter(), v3(0.0, 0.0, 0.0));
@@ -2178,8 +2214,9 @@ TEST(TransformTest, Similarity3DTransform)
   tx->SetCenter(center);
   EXPECT_EQ(tx->GetCenter(), center);
 
-  EXPECT_EQ(tx->SetRotation(v4(0.0, 1.0, 0.0, 0.0)).GetVersor(), v4(0.0, 1.0, 0.0, 0.0));
-  EXPECT_THROW(tx->SetRotation(v3(1.0, 0.0, 0.0)).GetVersor(), sitk::GenericException);
+  tx->SetRotation(v4(0.0, 1.0, 0.0, 0.0));
+  EXPECT_EQ(tx->GetVersor(), v4(0.0, 1.0, 0.0, 0.0));
+  EXPECT_THROW(tx->SetRotation(v3(1.0, 0.0, 0.0)), sitk::GenericException);
 
   EXPECT_EQ(tx->GetTranslation(), zeros);
   tx->SetTranslation(trans);
@@ -2203,16 +2240,19 @@ TEST(TransformTest, Similarity3DTransform_Points)
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(0.0, 0.0, 0.0)), v3(0.0, 0.0, 0.0), 1e-15);
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(1.0, 1.0, 1.0)), v3(1.0, 1.0, 1.0), 1e-15);
 
-  EXPECT_EQ(tx.Translate(v3(1.0, 2.0, 3.0)).GetTranslation(), v3(1.0, 2.0, 3.0));
+  tx.Translate(v3(1.0, 2.0, 3.0));
+  EXPECT_EQ(tx.GetTranslation(), v3(1.0, 2.0, 3.0));
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(0.0, 0.0, 0.0)), v3(1.0, 2.0, 3.0), 1e-15);
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(1.0, 1.0, 1.0)), v3(2.0, 3.0, 4.0), 1e-15);
 
   tx = sitk::Similarity3DTransform();
-  EXPECT_EQ(tx.SetRotation(v4(0.0, 1.0, 0.0, 0.0)).GetVersor(), v4(0.0, 1.0, 0.0, 0.0));
+  tx.SetRotation(v4(0.0, 1.0, 0.0, 0.0));
+  EXPECT_EQ(tx.GetVersor(), v4(0.0, 1.0, 0.0, 0.0));
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(0.0, 0.0, 0.0)), v3(0.0, 0.0, 0.0), 1e-15);
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(1.0, 0.0, 0.0)), v3(-1.0, 0.0, 0.0), 1e-15);
 
-  EXPECT_EQ(tx.Translate(v3(1.0, 2.0, 3.0)).GetTranslation(), v3(1.0, 2.0, 3.0));
+  tx.Translate(v3(1.0, 2.0, 3.0));
+  EXPECT_EQ(tx.GetTranslation(), v3(1.0, 2.0, 3.0));
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(0.0, 0.0, 0.0)), v3(1.0, 2.0, 3.0), 1e-15);
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(1.0, 0.0, 0.0)), v3(0.0, 2.0, 3.0), 1e-15);
 
@@ -2302,8 +2342,10 @@ TEST(TransformTest, VersorRigid3DTransform)
   EXPECT_EQ(tx->GetVersor(), v4(0.0, 0.0, 0.0, 1.0));
   EXPECT_EQ(tx->GetMatrix(), v9(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0));
 
-  EXPECT_EQ(tx->SetTranslation(trans).GetTranslation(), trans);
-  EXPECT_EQ(tx->SetCenter(center).GetCenter(), center);
+  tx->SetTranslation(trans);
+  EXPECT_EQ(tx->GetTranslation(), trans);
+  tx->SetCenter(center);
+  EXPECT_EQ(tx->GetCenter(), center);
 
   // constructor using versor
   sitk::VersorRigid3DTransform tx0(v4(1.0, 0.0, 0.0, 0.0), trans);
@@ -2383,8 +2425,9 @@ TEST(TransformTest, VersorRigid3DTransform)
   tx->SetCenter(center);
   EXPECT_EQ(tx->GetCenter(), center);
 
-  EXPECT_EQ(tx->SetRotation(v4(0.0, 1.0, 0.0, 0.0)).GetVersor(), v4(0.0, 1.0, 0.0, 0.0));
-  EXPECT_THROW(tx->SetRotation(v3(1.0, 0.0, 0.0)).GetVersor(), sitk::GenericException);
+  tx->SetRotation(v4(0.0, 1.0, 0.0, 0.0));
+  EXPECT_EQ(tx->GetVersor(), v4(0.0, 1.0, 0.0, 0.0));
+  EXPECT_THROW(tx->SetRotation(v3(1.0, 0.0, 0.0)), sitk::GenericException);
 
   EXPECT_EQ(tx->GetTranslation(), zeros);
   tx->SetTranslation(trans);
@@ -2411,16 +2454,19 @@ TEST(TransformTest, VersorRigid3DTransform_Points)
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(0.0, 0.0, 0.0)), v3(0.0, 0.0, 0.0), 1e-15);
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(1.0, 1.0, 1.0)), v3(1.0, 1.0, 1.0), 1e-15);
 
-  EXPECT_EQ(tx.Translate(v3(1.0, 2.0, 3.0)).GetTranslation(), v3(1.0, 2.0, 3.0));
+  tx.Translate(v3(1.0, 2.0, 3.0));
+  EXPECT_EQ(tx.GetTranslation(), v3(1.0, 2.0, 3.0));
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(0.0, 0.0, 0.0)), v3(1.0, 2.0, 3.0), 1e-15);
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(1.0, 1.0, 1.0)), v3(2.0, 3.0, 4.0), 1e-15);
 
   tx = sitk::VersorRigid3DTransform();
-  EXPECT_EQ(tx.SetRotation(v4(0.0, 1.0, 0.0, 0.0)).GetVersor(), v4(0.0, 1.0, 0.0, 0.0));
+  tx.SetRotation(v4(0.0, 1.0, 0.0, 0.0));
+  EXPECT_EQ(tx.GetVersor(), v4(0.0, 1.0, 0.0, 0.0));
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(0.0, 0.0, 0.0)), v3(0.0, 0.0, 0.0), 1e-15);
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(1.0, 0.0, 0.0)), v3(-1.0, 0.0, 0.0), 1e-15);
 
-  EXPECT_EQ(tx.Translate(v3(1.0, 2.0, 3.0)).GetTranslation(), v3(1.0, 2.0, 3.0));
+  tx.Translate(v3(1.0, 2.0, 3.0));
+  EXPECT_EQ(tx.GetTranslation(), v3(1.0, 2.0, 3.0));
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(0.0, 0.0, 0.0)), v3(1.0, 2.0, 3.0), 1e-15);
   EXPECT_VECTOR_DOUBLE_NEAR(tx.TransformPoint(v3(1.0, 0.0, 0.0)), v3(0.0, 2.0, 3.0), 1e-15);
 
@@ -2459,7 +2505,8 @@ TEST(TransformTest, VersorTransform)
   EXPECT_EQ(tx->GetCenter(), zeros);
   EXPECT_EQ(tx->GetMatrix(), v9(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0));
 
-  EXPECT_EQ(tx->SetCenter(center).GetCenter(), center);
+  tx->SetCenter(center);
+  EXPECT_EQ(tx->GetCenter(), center);
 
   // constructor using versor
   sitk::VersorTransform tx0(v4(1.0, 0.0, 0.0, 0.0));
@@ -2531,8 +2578,9 @@ TEST(TransformTest, VersorTransform)
   tx->SetCenter(center);
   EXPECT_EQ(tx->GetCenter(), center);
 
-  EXPECT_EQ(tx->SetRotation(v4(0.0, 1.0, 0.0, 0.0)).GetVersor(), v4(0.0, 1.0, 0.0, 0.0));
-  EXPECT_THROW(tx->SetRotation(v3(1.0, 0.0, 0.0)).GetVersor(), sitk::GenericException);
+  tx->SetRotation(v4(0.0, 1.0, 0.0, 0.0));
+  EXPECT_EQ(tx->GetVersor(), v4(0.0, 1.0, 0.0, 0.0));
+  EXPECT_THROW(tx->SetRotation(v3(1.0, 0.0, 0.0)), sitk::GenericException);
   EXPECT_NO_THROW(tx->SetIdentity());
 
   // inverse

--- a/Utilities/Doxygen/doxygen.config.in
+++ b/Utilities/Doxygen/doxygen.config.in
@@ -2130,8 +2130,7 @@ INCLUDE_FILE_PATTERNS  =
 PREDEFINED             = "itkNotUsed(x)=" \
                          "SITKBasicFilters_EXPORT= " \
                          "SITKITKIO_EXPORT= " \
-                         "SITKITKCommon_EXPORT= " \
-                         "SITK_RETURN_SELF_TYPE_HEADER=Self &"
+                         "SITKITKCommon_EXPORT= "
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/Wrapping/Common/SimpleITK_Common.i
+++ b/Wrapping/Common/SimpleITK_Common.i
@@ -146,11 +146,6 @@ namespace std
 #endif
 
 
-#ifndef SITK_RETURN_SELF_TYPE_HEADER
-#define SITK_RETURN_SELF_TYPE_HEADER void
-#endif
-
-
 // define these preprocessor directives to nothing for the swig interface
 #define SITKCommon_EXPORT
 #define SITKCommon_HIDDEN


### PR DESCRIPTION
Some Set method and Execute methods return "self" by reference, allowing for chained functions. This has been removed because in some situations the returned object can become invalid. Additionally, this was not supported by SWIG, and was not in any wrapped languages.