### PR TITLE
COMP: address issue with recursive_directory_iterator on OSX CI.

### DIFF
--- a/Examples/DicomConvert/CMakeLists.txt
+++ b/Examples/DicomConvert/CMakeLists.txt
@@ -63,6 +63,6 @@ sitk_add_test(
   NAME CXX.Example.DicomConvert
   COMMAND
     $<TARGET_FILE:DicomConvert>
-    DATA{${SimpleITK_DATA_ROOT}/Input/DicomSeries/,REGEX:Image[0-9]+.dcm} jpg
-    --w 64 --od "${out_dir}"
+    DATA{${SimpleITK_DATA_ROOT}/Input/DicomSeries/Image0076.dcm}
+    "${out_dir}/result.jpg" --w 64
 )


### PR DESCRIPTION
The 'recursive_directory_iterator' used in the example is unavailable on the OSX CI (error message says this iterator was introduced in macOS 10.15). As this is not a key feature of the example, it was simplified and no longer uses the iterator. Now, a given DICOM file is converted to the specified output format.