### PR TITLE
Update typing for Resample in extra.py

### DIFF
--- a/Wrapping/Python/SimpleITK/extra.py
+++ b/Wrapping/Python/SimpleITK/extra.py
@@ -49,7 +49,7 @@ def Resample(
     image1: Image,
     *args,
     referenceImage: Optional[Image] = None,
-    size: Optional[int] = None,
+    size: Optional[List[int]] = None,
     **kwargs,
 ) -> Image:
     """


### PR DESCRIPTION
I believe the typing here should be `Optional[List[int]]`, to match `VectorUInt32_Size` in the signature for `ResampleImageFilter_SetSize`.

My IDE has been giving me typing warnings when I provide a `List[Int]`, but the function works as expected. `int` is actually incorrect:

```
image = sitk.GetImageFromArray(np.random.random([5, 6, 7]))
resampled_image = sitk.Resample(image, size=[2, 2, 2])  # returns a valid image
resampled_image = sitk.Resample(image, size=[2])  # error
resampled_image = sitk.Resample(image, size=2)  # error
```