### PR TITLE
DOC: Add C#, C++ and java versions to the DicomImagePrintTags example.

### DIFF
--- a/Examples/DicomImagePrintTags/CMakeLists.txt
+++ b/Examples/DicomImagePrintTags/CMakeLists.txt
@@ -29,3 +29,47 @@ if(WRAP_R)
         "\\(0008|0060\\) = = \"MR\""
   )
 endif()
+
+sitk_add_java_test(
+  Example.DicomImagePrintTags
+  "${CMAKE_CURRENT_SOURCE_DIR}/DicomImagePrintTags.java"
+  DATA{${SimpleITK_DATA_ROOT}/Input/DicomSeries/Image0075.dcm}
+)
+if(WRAP_JAVA)
+  set_tests_properties(
+    Java.Example.DicomImagePrintTags
+    PROPERTIES
+      PASS_REGULAR_EXPRESSION
+        "\\(0008|0060\\) = = \"MR\""
+  )
+endif()
+
+sitk_add_csharp_test(
+  Example.DicomImagePrintTags
+  "${CMAKE_CURRENT_SOURCE_DIR}/DicomImagePrintTags.cs"
+  DATA{${SimpleITK_DATA_ROOT}/Input/DicomSeries/Image0075.dcm}
+)
+if(WRAP_CSHARP)
+  set_tests_properties(
+    CSharp.Example.DicomImagePrintTags
+    PROPERTIES
+      PASS_REGULAR_EXPRESSION
+        "\\(0008|0060\\) = = \"MR\""
+  )
+endif()
+
+add_executable(DicomImagePrintTags DicomImagePrintTags.cxx)
+target_link_libraries(DicomImagePrintTags ${SimpleITK_LIBRARIES})
+
+sitk_add_test(
+  NAME CXX.Example.DicomImagePrintTags
+  COMMAND
+    $<TARGET_FILE:DicomImagePrintTags>
+    DATA{${SimpleITK_DATA_ROOT}/Input/DicomSeries/Image0075.dcm}
+)
+set_tests_properties(
+  CXX.Example.DicomImagePrintTags
+  PROPERTIES
+    PASS_REGULAR_EXPRESSION
+      "\\(0008|0060\\) = = \"MR\""
+)

--- a/Examples/DicomImagePrintTags/DicomImagePrintTags.cs
+++ b/Examples/DicomImagePrintTags/DicomImagePrintTags.cs
@@ -1,0 +1,65 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+/// <summary>
+/// A SimpleITK example demonstrating how to print a DICOM image's tags.
+/// </summary>
+
+using System;
+using System.Collections.Generic;
+using itk.simple;
+
+namespace itk.simple.examples
+{
+    public class DicomImagePrintTags
+    {
+        /// <summary>
+        /// A SimpleITK script that prints a DICOM image's tags.
+        /// </summary>
+        public static void Main(string[] args)
+        {
+            if (args.Length < 1)
+            {
+                Console.WriteLine("Usage: DicomImagePrintTags <input_file>");
+                return;
+            }
+
+            var reader = new ImageFileReader();
+
+            reader.SetFileName(args[0]);
+            reader.LoadPrivateTagsOn();
+
+            reader.ReadImageInformation();
+
+            foreach (string k in reader.GetMetaDataKeys())
+            {
+                Console.WriteLine(string.Format("({0}) = = \"{1}\"", k, reader.GetMetaData(k)));
+            }
+
+            var size = reader.GetSize();
+            Console.Write("Image Size: [" + size[0]);
+            for (int i = 1; i < size.Count; i++)
+            {
+                Console.Write(", " + size[i]);
+            }
+            Console.WriteLine("]");
+
+            Console.WriteLine("Image PixelType: " + SimpleITK.GetPixelIDValueAsString(reader.GetPixelID()));
+        }
+    }
+}

--- a/Examples/DicomImagePrintTags/DicomImagePrintTags.cxx
+++ b/Examples/DicomImagePrintTags/DicomImagePrintTags.cxx
@@ -1,0 +1,65 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+/**
+ * A SimpleITK example demonstrating how to print a DICOM image's tags.
+ */
+
+#include <SimpleITK.h>
+#include <iostream>
+#include <vector>
+
+namespace sitk = itk::simple;
+
+/**
+ * A SimpleITK script that prints a DICOM image's tags.
+ */
+int
+main(int argc, char * argv[])
+{
+  if (argc < 2)
+  {
+    std::cout << "Usage: DicomImagePrintTags <input_file>" << std::endl;
+    return 1;
+  }
+
+  sitk::ImageFileReader reader;
+
+  reader.SetFileName(argv[1]);
+  reader.LoadPrivateTagsOn();
+
+  reader.ReadImageInformation();
+
+  std::vector<std::string> keys = reader.GetMetaDataKeys();
+  for (const auto & k : keys)
+  {
+    std::cout << "(" << k << ") = = \"" << reader.GetMetaData(k) << "\"" << std::endl;
+  }
+
+  std::vector<uint64_t> size = reader.GetSize();
+  std::cout << "Image Size: [" << size[0];
+  for (size_t i = 1; i < size.size(); ++i)
+  {
+    std::cout << ", " << size[i];
+  }
+  std::cout << "]" << std::endl;
+
+  std::cout << "Image PixelType: " << sitk::GetPixelIDValueAsString(reader.GetPixelID()) << std::endl;
+
+  return 0;
+}

--- a/Examples/DicomImagePrintTags/DicomImagePrintTags.java
+++ b/Examples/DicomImagePrintTags/DicomImagePrintTags.java
@@ -1,0 +1,56 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+/**
+ * A SimpleITK example demonstrating how to print a DICOM image's tags.
+ */
+
+import org.itk.simple.*;
+import java.util.*;
+
+public class DicomImagePrintTags {
+    /**
+     * A SimpleITK script that prints a DICOM image's tags.
+     */
+    public static void main(String[] args) {
+        if (args.length < 1) {
+            System.out.println("Usage: DicomImagePrintTags <input_file>");
+            System.exit(1);
+        }
+
+        ImageFileReader reader = new ImageFileReader();
+
+        reader.setFileName(args[0]);
+        reader.loadPrivateTagsOn();
+
+        reader.readImageInformation();
+
+        for (String k : reader.getMetaDataKeys()) {
+            System.out.println("(" + k + ") = = \"" + reader.getMetaData(k) + "\"");
+        }
+
+        VectorUInt64 size = reader.getSize();
+        System.out.print("Image Size: [" + size.get(0));
+        for (int i = 1; i < size.size(); i++) {
+            System.out.print(", " + size.get(i));
+        }
+        System.out.println("]");
+
+        System.out.println("Image PixelType: " + SimpleITK.getPixelIDValueAsString(reader.getPixelID()));
+    }
+}

--- a/Examples/DicomImagePrintTags/Documentation.rst
+++ b/Examples/DicomImagePrintTags/Documentation.rst
@@ -36,6 +36,24 @@ Code
 
 .. tabs::
 
+  .. tab:: C#
+
+    .. literalinclude:: ../../Examples/DicomImagePrintTags/DicomImagePrintTags.cs
+       :language: csharp
+       :lines: 22-
+
+  .. tab:: C++
+
+    .. literalinclude:: ../../Examples/DicomImagePrintTags/DicomImagePrintTags.cxx
+       :language: c++
+       :lines: 22-
+
+  .. tab:: Java
+
+    .. literalinclude:: ../../Examples/DicomImagePrintTags/DicomImagePrintTags.java
+       :language: java
+       :lines: 23-
+
   .. tab:: Python
 
     .. literalinclude:: ../../Examples/DicomImagePrintTags/DicomImagePrintTags.py


### PR DESCRIPTION
Provide the example in three additional languages.