### PR TITLE
Make the Addressor constexpr

### DIFF
--- a/Code/BasicFilters/include/sitkCastImageFilter.h
+++ b/Code/BasicFilters/include/sitkCastImageFilter.h
@@ -111,7 +111,7 @@ private:
     using ObjectType = typename ::detail::FunctionTraits<TMemberFunctionPointer>::ClassType;
 
     template <typename TImageType1, typename TImageType2>
-    TMemberFunctionPointer
+    constexpr TMemberFunctionPointer
     operator()() const
     {
       return &ObjectType::template ExecuteInternalCast<TImageType1, TImageType2>;
@@ -127,7 +127,7 @@ private:
     using ObjectType = typename ::detail::FunctionTraits<TMemberFunctionPointer>::ClassType;
 
     template <typename TImageType1, typename TImageType2>
-    TMemberFunctionPointer
+    constexpr TMemberFunctionPointer
     operator()() const
     {
       return &ObjectType::template ExecuteInternalToVector<TImageType1, TImageType2>;
@@ -143,7 +143,7 @@ private:
     using ObjectType = typename ::detail::FunctionTraits<TMemberFunctionPointer>::ClassType;
 
     template <typename TImageType1, typename TImageType2>
-    TMemberFunctionPointer
+    constexpr TMemberFunctionPointer
     operator()() const
     {
       return &ObjectType::template ExecuteInternalToLabel<TImageType1, TImageType2>;
@@ -159,7 +159,7 @@ private:
     using ObjectType = typename ::detail::FunctionTraits<TMemberFunctionPointer>::ClassType;
 
     template <typename TImageType1, typename TImageType2>
-    TMemberFunctionPointer
+    constexpr TMemberFunctionPointer
     operator()() const
     {
       return &ObjectType::template ExecuteInternalLabelToImage<TImageType1, TImageType2>;

--- a/Code/Common/include/Ancillary/type_list2.h
+++ b/Code/Common/include/Ancillary/type_list2.h
@@ -168,7 +168,7 @@ struct visit<typelist<Ts...>>
 {
 
   template <typename Predicate>
-  void
+  constexpr void
   operator()(Predicate && visitor)
   {
     ((visitor.CLANG_TEMPLATE operator()<Ts>()), ...);
@@ -201,7 +201,7 @@ template <typename... Tls, typename... Trs>
 struct dual_visit<typelist<Tls...>, typelist<Trs...>>
 {
   template <typename Visitor>
-  void
+  constexpr void
   operator()(Visitor && visitor) const
   {
     ((right_visit<Tls>(visitor)), ...);
@@ -209,7 +209,7 @@ struct dual_visit<typelist<Tls...>, typelist<Trs...>>
 
 private:
   template <typename tl, typename Predicate>
-  static int
+  static constexpr int
   right_visit(Predicate && visitor)
   {
     ((visitor.CLANG_TEMPLATE operator()<tl, Trs>()), ...);

--- a/Code/Common/include/sitkDetail.h
+++ b/Code/Common/include/sitkDetail.h
@@ -31,7 +31,7 @@ struct MemberFunctionAddressor
   using ObjectType = typename ::detail::FunctionTraits<TMemberFunctionPointer>::ClassType;
 
   template <typename TImageType>
-  TMemberFunctionPointer
+  constexpr TMemberFunctionPointer
   operator()() const
   {
     return &ObjectType::template ExecuteInternal<TImageType>;
@@ -44,7 +44,7 @@ struct DualExecuteInternalAddressor
   using ObjectType = typename ::detail::FunctionTraits<TMemberFunctionPointer>::ClassType;
 
   template <typename TImageType1, typename TImageType2>
-  TMemberFunctionPointer
+  constexpr TMemberFunctionPointer
   operator()() const
   {
     return &ObjectType::template DualExecuteInternal<TImageType1, TImageType2>;
@@ -52,7 +52,7 @@ struct DualExecuteInternalAddressor
 
 
   template <typename TImageType>
-  TMemberFunctionPointer
+  constexpr TMemberFunctionPointer
   operator()() const
   {
     return &ObjectType::template DualExecuteInternal<TImageType, TImageType>;
@@ -68,7 +68,7 @@ struct ExecuteInternalVectorImageAddressor
   using ObjectType = typename ::detail::FunctionTraits<TMemberFunctionPointer>::ClassType;
 
   template <typename TImageType>
-  TMemberFunctionPointer
+  constexpr TMemberFunctionPointer
   operator()() const
   {
     return &ObjectType::template ExecuteInternalVectorImage<TImageType>;
@@ -85,7 +85,7 @@ struct DualExecuteInternalVectorAddressor
   using ObjectType = typename ::detail::FunctionTraits<TMemberFunctionPointer>::ClassType;
 
   template <typename TImageType1, typename TImageType2>
-  TMemberFunctionPointer
+  constexpr TMemberFunctionPointer
   operator()() const
   {
     return &ObjectType::template DualExecuteInternalVector<TImageType1, TImageType2>;
@@ -101,7 +101,7 @@ struct ExecuteInternalLabelImageAddressor
   using ObjectType = typename ::detail::FunctionTraits<TMemberFunctionPointer>::ClassType;
 
   template <typename TImageType>
-  TMemberFunctionPointer
+  constexpr TMemberFunctionPointer
   operator()() const
   {
     return &ObjectType::template ExecuteInternalLabelImage<TImageType>;

--- a/Code/Common/include/sitkTransform.h
+++ b/Code/Common/include/sitkTransform.h
@@ -327,7 +327,7 @@ private:
     using ObjectType = typename ::detail::FunctionTraits<TMemberFunctionPointer>::ClassType;
 
     template <typename TImageType>
-    TMemberFunctionPointer
+    constexpr TMemberFunctionPointer
     operator()() const
     {
       return &ObjectType::template InternalDisplacementInitialization<TImageType>;

--- a/Code/Common/src/sitkImageExplicit.cxx
+++ b/Code/Common/src/sitkImageExplicit.cxx
@@ -28,7 +28,7 @@ namespace itk::simple
 struct AllocateMemberFunctionAddressor
 {
   template <typename TImageType>
-  auto
+  constexpr auto
   operator()() const
   {
     return &Image::template AllocateInternal<TImageType>;
@@ -38,7 +38,7 @@ struct AllocateMemberFunctionAddressor
 struct DispatchedInternalInitialiationAddressor
 {
   template <typename TImageType>
-  auto
+  constexpr auto
   operator()() const
   {
     return &Image::template DispatchedInternalInitialization<TImageType>;
@@ -48,7 +48,7 @@ struct DispatchedInternalInitialiationAddressor
 struct ToVectorAddressor
 {
   template <typename TImageType>
-  auto
+  constexpr auto
   operator()() const
   {
     return &Image::template ToVectorInternal<TImageType>;
@@ -58,7 +58,7 @@ struct ToVectorAddressor
 struct ToScalarAddressor
 {
   template <typename TImageType>
-  auto
+  constexpr auto
   operator()() const
   {
     return &Image::template ToScalarInternal<TImageType>;

--- a/Code/Registration/include/sitkImageRegistrationMethod.h
+++ b/Code/Registration/include/sitkImageRegistrationMethod.h
@@ -822,7 +822,7 @@ private:
     using ObjectType = typename ::detail::FunctionTraits<TMemberFunctionPointer>::ClassType;
 
     template <typename TImageType>
-    TMemberFunctionPointer
+    constexpr TMemberFunctionPointer
     operator()() const
     {
       return &ObjectType::template EvaluateInternal<TImageType>;


### PR DESCRIPTION
Explicitly declare methods as constexpr to support additional compile time creation of objects. 