### PR TITLE
Keep uv install XDG receipt local to build.

### DIFF
--- a/SuperBuild/SuperBuild.cmake
+++ b/SuperBuild/SuperBuild.cmake
@@ -451,7 +451,8 @@ add_custom_command(
     "${_SimpleITK_uv_EXECUTABLE}"
   COMMAND
     "${CMAKE_COMMAND}" -E env "XDG_BIN_HOME=${_SimpleITK_uv_PATH}/bin"
-    NO_MODIFY_PATH=1 sh ${UV_INSTALLER} --quiet --no-modify-path
+    "XDG_CONFIG_HOME=${CMAKE_CURRENT_BINARY_DIR}" UV_NO_MODIFY_PATH=1 sh
+    ${UV_INSTALLER} ${UV_INSTALLER} --quiet
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
   DEPENDS
     "${UV_INSTALLER}"


### PR DESCRIPTION
Using the default XDG home can cause conflict with an already installed uv command. Keep the xdg installation reciept local to the superbuild directory.