### PR TITLE
ENH: Address changes in Fiji installation on windows.

### DIFF
--- a/Code/IO/src/sitkImageViewer.cxx
+++ b/Code/IO/src/sitkImageViewer.cxx
@@ -228,7 +228,7 @@ GlobalConfig::GlobalConfig()
   //  Set the ExecutableNames
   //
 #if defined(_WIN32)
-  m_DefaultExecutableNames = { "Fiji.app/ImageJ-win64.exe", "Fiji.app/ImageJ-win32.exe" };
+  m_DefaultExecutableNames = { "Fiji.app/ImageJ-win64.exe", "Fiji.app/ImageJ-win32.exe", "Fiji/fiji-windows-x64.exe" };
 #elif defined(__APPLE__)
   m_DefaultExecutableNames = { "Fiji.app" };
 #else

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -178,7 +178,7 @@ Why isn't Fiji or ImageJ found by the Show function (RuntimeError: Exception thr
 The SimpleITK ``Show`` function expects the Fiji or ImageJ application to be
 installed in specific locations. The recommended installation locations are:
 
-- On Windows: in your user directory (e.g. C:\\Users\\your_user_name\\Fiji.app).
+- On Windows: in your user directory (e.g. C:\\Users\\your_user_name\\Fiji.app or C:\\Users\\your_user_name\\Fiji).
 - On Linux: in ~/bin.
 - On Mac: in /Applications or ~/Applications.
 


### PR DESCRIPTION
Newer versions of the Fiji distribution (5/2025 and later) now install in a directory called Fiji and the executable is
fiji-windows-x64.exe. Adding to the image viewer's default-executables list.