### PR TITLE
Refactor the function factories to not take pointer in constructor

### DIFF
--- a/Code/BasicFilters/src/sitkBSplineTransformInitializerFilter.cxx
+++ b/Code/BasicFilters/src/sitkBSplineTransformInitializerFilter.cxx
@@ -49,7 +49,7 @@ BSplineTransformInitializerFilter::BSplineTransformInitializerFilter()
   this->m_TransformDomainMeshSize = std::vector<uint32_t>(3, 1u);
   this->m_Order = 3u;
 
-  this->m_MemberFactory = std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>(this);
+  this->m_MemberFactory = std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>();
 
   this->m_MemberFactory->RegisterMemberFunctions<PixelIDTypeList, 3>();
   this->m_MemberFactory->RegisterMemberFunctions<PixelIDTypeList, 2>();
@@ -89,7 +89,7 @@ BSplineTransformInitializerFilter::Execute(const Image & image1)
   unsigned int     dimension = image1.GetDimension();
 
 
-  return this->m_MemberFactory->GetMemberFunction(type, dimension)(image1);
+  return this->m_MemberFactory->GetMemberFunction(type, dimension, this)(image1);
 }
 
 

--- a/Code/BasicFilters/src/sitkCastImageFilter.cxx
+++ b/Code/BasicFilters/src/sitkCastImageFilter.cxx
@@ -34,7 +34,7 @@ CastImageFilter::CastImageFilter()
 {
   this->m_OutputPixelType = sitkFloat32;
 
-  m_DualMemberFactory.reset(new detail::DualMemberFunctionFactory<MemberFunctionType>(this));
+  m_DualMemberFactory.reset(new detail::DualMemberFunctionFactory<MemberFunctionType>());
 
   this->RegisterMemberFactory2();
   this->RegisterMemberFactory2v();
@@ -89,7 +89,7 @@ CastImageFilter::Execute(const Image & image)
 
   if (this->m_DualMemberFactory->HasMemberFunction(inputType, outputType, dimension))
   {
-    return this->m_DualMemberFactory->GetMemberFunction(inputType, outputType, dimension)(image);
+    return this->m_DualMemberFactory->GetMemberFunction(inputType, outputType, dimension, this)(image);
   }
 
   sitkExceptionMacro(<< "Filter does not support casting from casting "

--- a/Code/BasicFilters/src/sitkCenteredTransformInitializerFilter.cxx
+++ b/Code/BasicFilters/src/sitkCenteredTransformInitializerFilter.cxx
@@ -47,7 +47,7 @@ CenteredTransformInitializerFilter::CenteredTransformInitializerFilter()
 
   this->m_OperationMode = itk::simple::CenteredTransformInitializerFilter::MOMENTS;
 
-  this->m_MemberFactory = std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>(this);
+  this->m_MemberFactory = std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>();
 
   this->m_MemberFactory->RegisterMemberFunctions<PixelIDTypeList, 3>();
   this->m_MemberFactory->RegisterMemberFunctions<PixelIDTypeList, 2>();
@@ -94,7 +94,7 @@ CenteredTransformInitializerFilter::Execute(const Image &     fixedImage,
     sitkExceptionMacro("Transform parameter for " << this->GetName() << " doesn't match dimension!");
   }
 
-  return this->m_MemberFactory->GetMemberFunction(type, dimension)(&fixedImage, &movingImage, &transform);
+  return this->m_MemberFactory->GetMemberFunction(type, dimension, this)(&fixedImage, &movingImage, &transform);
 }
 
 

--- a/Code/BasicFilters/src/sitkCenteredVersorTransformInitializerFilter.cxx
+++ b/Code/BasicFilters/src/sitkCenteredVersorTransformInitializerFilter.cxx
@@ -48,7 +48,7 @@ CenteredVersorTransformInitializerFilter::CenteredVersorTransformInitializerFilt
 
   this->m_ComputeRotation = false;
 
-  this->m_MemberFactory = std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>(this);
+  this->m_MemberFactory = std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>();
 
   this->m_MemberFactory->RegisterMemberFunctions<PixelIDTypeList, 3>();
 }
@@ -95,7 +95,7 @@ CenteredVersorTransformInitializerFilter::Execute(const Image &     fixedImage,
     sitkExceptionMacro("Transform parameter for " << this->GetName() << " doesn't match dimension!");
   }
 
-  return this->m_MemberFactory->GetMemberFunction(type, dimension)(&fixedImage, &movingImage, &transform);
+  return this->m_MemberFactory->GetMemberFunction(type, dimension, this)(&fixedImage, &movingImage, &transform);
 }
 
 

--- a/Code/BasicFilters/src/sitkExtractImageFilter.cxx
+++ b/Code/BasicFilters/src/sitkExtractImageFilter.cxx
@@ -39,7 +39,7 @@ namespace itk::simple
 //
 ExtractImageFilter::ExtractImageFilter()
 {
-  this->m_MemberFactory.reset(new detail::MemberFunctionFactory<MemberFunctionType>(this));
+  this->m_MemberFactory.reset(new detail::MemberFunctionFactory<MemberFunctionType>());
 
   this->m_MemberFactory->RegisterMemberFunctions<PixelIDTypeList, 2, SITK_MAX_DIMENSION>();
 }
@@ -80,7 +80,7 @@ ExtractImageFilter::Execute(const Image & image1)
   const PixelIDValueEnum type = image1.GetPixelID();
   const unsigned int     dimension = image1.GetDimension();
 
-  return this->m_MemberFactory->GetMemberFunction(type, dimension)(image1);
+  return this->m_MemberFactory->GetMemberFunction(type, dimension, this)(image1);
 }
 Image
 ExtractImageFilter::Execute(Image && image1)

--- a/Code/BasicFilters/src/sitkHashImageFilter.cxx
+++ b/Code/BasicFilters/src/sitkHashImageFilter.cxx
@@ -35,7 +35,7 @@ HashImageFilter::HashImageFilter()
 {
   this->m_HashFunction = SHA1;
 
-  this->m_MemberFactory.reset(new detail::MemberFunctionFactory<MemberFunctionType>(this));
+  this->m_MemberFactory.reset(new detail::MemberFunctionFactory<MemberFunctionType>());
 
   this->m_MemberFactory->RegisterMemberFunctions<PixelIDTypeList, 2, SITK_MAX_DIMENSION>();
   this->m_MemberFactory->RegisterMemberFunctions<LabelPixelIDTypeList,
@@ -83,7 +83,7 @@ HashImageFilter::Execute(const Image & image)
   PixelIDValueEnum type = image.GetPixelID();
   unsigned int     dimension = image.GetDimension();
 
-  return this->m_MemberFactory->GetMemberFunction(type, dimension)(image);
+  return this->m_MemberFactory->GetMemberFunction(type, dimension, this)(image);
 }
 
 template <class TLabelImageType>

--- a/Code/BasicFilters/src/sitkLandmarkBasedTransformInitializerFilter.cxx
+++ b/Code/BasicFilters/src/sitkLandmarkBasedTransformInitializerFilter.cxx
@@ -52,7 +52,7 @@ LandmarkBasedTransformInitializerFilter::LandmarkBasedTransformInitializerFilter
   this->m_ReferenceImage = Image();
   this->m_BSplineNumberOfControlPoints = 4u;
 
-  this->m_MemberFactory = std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>(this);
+  this->m_MemberFactory = std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>();
 
   this->m_MemberFactory->RegisterMemberFunctions<PixelIDTypeList, 3>();
   this->m_MemberFactory->RegisterMemberFunctions<PixelIDTypeList, 2>();
@@ -109,7 +109,7 @@ LandmarkBasedTransformInitializerFilter::Execute(const Transform & transform)
       "ReferenceImage for LandmarkBasedTransformInitializerFilter does not match dimension of the transform!");
   }
 
-  return this->m_MemberFactory->GetMemberFunction(sitkFloat32, dimension)(&transform);
+  return this->m_MemberFactory->GetMemberFunction(sitkFloat32, dimension, this)(&transform);
 }
 
 

--- a/Code/BasicFilters/src/sitkPasteImageFilter.cxx
+++ b/Code/BasicFilters/src/sitkPasteImageFilter.cxx
@@ -48,11 +48,11 @@ namespace itk::simple
 //
 PasteImageFilter::PasteImageFilter()
 {
-  this->m_MemberFactory = std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>(this);
+  this->m_MemberFactory = std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>();
 
   this->m_MemberFactory->RegisterMemberFunctions<PixelIDTypeList, 2, SITK_MAX_DIMENSION>();
 
-  this->m_MemberFactory2 = std::make_unique<detail::MemberFunctionFactory<MemberFunction2Type>>(this);
+  this->m_MemberFactory2 = std::make_unique<detail::MemberFunctionFactory<MemberFunction2Type>>();
   this->m_MemberFactory2->RegisterMemberFunctions<PixelIDTypeList, 2, SITK_MAX_DIMENSION>();
 }
 
@@ -97,7 +97,7 @@ PasteImageFilter::Execute(const Image & destinationImage, const Image & sourceIm
   const unsigned int     dimension = destinationImage.GetDimension();
   CheckImageMatchingPixelType(destinationImage, sourceImage, "sourceImage");
 
-  return this->m_MemberFactory->GetMemberFunction(type, dimension)(&destinationImage, &sourceImage);
+  return this->m_MemberFactory->GetMemberFunction(type, dimension, this)(&destinationImage, &sourceImage);
 }
 Image
 PasteImageFilter::Execute(const Image & destinationImage, double constant)
@@ -105,7 +105,7 @@ PasteImageFilter::Execute(const Image & destinationImage, double constant)
   const PixelIDValueEnum type = destinationImage.GetPixelID();
   const unsigned int     dimension = destinationImage.GetDimension();
 
-  return this->m_MemberFactory2->GetMemberFunction(type, dimension)(&destinationImage, constant);
+  return this->m_MemberFactory2->GetMemberFunction(type, dimension, this)(&destinationImage, constant);
 }
 Image
 PasteImageFilter::Execute(Image && destinationImage, const Image & sourceImage)

--- a/Code/BasicFilters/templates/sitkBinaryFunctorFilterTemplate.cxx.jinja
+++ b/Code/BasicFilters/templates/sitkBinaryFunctorFilterTemplate.cxx.jinja
@@ -1,4 +1,3 @@
-
 /*=========================================================================*/
 /*
  *  Copyright NumFOCUS
@@ -37,11 +36,11 @@ namespace itk::simple {
   {% include "ConstructorMemberFunctionSetup.cxx.jinja" %}
   {% include "ConstructorVectorPixels.cxx.jinja" %}
 
-  this->m_MemberFactory1.reset( new detail::MemberFunctionFactory<MemberFunction1Type>( this ) );
+  this->m_MemberFactory1.reset( new detail::MemberFunctionFactory<MemberFunction1Type> );
   this->m_MemberFactory1->RegisterMemberFunctions< PixelIDTypeList, 3 >();
   this->m_MemberFactory1->RegisterMemberFunctions< PixelIDTypeList, 2 >();
 
-  this->m_MemberFactory2.reset( new detail::MemberFunctionFactory<MemberFunction2Type>( this ) );
+  this->m_MemberFactory2.reset( new detail::MemberFunctionFactory<MemberFunction2Type> );
   this->m_MemberFactory2->RegisterMemberFunctions< PixelIDTypeList, 3 >();
   this->m_MemberFactory2->RegisterMemberFunctions< PixelIDTypeList, 2 >();
 }
@@ -88,14 +87,14 @@ Image {{ name }}::Execute ( {{ constant_type }} constant, const Image& image2 )
 {
   PixelIDValueEnum type = image2.GetPixelID();
   unsigned int dimension = image2.GetDimension();
-  return this->m_MemberFactory1->GetMemberFunction( type, dimension )( constant, image2 );
+  return this->m_MemberFactory1->GetMemberFunction( type, dimension, this )( constant, image2 );
 }
 
 Image {{ name }}::Execute ( const Image& image1, {{ constant_type }} constant )
 {
   PixelIDValueEnum type = image1.GetPixelID();
   unsigned int dimension = image1.GetDimension();
-  return this->m_MemberFactory2->GetMemberFunction( type, dimension )( image1, constant );
+  return this->m_MemberFactory2->GetMemberFunction( type, dimension, this )( image1, constant );
 }
 
 Image {{ name }}::Execute ( Image&& image1, {{ constant_type }} constant )

--- a/Code/BasicFilters/templates/sitkDualImageFilterTemplate.cxx.jinja
+++ b/Code/BasicFilters/templates/sitkDualImageFilterTemplate.cxx.jinja
@@ -27,7 +27,7 @@ namespace itk::simple {
 // Default constructor that initializes parameters
 {% include "ConstructorSignature.cxx.jinja" %}
 {
-  this->m_DualMemberFactory.reset( new detail::DualMemberFunctionFactory<MemberFunctionType>( this ) );
+  this->m_DualMemberFactory.reset( new detail::DualMemberFunctionFactory<MemberFunctionType> );
   {% if pixel_types2 %}
   using PixelIDTypeList2 = {{ pixel_types2 }};
   {% endif %}
@@ -100,7 +100,7 @@ namespace itk::simple {
         {{ custom_type2 }}
     {% endif %}
 
-    return this->m_DualMemberFactory->GetMemberFunction(type1, type2, dimension)(
+    return this->m_DualMemberFactory->GetMemberFunction(type1, type2, dimension, this)(
         {%- for inum in range(1, number_of_inputs+1) -%}
             {%- if inum > 1 %}, {% endif -%}image{{ inum }}
         {%- endfor -%}

--- a/Code/BasicFilters/templates/sitkImageSourceTemplate.cxx.jinja
+++ b/Code/BasicFilters/templates/sitkImageSourceTemplate.cxx.jinja
@@ -59,7 +59,7 @@ Image {{ name }}::Execute ( {{ macros.image_parameters(number_of_inputs) }}{{ ma
     if ( type != image{{ inum }}.GetPixelIDValue() || dimension != image{{ inum }}.GetDimension() ) { sitkExceptionMacro ( "Image{{ inum }} for {{ name }} doesn't match type or dimension!" ); }
   {%- endfor %}
 
-  return this->m_MemberFactory->GetMemberFunction( type, dimension )(
+  return this->m_MemberFactory->GetMemberFunction( type, dimension, this )(
     {%- for inum in range(1, number_of_inputs+1) -%}
       {%- if inum > 1 %}, {% endif -%}
       image{{ inum }}

--- a/Code/BasicFilters/templates/sitkMultiInputImageFilterTemplate.cxx.jinja
+++ b/Code/BasicFilters/templates/sitkMultiInputImageFilterTemplate.cxx.jinja
@@ -79,7 +79,7 @@ Image {{ name }}::Execute ( const std::vector<Image> &images )
     ++inputIndex;
     }
 
-  return this->m_MemberFactory->GetMemberFunction( type, dimension )( images );
+  return this->m_MemberFactory->GetMemberFunction( type, dimension, this )( images );
 }
 
 //-----------------------------------------------------------------------------

--- a/Code/Common/include/sitkDualMemberFunctionFactory.h
+++ b/Code/Common/include/sitkDualMemberFunctionFactory.h
@@ -72,7 +72,7 @@ public:
 
   /** \brief Constructor which permanently binds the constructed
    * object to pObject */
-  DualMemberFunctionFactory(ObjectType * pObject);
+  DualMemberFunctionFactory() = default;
 
   /** \brief Registers a specific member function.
    *
@@ -149,7 +149,12 @@ public:
 
 
   /** \brief Returns a function object for the combination of
-   *  PixelID1 and PixelID2, and image dimension.
+   *  PixelID1 and PixelID2, and image dimension, with a object pointer.
+   *
+   *  This overload of GetMemberFunction allows the caller to specify a
+   *  custom object pointer type, which can be useful in certain
+   *  situations where the object pointer type needs to be different from
+   *  the one used during factory construction.
    *
    *  pixelID1 or pixelID2 is the value of Image::GetPixelIDValue(),
    *  or PixelIDToPixelIDValue<PixelIDType>::Result
@@ -160,7 +165,7 @@ public:
    *  \code
    *  PixelIDValueType pixelID = image->GetPixelIDValue();
    *  unsigned int dimension = image->GetDimension();
-   *  return this->m_MemberFactory->GetMemberFunction( pixelID, pixelID, dimension )( image );
+   *  return this->m_MemberFactory->GetMemberFunction( pixelID, pixelID, dimension, objectPointer )( image );
    *  \endcode
    *
    *  If the requested member function is not registered then an
@@ -168,7 +173,10 @@ public:
    *  guaranteed to be valid.
    */
   FunctionObjectType
-  GetMemberFunction(PixelIDValueType pixelID1, PixelIDValueType pixelID2, unsigned int imageDimension);
+  GetMemberFunction(PixelIDValueType pixelID1,
+                    PixelIDValueType pixelID2,
+                    unsigned int     imageDimension,
+                    ObjectType *     objectPointer) const;
 
 protected:
   ObjectType * m_ObjectPointer;

--- a/Code/Common/include/sitkDualMemberFunctionFactory.hxx
+++ b/Code/Common/include/sitkDualMemberFunctionFactory.hxx
@@ -69,13 +69,6 @@ private:
 };
 
 template <typename TMemberFunctionPointer>
-DualMemberFunctionFactory<TMemberFunctionPointer>::DualMemberFunctionFactory(ObjectType * pObject)
-  : m_ObjectPointer(pObject)
-{
-  assert(pObject);
-}
-
-template <typename TMemberFunctionPointer>
 template <typename TImageType1, typename TImageType2>
 void
 DualMemberFunctionFactory<TMemberFunctionPointer>::Register(MemberFunctionType pfunc, TImageType1 *, TImageType2 *)
@@ -98,7 +91,7 @@ DualMemberFunctionFactory<TMemberFunctionPointer>::Register(MemberFunctionType p
   typename Superclass::KeyType key(
     TImageType1::GetImageDimension(), pixelID1, TImageType2::GetImageDimension(), pixelID2);
 
-  Superclass::m_PFunction[key] = Superclass::BindObject(pfunc, m_ObjectPointer);
+  Superclass::m_PFunction[key] = pfunc;
 }
 
 template <typename TMemberFunctionPointer>
@@ -148,9 +141,11 @@ DualMemberFunctionFactory<TMemberFunctionPointer>::HasMemberFunction(PixelIDValu
 
 template <typename TMemberFunctionPointer>
 typename DualMemberFunctionFactory<TMemberFunctionPointer>::FunctionObjectType
-DualMemberFunctionFactory<TMemberFunctionPointer>::GetMemberFunction(PixelIDValueType pixelID1,
-                                                                     PixelIDValueType pixelID2,
-                                                                     unsigned int     imageDimension)
+DualMemberFunctionFactory<TMemberFunctionPointer>::GetMemberFunction(
+  PixelIDValueType                                                pixelID1,
+  PixelIDValueType                                                pixelID2,
+  unsigned int                                                    imageDimension,
+  DualMemberFunctionFactory<TMemberFunctionPointer>::ObjectType * objectPointer) const
 {
   if (pixelID1 >= typelist2::length<InstantiatedPixelIDTypeList>::value || pixelID1 < 0)
   {
@@ -168,9 +163,9 @@ DualMemberFunctionFactory<TMemberFunctionPointer>::GetMemberFunction(PixelIDValu
   auto ret_pair = Superclass::m_PFunction.find(key);
   if (ret_pair != Superclass::m_PFunction.end())
   {
-    return ret_pair->second;
+    return Superclass::BindObject(ret_pair->second, objectPointer);
   }
-  // todo updated exceptions here
+
   sitkExceptionMacro(<< "Pixel type: " << GetPixelIDValueAsString(pixelID1) << " is not supported in " << imageDimension
                      << "D by" << typeid(ObjectType).name());
 }

--- a/Code/Common/include/sitkMemberFunctionFactory.h
+++ b/Code/Common/include/sitkMemberFunctionFactory.h
@@ -59,9 +59,7 @@ public:
   using ObjectType = typename ::detail::FunctionTraits<MemberFunctionType>::ClassType;
   using FunctionObjectType = typename Superclass::FunctionObjectType;
 
-  /** \brief Constructor which permanently binds the constructed
-   * object to pObject */
-  MemberFunctionFactory(ObjectType * pObject);
+  MemberFunctionFactory() = default;
 
   /** \brief Registers a specific member function.
    *
@@ -151,7 +149,7 @@ public:
   bool
   HasMemberFunction(PixelIDValueType pixelID, unsigned int imageDimension) const noexcept;
 
-  /** \brief Returns a function object for the PixelIndex, and image
+  /** \brief Returns a function object for the PixelID and image
    *  dimension.
    *
    *  pixelID is the value of Image::GetPixelIDValue(), or
@@ -171,10 +169,7 @@ public:
    *  guaranteed to be valid.
    */
   FunctionObjectType
-  GetMemberFunction(PixelIDValueType pixelID, unsigned int imageDimension);
-
-protected:
-  ObjectType * m_ObjectPointer;
+  GetMemberFunction(PixelIDValueType pixelID, unsigned int imageDimension, ObjectType * objectPointer) const;
 };
 
 } // namespace itk::simple::detail

--- a/Code/Common/include/sitkMemberFunctionFactory.hxx
+++ b/Code/Common/include/sitkMemberFunctionFactory.hxx
@@ -61,14 +61,6 @@ private:
 };
 
 template <typename TMemberFunctionPointer>
-MemberFunctionFactory<TMemberFunctionPointer>::MemberFunctionFactory(
-  typename MemberFunctionFactory::ObjectType * pObject)
-  : m_ObjectPointer(pObject)
-{
-  assert(pObject);
-}
-
-template <typename TMemberFunctionPointer>
 template <typename TImageType>
 void
 MemberFunctionFactory<TMemberFunctionPointer>::Register(typename MemberFunctionFactory::MemberFunctionType pfunc,
@@ -84,7 +76,7 @@ MemberFunctionFactory<TMemberFunctionPointer>::Register(typename MemberFunctionF
 
   auto key = std::pair<unsigned int, int>(TImageType::GetImageDimension(), pixelID);
 
-  Superclass::m_PFunction[key] = Superclass::BindObject(pfunc, m_ObjectPointer);
+  Superclass::m_PFunction[key] = pfunc;
 }
 
 template <typename TMemberFunctionPointer>
@@ -108,7 +100,7 @@ MemberFunctionFactory<TMemberFunctionPointer>::HasMemberFunction(PixelIDValueTyp
   auto key = typename Superclass::KeyType(imageDimension, pixelID);
   try
   {
-    // check if tr1::function has been set in map
+    // check if function has been set in map
     return Superclass::m_PFunction.find(key) != Superclass::m_PFunction.end();
   }
   // we do not throw exceptions
@@ -120,7 +112,10 @@ MemberFunctionFactory<TMemberFunctionPointer>::HasMemberFunction(PixelIDValueTyp
 
 template <typename TMemberFunctionPointer>
 typename MemberFunctionFactory<TMemberFunctionPointer>::FunctionObjectType
-MemberFunctionFactory<TMemberFunctionPointer>::GetMemberFunction(PixelIDValueType pixelID, unsigned int imageDimension)
+MemberFunctionFactory<TMemberFunctionPointer>::GetMemberFunction(
+  PixelIDValueType                                                     pixelID,
+  unsigned int                                                         imageDimension,
+  typename MemberFunctionFactory<TMemberFunctionPointer>::ObjectType * objectPointer) const
 {
   if (pixelID >= typelist2::length<InstantiatedPixelIDTypeList>::value || pixelID < 0)
   {
@@ -133,7 +128,7 @@ MemberFunctionFactory<TMemberFunctionPointer>::GetMemberFunction(PixelIDValueTyp
   auto ret_pair = Superclass::m_PFunction.find(key);
   if (ret_pair != Superclass::m_PFunction.end())
   {
-    return ret_pair->second;
+    return Superclass::BindObject(ret_pair->second, objectPointer);
   }
 
   sitkExceptionMacro(<< "Pixel type: " << GetPixelIDValueAsString(pixelID) << " is not supported in " << imageDimension

--- a/Code/Common/include/sitkMemberFunctionFactoryBase.h
+++ b/Code/Common/include/sitkMemberFunctionFactoryBase.h
@@ -116,7 +116,7 @@ protected:
   }
 
 
-  using FunctionMapType = std::unordered_map<TKey, FunctionObjectType, hash<TKey>>;
+  using FunctionMapType = std::unordered_map<TKey, MemberFunctionType, hash<TKey>>;
 
   // maps of Keys to pointers to member functions
   FunctionMapType m_PFunction;

--- a/Code/Common/include/sitkTemplateFunctions.h
+++ b/Code/Common/include/sitkTemplateFunctions.h
@@ -25,6 +25,7 @@
 #include <vector>
 #include <ostream>
 #include <iterator>
+#include <utility>
 
 namespace itk
 {
@@ -279,6 +280,21 @@ make_scope_exit(F && f) noexcept
   return scope_exit<F>{ std::forward<F>(f) };
 }
 
+namespace detail
+{
+
+template <typename T, T Offset, T... Is>
+struct make_offset_integer_sequence_helper
+{
+  using type = std::integer_sequence<T, Offset + Is...>;
+};
+} // namespace detail
+
+template <unsigned int Start, unsigned int Stop>
+using make_dimension_sequence =
+  detail::make_offset_integer_sequence_helper<unsigned int,
+                                              Start,
+                                              std::make_integer_sequence<unsigned int, Stop - Start + 1>::type>;
 
 } // namespace simple
 } // namespace itk

--- a/Code/Common/src/sitkImageExplicit.cxx
+++ b/Code/Common/src/sitkImageExplicit.cxx
@@ -74,11 +74,11 @@ Image::InternalInitialization(PixelIDValueType type, unsigned int dimension, itk
 
   typedef PimpleImageBase * (Self::*MemberFunctionType)(itk::DataObject *);
 
-  detail::MemberFunctionFactory<MemberFunctionType> memberFactory(this);
+  detail::MemberFunctionFactory<MemberFunctionType> memberFactory;
 
   memberFactory.RegisterMemberFunctions<PixelIDTypeList, 2, SITK_MAX_DIMENSION, Addressor>();
 
-  this->m_PimpleImage.reset(memberFactory.GetMemberFunction(type, dimension)(image));
+  this->m_PimpleImage.reset(memberFactory.GetMemberFunction(type, dimension, this)(image));
 }
 
 void
@@ -93,7 +93,7 @@ Image::Allocate(const std::vector<unsigned int> & _size, PixelIDValueEnum ValueE
 
   using AllocateAddressor = AllocateMemberFunctionAddressor;
 
-  detail::MemberFunctionFactory<MemberFunctionType> allocateMemberFactory(this);
+  detail::MemberFunctionFactory<MemberFunctionType> allocateMemberFactory;
   allocateMemberFactory.RegisterMemberFunctions<PixelIDTypeList, 2, SITK_MAX_DIMENSION, AllocateAddressor>();
 
   if (ValueEnum == sitkUnknown)
@@ -108,7 +108,7 @@ Image::Allocate(const std::vector<unsigned int> & _size, PixelIDValueEnum ValueE
                        << "The maximum supported Image dimension is " << SITK_MAX_DIMENSION << ".");
   }
 
-  allocateMemberFactory.GetMemberFunction(ValueEnum, _size.size())(_size, numberOfComponents);
+  allocateMemberFactory.GetMemberFunction(ValueEnum, _size.size(), this)(_size, numberOfComponents);
 }
 
 
@@ -121,7 +121,7 @@ Image::ToVectorImage(bool inPlace)
 
   typedef Image (Self::*MemberFunctionType)(bool);
 
-  detail::MemberFunctionFactory<MemberFunctionType> toVectorMemberFactory(this);
+  detail::MemberFunctionFactory<MemberFunctionType> toVectorMemberFactory;
 
   toVectorMemberFactory.RegisterMemberFunctions<PixelIDTypeList, 3, SITK_MAX_DIMENSION, ToVectorAddressor>();
   toVectorMemberFactory.RegisterMemberFunctions<VectorPixelIDTypeList, 2, 2, ToVectorAddressor>();
@@ -132,7 +132,7 @@ Image::ToVectorImage(bool inPlace)
                                                                       << this->GetDimension() << " to a vector image!");
   }
 
-  return toVectorMemberFactory.GetMemberFunction(this->GetPixelID(), this->GetDimension())(inPlace);
+  return toVectorMemberFactory.GetMemberFunction(this->GetPixelID(), this->GetDimension(), this)(inPlace);
 }
 
 Image
@@ -141,11 +141,10 @@ Image::ToScalarImage(bool inPlace)
   assert(m_PimpleImage);
 
   using PixelIDTypeList = typelist2::append<ScalarPixelIDTypeList, VectorPixelIDTypeList>::type;
-  ;
 
   typedef Image (Self::*MemberFunctionType)(bool);
 
-  detail::MemberFunctionFactory<MemberFunctionType> toScalarMemberFactory(this);
+  detail::MemberFunctionFactory<MemberFunctionType> toScalarMemberFactory;
 
   toScalarMemberFactory.RegisterMemberFunctions<PixelIDTypeList, 2, SITK_MAX_DIMENSION - 1, ToScalarAddressor>();
   toScalarMemberFactory
@@ -157,7 +156,7 @@ Image::ToScalarImage(bool inPlace)
                                                                       << this->GetDimension() << " to a scalar image!");
   }
 
-  return toScalarMemberFactory.GetMemberFunction(this->GetPixelID(), this->GetDimension())(inPlace);
+  return toScalarMemberFactory.GetMemberFunction(this->GetPixelID(), this->GetDimension(), this)(inPlace);
 }
 
 } // namespace itk::simple

--- a/Code/Common/src/sitkTransform.cxx
+++ b/Code/Common/src/sitkTransform.cxx
@@ -178,12 +178,12 @@ Transform::Transform(Image & image, TransformEnum txType)
 
     using Addressor = DisplacementInitializationMemberFunctionAddressor<MemberFunctionType>;
 
-    detail::MemberFunctionFactory<MemberFunctionType> initializationMemberFactory(this);
+    detail::MemberFunctionFactory<MemberFunctionType> initializationMemberFactory;
     initializationMemberFactory.RegisterMemberFunctions<PixelIDTypeList, 3, Addressor>();
     initializationMemberFactory.RegisterMemberFunctions<PixelIDTypeList, 2, Addressor>();
 
 
-    initializationMemberFactory.GetMemberFunction(type, dimension)(image);
+    initializationMemberFactory.GetMemberFunction(type, dimension, this)(image);
   }
   else if (txType == sitkBSplineTransform)
   {

--- a/Code/ElastixTransformixWrappers/src/sitkElastixImageFilterImpl.cxx
+++ b/Code/ElastixTransformixWrappers/src/sitkElastixImageFilterImpl.cxx
@@ -11,7 +11,7 @@ namespace itk::simple
 ElastixImageFilter::ElastixImageFilterImpl ::ElastixImageFilterImpl(void)
 {
   // Register this class with SimpleITK
-  this->m_DualMemberFactory = std::make_unique<detail::DualMemberFunctionFactory<MemberFunctionType>>(this);
+  this->m_DualMemberFactory = std::make_unique<detail::DualMemberFunctionFactory<MemberFunctionType>>();
   this->m_DualMemberFactory->RegisterMemberFunctions<FloatPixelIDTypeList, FloatPixelIDTypeList, 2>();
   this->m_DualMemberFactory->RegisterMemberFunctions<FloatPixelIDTypeList, FloatPixelIDTypeList, 3>();
 
@@ -183,7 +183,7 @@ ElastixImageFilter::ElastixImageFilterImpl ::Execute(void)
 
   if (this->m_DualMemberFactory->HasMemberFunction(sitkFloat32, sitkFloat32, FixedImageDimension))
   {
-    return this->m_DualMemberFactory->GetMemberFunction(sitkFloat32, sitkFloat32, FixedImageDimension)();
+    return this->m_DualMemberFactory->GetMemberFunction(sitkFloat32, sitkFloat32, FixedImageDimension, this)();
   }
 
   sitkExceptionMacro(<< "ElastixImageFilter does not support the combination of " << FixedImageDimension

--- a/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilterImpl.cxx
+++ b/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilterImpl.cxx
@@ -122,7 +122,7 @@ GetPixelIDValueFromElastixString(const std::string & enumString)
 TransformixImageFilter::TransformixImageFilterImpl ::TransformixImageFilterImpl()
 {
   // Register this class with SimpleITK
-  this->m_MemberFactory = std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>(this);
+  this->m_MemberFactory = std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>();
   this->m_MemberFactory->RegisterMemberFunctions<FloatPixelIDTypeList, 2>();
   this->m_MemberFactory->RegisterMemberFunctions<FloatPixelIDTypeList, 3>();
 
@@ -158,7 +158,7 @@ TransformixImageFilter::TransformixImageFilterImpl ::Execute()
 
   if (this->m_MemberFactory->HasMemberFunction(sitkFloat32, MovingImageDimension))
   {
-    return this->m_MemberFactory->GetMemberFunction(sitkFloat32, MovingImageDimension)();
+    return this->m_MemberFactory->GetMemberFunction(sitkFloat32, MovingImageDimension, this)();
   }
 
   sitkExceptionMacro(<< "TransformixImageFilter does not support the combination of image type "

--- a/Code/IO/src/sitkImageFileReader.cxx
+++ b/Code/IO/src/sitkImageFileReader.cxx
@@ -88,7 +88,7 @@ ImageFileReader::ImageFileReader()
   // list of pixel types supported
   using PixelIDTypeList = NonLabelPixelIDTypeList;
 
-  this->m_MemberFactory = std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>(this);
+  this->m_MemberFactory = std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>();
 
   this->m_MemberFactory->RegisterMemberFunctions<PixelIDTypeList, 2, SITK_MAX_DIMENSION>();
 }
@@ -337,7 +337,7 @@ ImageFileReader::Execute()
                        << "Refusing to load! " << std::endl);
   }
 
-  return this->m_MemberFactory->GetMemberFunction(type, dimension)(imageio.GetPointer());
+  return this->m_MemberFactory->GetMemberFunction(type, dimension, this)(imageio.GetPointer());
 }
 
 template <class TImageType>

--- a/Code/IO/src/sitkImageFileWriter.cxx
+++ b/Code/IO/src/sitkImageFileWriter.cxx
@@ -45,7 +45,7 @@ ImageFileWriter::ImageFileWriter()
   this->m_KeepOriginalImageUID = false;
   this->m_CompressionLevel = -1;
 
-  this->m_MemberFactory = std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>(this);
+  this->m_MemberFactory = std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>();
 
   this->m_MemberFactory->RegisterMemberFunctions<PixelIDTypeList, 1, SITK_MAX_DIMENSION>();
 }
@@ -170,7 +170,7 @@ ImageFileWriter::Execute(const Image & image)
   PixelIDValueType type = image.GetPixelIDValue();
   unsigned int     dimension = image.GetDimension();
 
-  return this->m_MemberFactory->GetMemberFunction(type, dimension)(image);
+  return this->m_MemberFactory->GetMemberFunction(type, dimension, this)(image);
 }
 
 

--- a/Code/IO/src/sitkImageSeriesReader.cxx
+++ b/Code/IO/src/sitkImageSeriesReader.cxx
@@ -142,7 +142,7 @@ ImageSeriesReader::ImageSeriesReader()
   // list of pixel types supported
   using PixelIDTypeList = NonLabelPixelIDTypeList;
 
-  this->m_MemberFactory = std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>(this);
+  this->m_MemberFactory = std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>();
 
   this->m_MemberFactory->RegisterMemberFunctions<PixelIDTypeList, 2, SITK_MAX_DIMENSION>();
 }
@@ -242,7 +242,7 @@ ImageSeriesReader::Execute()
                        << "Refusing to load! " << std::endl);
   }
 
-  return this->m_MemberFactory->GetMemberFunction(type, dimension)(imageio);
+  return this->m_MemberFactory->GetMemberFunction(type, dimension, this)(imageio);
 }
 
 

--- a/Code/IO/src/sitkImageSeriesWriter.cxx
+++ b/Code/IO/src/sitkImageSeriesWriter.cxx
@@ -51,7 +51,7 @@ ImageSeriesWriter::ImageSeriesWriter()
   // list of pixel types supported
   using PixelIDTypeList = NonLabelPixelIDTypeList;
 
-  this->m_MemberFactory = std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>(this);
+  this->m_MemberFactory = std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>();
 
   this->m_MemberFactory->RegisterMemberFunctions<PixelIDTypeList, 3>();
   // this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 2 > ();
@@ -204,7 +204,7 @@ ImageSeriesWriter::Execute(const Image & image)
   PixelIDValueType type = image.GetPixelIDValue();
   unsigned int     dimension = image.GetDimension();
 
-  this->m_MemberFactory->GetMemberFunction(type, dimension)(image);
+  this->m_MemberFactory->GetMemberFunction(type, dimension, this)(image);
 }
 
 template <class TImageType>

--- a/Code/IO/src/sitkImportImageFilter.cxx
+++ b/Code/IO/src/sitkImportImageFilter.cxx
@@ -221,11 +221,9 @@ ImportImageFilter::ImportImageFilter()
   // list of pixel types supported
   using PixelIDTypeList = NonLabelPixelIDTypeList;
 
-  this->m_MemberFactory = std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>(this);
+  this->m_MemberFactory = std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>();
 
-  this->m_MemberFactory->RegisterMemberFunctions<PixelIDTypeList, 4>();
-  this->m_MemberFactory->RegisterMemberFunctions<PixelIDTypeList, 3>();
-  this->m_MemberFactory->RegisterMemberFunctions<PixelIDTypeList, 2>();
+  this->m_MemberFactory->RegisterMemberFunctions<PixelIDTypeList, 2, 4>();
 }
 
 void
@@ -458,7 +456,7 @@ ImportImageFilter::Execute()
                        << "Refusing to load! " << std::endl);
   }
 
-  return this->m_MemberFactory->GetMemberFunction(this->m_PixelIDValue, imageDimension)();
+  return this->m_MemberFactory->GetMemberFunction(this->m_PixelIDValue, imageDimension, this)();
 }
 
 

--- a/Code/Registration/src/sitkImageRegistrationMethod.cxx
+++ b/Code/Registration/src/sitkImageRegistrationMethod.cxx
@@ -79,9 +79,9 @@ ImageRegistrationMethod::ImageRegistrationMethod()
   , m_SmoothingSigmasAreSpecifiedInPhysicalUnits(true)
   , m_ActiveOptimizer(NULL)
 {
-  m_MemberFactory = std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>(this);
+  m_MemberFactory = std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>();
 
-  m_EvaluateMemberFactory = std::make_unique<detail::MemberFunctionFactory<EvaluateMemberFunctionType>>(this);
+  m_EvaluateMemberFactory = std::make_unique<detail::MemberFunctionFactory<EvaluateMemberFunctionType>>();
 
   // m_MemberFactory->RegisterMemberFunctions< BasicPixelIDTypeList, 3 > ();
   // m_MemberFactory->RegisterMemberFunctions< BasicPixelIDTypeList, 2 > ();
@@ -759,7 +759,7 @@ ImageRegistrationMethod::Execute(const Image & fixed, const Image & moving)
 
   if (this->m_MemberFactory->HasMemberFunction(fixedType, fixedDim))
   {
-    return this->m_MemberFactory->GetMemberFunction(fixedType, fixedDim)(fixed, moving);
+    return this->m_MemberFactory->GetMemberFunction(fixedType, fixedDim, this)(fixed, moving);
   }
 
   sitkExceptionMacro(<< "Filter does not support fixed image type: "
@@ -1015,7 +1015,7 @@ ImageRegistrationMethod::MetricEvaluate(const Image & fixed, const Image & movin
 
   if (this->m_MemberFactory->HasMemberFunction(fixedType, fixedDim))
   {
-    return this->m_EvaluateMemberFactory->GetMemberFunction(fixedType, fixedDim)(fixed, moving);
+    return this->m_EvaluateMemberFactory->GetMemberFunction(fixedType, fixedDim, this)(fixed, moving);
   }
 
   sitkExceptionMacro(<< "Filter does not support fixed image type: "

--- a/ExpandTemplateGenerator/templates/ConstructorMemberFunctionSetup.cxx.jinja
+++ b/ExpandTemplateGenerator/templates/ConstructorMemberFunctionSetup.cxx.jinja
@@ -1,4 +1,4 @@
-  this->m_MemberFactory =  std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>( this );
+  this->m_MemberFactory =  std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>( );
 
 {%- if custom_register %}
   {{ custom_register }}

--- a/ExpandTemplateGenerator/templates/ExecuteNoParameters.cxx.jinja
+++ b/ExpandTemplateGenerator/templates/ExecuteNoParameters.cxx.jinja
@@ -35,7 +35,7 @@
     {%- endfor %}
   {%- endif %}
 
-  return this->m_MemberFactory->GetMemberFunction( type, dimension )(
+  return this->m_MemberFactory->GetMemberFunction( type, dimension, this )(
     {#- Pass numbered image arguments #}
     {{- range(1, number_of_inputs+1) | format_list('image{}') | join(', ') }}
     {%- set comma = joiner(', ') %}


### PR DESCRIPTION
Allow the function factories to be used between different instances of an object.