### PR TITLE
Use a singleton for function factory in coded filter

### DIFF
--- a/Code/BasicFilters/include/sitkBSplineTransformInitializerFilter.h
+++ b/Code/BasicFilters/include/sitkBSplineTransformInitializerFilter.h
@@ -124,11 +124,11 @@ private:
 
   friend struct detail::MemberFunctionAddressor<MemberFunctionType>;
 
-  std::unique_ptr<detail::MemberFunctionFactory<MemberFunctionType>> m_MemberFactory;
+  static const detail::MemberFunctionFactory<MemberFunctionType> &
+  GetMemberFunctionFactory();
 
-
-  std::vector<uint32_t> m_TransformDomainMeshSize;
-  unsigned int          m_Order;
+  std::vector<uint32_t> m_TransformDomainMeshSize{ std::vector<uint32_t>(3, 1u) };
+  unsigned int          m_Order{ 3u };
 };
 
 

--- a/Code/BasicFilters/include/sitkCastImageFilter.h
+++ b/Code/BasicFilters/include/sitkCastImageFilter.h
@@ -71,7 +71,7 @@ public:
   Execute(const Image &);
 
 private:
-  PixelIDValueEnum m_OutputPixelType;
+  PixelIDValueEnum m_OutputPixelType{ sitkFloat32 };
 
   /** Methods to actually implement conversion from one image type
    * to another.
@@ -167,30 +167,33 @@ private:
   };
 #endif
 
+  typedef Image (Self::*MemberFunctionType)(const Image &);
+
   /**
    * These methods are used to instantiate and register member functions
    * with the factory. Each function is split into a separate file to
    * make the compilation units smaller, and take less time to compile.
    * @{
    */
-  void
-  RegisterMemberFactory2();
-  void
-  RegisterMemberFactory2v();
-  void
-  RegisterMemberFactory2l();
-  void
-  RegisterMemberFactory3();
-  void
-  RegisterMemberFactory3v();
-  void
-  RegisterMemberFactory3l();
-  void
-  RegisterMemberFactory4();
+  static void
+  RegisterMemberFactory2(detail::DualMemberFunctionFactory<MemberFunctionType> & factory);
+  static void
+  RegisterMemberFactory2v(detail::DualMemberFunctionFactory<MemberFunctionType> & factory);
+  static void
+  RegisterMemberFactory2l(detail::DualMemberFunctionFactory<MemberFunctionType> & factory);
+  static void
+  RegisterMemberFactory3(detail::DualMemberFunctionFactory<MemberFunctionType> & factory);
+  static void
+  RegisterMemberFactory3v(detail::DualMemberFunctionFactory<MemberFunctionType> & factory);
+  static void
+  RegisterMemberFactory3l(detail::DualMemberFunctionFactory<MemberFunctionType> & factory);
+  static void
+  RegisterMemberFactory4(detail::DualMemberFunctionFactory<MemberFunctionType> & factory);
   /** @} */
 
-  typedef Image (Self::*MemberFunctionType)(const Image &);
-  std::unique_ptr<detail::DualMemberFunctionFactory<MemberFunctionType>> m_DualMemberFactory;
+
+  static const detail::DualMemberFunctionFactory<MemberFunctionType> &
+  GetMemberFunctionFactory();
 };
 
 SITKBasicFilters_EXPORT Image

--- a/Code/BasicFilters/include/sitkCenteredTransformInitializerFilter.h
+++ b/Code/BasicFilters/include/sitkCenteredTransformInitializerFilter.h
@@ -146,10 +146,11 @@ private:
 
   friend struct detail::MemberFunctionAddressor<MemberFunctionType>;
 
-  std::unique_ptr<detail::MemberFunctionFactory<MemberFunctionType>> m_MemberFactory;
+  static const detail::MemberFunctionFactory<MemberFunctionType> &
+  GetMemberFunctionFactory();
 
 
-  OperationModeType m_OperationMode;
+  OperationModeType m_OperationMode{ MOMENTS };
 };
 
 /**

--- a/Code/BasicFilters/include/sitkCenteredVersorTransformInitializerFilter.h
+++ b/Code/BasicFilters/include/sitkCenteredVersorTransformInitializerFilter.h
@@ -121,10 +121,12 @@ private:
 
   friend struct detail::MemberFunctionAddressor<MemberFunctionType>;
 
-  std::unique_ptr<detail::MemberFunctionFactory<MemberFunctionType>> m_MemberFactory;
+  static const detail::MemberFunctionFactory<MemberFunctionType> &
+  GetMemberFunctionFactory();
 
 
-  bool m_ComputeRotation;
+  /*  */
+  bool m_ComputeRotation{ false };
 };
 
 

--- a/Code/BasicFilters/include/sitkExtractImageFilter.h
+++ b/Code/BasicFilters/include/sitkExtractImageFilter.h
@@ -199,8 +199,8 @@ private:
 
   friend struct detail::MemberFunctionAddressor<MemberFunctionType>;
 
-  std::unique_ptr<detail::MemberFunctionFactory<MemberFunctionType>> m_MemberFactory;
-
+  static const detail::MemberFunctionFactory<MemberFunctionType> &
+  GetMemberFunctionFactory();
 
   template <class TImageType, unsigned int OutputDimension>
   Image

--- a/Code/BasicFilters/include/sitkHashImageFilter.h
+++ b/Code/BasicFilters/include/sitkHashImageFilter.h
@@ -74,7 +74,7 @@ public:
 
 
 private:
-  HashFunction m_HashFunction;
+  HashFunction m_HashFunction{ SHA1 };
 
   template <class TImageType>
   std::string
@@ -87,7 +87,8 @@ private:
   friend struct detail::MemberFunctionAddressor<MemberFunctionType>;
   friend struct detail::ExecuteInternalLabelImageAddressor<MemberFunctionType>;
 
-  std::unique_ptr<detail::MemberFunctionFactory<MemberFunctionType>> m_MemberFactory;
+  static const detail::MemberFunctionFactory<MemberFunctionType> &
+  GetMemberFunctionFactory();
 };
 
 SITKBasicFilters_EXPORT std::string

--- a/Code/BasicFilters/include/sitkLandmarkBasedTransformInitializerFilter.h
+++ b/Code/BasicFilters/include/sitkLandmarkBasedTransformInitializerFilter.h
@@ -203,7 +203,8 @@ private:
 
   friend struct detail::MemberFunctionAddressor<MemberFunctionType>;
 
-  std::unique_ptr<detail::MemberFunctionFactory<MemberFunctionType>> m_MemberFactory;
+  static const detail::MemberFunctionFactory<MemberFunctionType> &
+  GetMemberFunctionFactory();
 
 
   /*  */
@@ -214,7 +215,7 @@ private:
   std::vector<double> m_LandmarkWeight;
 
   Image        m_ReferenceImage;
-  unsigned int m_BSplineNumberOfControlPoints;
+  unsigned int m_BSplineNumberOfControlPoints{ 4u };
 };
 
 

--- a/Code/BasicFilters/include/sitkPasteImageFilter.h
+++ b/Code/BasicFilters/include/sitkPasteImageFilter.h
@@ -191,18 +191,22 @@ private:
   ExecuteInternal(const TImageType *                      destinationImage,
                   const Image *                           sourceImage,
                   std::integral_constant<unsigned int, 1> meta);
+  template <class TImageType>
+  Image
+  ExecuteInternal(const Image * image, double constant);
 
 
   friend struct detail::MemberFunctionAddressor<MemberFunctionType>;
 
-  std::unique_ptr<detail::MemberFunctionFactory<MemberFunctionType>> m_MemberFactory;
-
   using MemberFunction2Type = Image (Self::*)(const Image * image, double constant);
-  template <class TImageType>
-  Image
-  ExecuteInternal(const Image * image, double constant);
+
+
   friend struct detail::MemberFunctionAddressor<MemberFunction2Type>;
-  std::unique_ptr<detail::MemberFunctionFactory<MemberFunction2Type>> m_MemberFactory2;
+
+  static const detail::MemberFunctionFactory<MemberFunctionType> &
+  GetMemberFunctionFactory();
+  static const detail::MemberFunctionFactory<MemberFunction2Type> &
+  GetMemberFunctionFactory2();
 
 
   std::vector<unsigned int> m_SourceSize{ std::vector<unsigned int>(SITK_MAX_DIMENSION, 1) };

--- a/Code/BasicFilters/json/BinaryProjectionImageFilter.json
+++ b/Code/BasicFilters/json/BinaryProjectionImageFilter.json
@@ -5,7 +5,7 @@
   "number_of_inputs": 1,
   "doc": "",
   "pixel_types": "BasicPixelIDTypeList",
-  "custom_register": "this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 2, SITK_MAX_DIMENSION > ();\n",
+  "custom_register": "factory.RegisterMemberFunctions< PixelIDTypeList, 2, SITK_MAX_DIMENSION > ();\n",
   "members": [
     {
       "name": "ProjectionDimension",

--- a/Code/BasicFilters/json/DICOMOrientImageFilter.json
+++ b/Code/BasicFilters/json/DICOMOrientImageFilter.json
@@ -4,7 +4,7 @@
   "template_test_filename": "ImageFilter",
   "number_of_inputs": 1,
   "pixel_types": "typelist2::append<BasicPixelIDTypeList, VectorPixelIDTypeList>::type",
-  "custom_register": "this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 3 > ();\n",
+  "custom_register": "factory.RegisterMemberFunctions< PixelIDTypeList, 3 > ();\n",
   "public_declarations": "static std::string GetOrientationFromDirectionCosines( const std::vector<double> &direction );\n   static std::vector<double> GetDirectionCosinesFromOrientation( const std::string &str );",
   "filter_type": "itk::DICOMOrientImageFilter<InputImageType>",
   "members": [

--- a/Code/BasicFilters/json/JoinSeriesImageFilter.json
+++ b/Code/BasicFilters/json/JoinSeriesImageFilter.json
@@ -5,7 +5,7 @@
   "number_of_inputs": 1,
   "pixel_types": "NonLabelPixelIDTypeList",
   "output_image_type": "typename InputImageType::template RebindImageType<typename InputImageType::PixelType, InputImageType::ImageDimension+1>",
-  "custom_register": "this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 2, SITK_MAX_DIMENSION-1 > ();\n",
+  "custom_register": "factory.RegisterMemberFunctions< PixelIDTypeList, 2, SITK_MAX_DIMENSION-1 > ();\n",
   "members": [
     {
       "name": "Origin",

--- a/Code/BasicFilters/json/MaskImageFilter.json
+++ b/Code/BasicFilters/json/MaskImageFilter.json
@@ -10,7 +10,7 @@
   ],
   "pixel_types": "NonLabelPixelIDTypeList",
   "pixel_types2": "MaskedPixelIDTypeList",
-  "custom_type2": "PixelIDValueEnum type2 = maskImage.GetPixelID();\n  if (!this->m_DualMemberFactory->HasMemberFunction( type1, type2, dimension ) && TypeListHasPixelIDValue<IntegerPixelIDTypeList>(type2)) { type2 = sitkUInt8; }",
+  "custom_type2": "PixelIDValueEnum type2 = maskImage.GetPixelID();\n  if (!GetMemberFunctionFactory().HasMemberFunction( type1, type2, dimension ) && TypeListHasPixelIDValue<IntegerPixelIDTypeList>(type2)) { type2 = sitkUInt8; }",
   "inputs": [
     {
       "name": "Image",

--- a/Code/BasicFilters/json/MaximumProjectionImageFilter.json
+++ b/Code/BasicFilters/json/MaximumProjectionImageFilter.json
@@ -6,7 +6,7 @@
   "doc": "",
   "pixel_types": "BasicPixelIDTypeList",
   "vector_pixel_types_by_component": "VectorPixelIDTypeList",
-  "custom_register": "this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 2, SITK_MAX_DIMENSION > ();\n",
+  "custom_register": "factory.RegisterMemberFunctions< PixelIDTypeList, 2, SITK_MAX_DIMENSION > ();\n",
   "members": [
     {
       "name": "ProjectionDimension",

--- a/Code/BasicFilters/json/MeanImageFilter.json
+++ b/Code/BasicFilters/json/MeanImageFilter.json
@@ -5,7 +5,7 @@
   "number_of_inputs": 1,
   "doc": "",
   "pixel_types": "NonLabelPixelIDTypeList",
-  "custom_register": "this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 2, SITK_MAX_DIMENSION > ();\n",
+  "custom_register": "factory.RegisterMemberFunctions< PixelIDTypeList, 2, SITK_MAX_DIMENSION > ();\n",
   "members": [
     {
       "name": "Radius",

--- a/Code/BasicFilters/json/MedianProjectionImageFilter.json
+++ b/Code/BasicFilters/json/MedianProjectionImageFilter.json
@@ -6,7 +6,7 @@
   "doc": "",
   "pixel_types": "BasicPixelIDTypeList",
   "vector_pixel_types_by_component": "VectorPixelIDTypeList",
-  "custom_register": "this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 2, SITK_MAX_DIMENSION > ();\n",
+  "custom_register": "factory.RegisterMemberFunctions< PixelIDTypeList, 2, SITK_MAX_DIMENSION > ();\n",
   "members": [
     {
       "name": "ProjectionDimension",

--- a/Code/BasicFilters/json/MinimumImageFilter.json
+++ b/Code/BasicFilters/json/MinimumImageFilter.json
@@ -6,7 +6,7 @@
   "number_of_inputs": 2,
   "doc": "Some global documentation",
   "pixel_types": "BasicPixelIDTypeList",
-  "custom_register": "this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 2, SITK_MAX_DIMENSION > ();\n",
+  "custom_register": "factory.RegisterMemberFunctions< PixelIDTypeList, 2, SITK_MAX_DIMENSION > ();\n",
   "members": [],
   "tests": [
     {

--- a/Code/BasicFilters/json/MinimumProjectionImageFilter.json
+++ b/Code/BasicFilters/json/MinimumProjectionImageFilter.json
@@ -6,7 +6,7 @@
   "doc": "",
   "pixel_types": "BasicPixelIDTypeList",
   "vector_pixel_types_by_component": "VectorPixelIDTypeList",
-  "custom_register": "this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 2, SITK_MAX_DIMENSION > ();\n",
+  "custom_register": "factory.RegisterMemberFunctions< PixelIDTypeList, 2, SITK_MAX_DIMENSION > ();\n",
   "members": [
     {
       "name": "ProjectionDimension",

--- a/Code/BasicFilters/json/PermuteAxesImageFilter.json
+++ b/Code/BasicFilters/json/PermuteAxesImageFilter.json
@@ -7,7 +7,7 @@
   "pixel_types": "NonLabelPixelIDTypeList",
   "filter_type": "itk::PermuteAxesImageFilter< InputImageType >",
   "public_declarations": "static const std::vector<unsigned int> DefaultOrder;",
-  "custom_register": "this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 2, SITK_MAX_DIMENSION > ();\n",
+  "custom_register": "factory.RegisterMemberFunctions< PixelIDTypeList, 2, SITK_MAX_DIMENSION > ();\n",
   "include_files": [
     "sitkPermuteAxis_Static.hxx"
   ],

--- a/Code/BasicFilters/json/SliceImageFilter.json
+++ b/Code/BasicFilters/json/SliceImageFilter.json
@@ -4,7 +4,7 @@
   "template_test_filename": "ImageFilter",
   "number_of_inputs": 1,
   "pixel_types": "NonLabelPixelIDTypeList",
-  "custom_register": "this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 2, SITK_MAX_DIMENSION > ();\n",
+  "custom_register": "factory.RegisterMemberFunctions< PixelIDTypeList, 2, SITK_MAX_DIMENSION > ();\n",
   "members": [
     {
       "name": "Start",

--- a/Code/BasicFilters/json/StandardDeviationProjectionImageFilter.json
+++ b/Code/BasicFilters/json/StandardDeviationProjectionImageFilter.json
@@ -6,7 +6,7 @@
   "doc": "",
   "pixel_types": "BasicPixelIDTypeList",
   "output_pixel_type": "typename itk::NumericTraits<typename InputImageType::PixelType>::RealType",
-  "custom_register": "this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 2, SITK_MAX_DIMENSION > ();\n",
+  "custom_register": "factory.RegisterMemberFunctions< PixelIDTypeList, 2, SITK_MAX_DIMENSION > ();\n",
   "members": [
     {
       "name": "ProjectionDimension",

--- a/Code/BasicFilters/json/SumProjectionImageFilter.json
+++ b/Code/BasicFilters/json/SumProjectionImageFilter.json
@@ -6,7 +6,7 @@
   "pixel_types": "BasicPixelIDTypeList",
   "output_pixel_type": "typename itk::NumericTraits<typename InputImageType::PixelType>::RealType",
   "vector_pixel_types_by_component": "VectorPixelIDTypeList",
-  "custom_register": "this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 2, SITK_MAX_DIMENSION > ();\n",
+  "custom_register": "factory.RegisterMemberFunctions< PixelIDTypeList, 2, SITK_MAX_DIMENSION > ();\n",
   "members": [
     {
       "name": "ProjectionDimension",

--- a/Code/BasicFilters/src/sitkBSplineTransformInitializerFilter.cxx
+++ b/Code/BasicFilters/src/sitkBSplineTransformInitializerFilter.cxx
@@ -48,14 +48,14 @@ BSplineTransformInitializerFilter::BSplineTransformInitializerFilter() = default
 const detail::MemberFunctionFactory<BSplineTransformInitializerFilter::MemberFunctionType> &
 BSplineTransformInitializerFilter::GetMemberFunctionFactory()
 {
-  static detail::MemberFunctionFactory<MemberFunctionType> factory = [] {
+  static detail::MemberFunctionFactory<MemberFunctionType> static_factory = [] {
     detail::MemberFunctionFactory<MemberFunctionType> factory;
     factory.RegisterMemberFunctions<PixelIDTypeList, 3>();
     factory.RegisterMemberFunctions<PixelIDTypeList, 2>();
     return factory;
   }();
 
-  return factory;
+  return static_factory;
 }
 
 //

--- a/Code/BasicFilters/src/sitkCastImageFilter-2.cxx
+++ b/Code/BasicFilters/src/sitkCastImageFilter-2.cxx
@@ -24,19 +24,17 @@ namespace itk::simple
 
 
 void
-CastImageFilter::RegisterMemberFactory2()
+CastImageFilter::RegisterMemberFactory2(detail::DualMemberFunctionFactory<MemberFunctionType> & factory)
 {
   // cast between complex pixels and complex pixel
-  m_DualMemberFactory
-    ->RegisterMemberFunctions<ComplexPixelIDTypeList, ComplexPixelIDTypeList, 2, CastAddressor<MemberFunctionType>>();
+  factory
+    .RegisterMemberFunctions<ComplexPixelIDTypeList, ComplexPixelIDTypeList, 2, CastAddressor<MemberFunctionType>>();
 
   // cast between basic pixels and complex number pixels
-  m_DualMemberFactory
-    ->RegisterMemberFunctions<BasicPixelIDTypeList, ComplexPixelIDTypeList, 2, CastAddressor<MemberFunctionType>>();
+  factory.RegisterMemberFunctions<BasicPixelIDTypeList, ComplexPixelIDTypeList, 2, CastAddressor<MemberFunctionType>>();
 
   // cast between basic images
-  m_DualMemberFactory
-    ->RegisterMemberFunctions<BasicPixelIDTypeList, BasicPixelIDTypeList, 2, CastAddressor<MemberFunctionType>>();
+  factory.RegisterMemberFunctions<BasicPixelIDTypeList, BasicPixelIDTypeList, 2, CastAddressor<MemberFunctionType>>();
 }
 
 } // namespace itk::simple

--- a/Code/BasicFilters/src/sitkCastImageFilter-2l.cxx
+++ b/Code/BasicFilters/src/sitkCastImageFilter-2l.cxx
@@ -24,15 +24,15 @@ namespace itk::simple
 
 
 void
-CastImageFilter::RegisterMemberFactory2l()
+CastImageFilter::RegisterMemberFactory2l(detail::DualMemberFunctionFactory<MemberFunctionType> & factory)
 {
   // basic to Label
-  m_DualMemberFactory
-    ->RegisterMemberFunctions<IntegerPixelIDTypeList, LabelPixelIDTypeList, 2, ToLabelAddressor<MemberFunctionType>>();
+  factory
+    .RegisterMemberFunctions<IntegerPixelIDTypeList, LabelPixelIDTypeList, 2, ToLabelAddressor<MemberFunctionType>>();
 
   // Label to basic
-  m_DualMemberFactory
-    ->RegisterMemberFunctions<LabelPixelIDTypeList, IntegerPixelIDTypeList, 2, LabelToAddressor<MemberFunctionType>>();
+  factory
+    .RegisterMemberFunctions<LabelPixelIDTypeList, IntegerPixelIDTypeList, 2, LabelToAddressor<MemberFunctionType>>();
 }
 
 } // namespace itk::simple

--- a/Code/BasicFilters/src/sitkCastImageFilter-2v.cxx
+++ b/Code/BasicFilters/src/sitkCastImageFilter-2v.cxx
@@ -24,16 +24,14 @@ namespace itk::simple
 
 
 void
-CastImageFilter::RegisterMemberFactory2v()
+CastImageFilter::RegisterMemberFactory2v(detail::DualMemberFunctionFactory<MemberFunctionType> & factory)
 {
-
   // cast between vector images
-  m_DualMemberFactory
-    ->RegisterMemberFunctions<VectorPixelIDTypeList, VectorPixelIDTypeList, 2, CastAddressor<MemberFunctionType>>();
+  factory.RegisterMemberFunctions<VectorPixelIDTypeList, VectorPixelIDTypeList, 2, CastAddressor<MemberFunctionType>>();
 
   // basic to vector
-  m_DualMemberFactory
-    ->RegisterMemberFunctions<BasicPixelIDTypeList, VectorPixelIDTypeList, 2, ToVectorAddressor<MemberFunctionType>>();
+  factory
+    .RegisterMemberFunctions<BasicPixelIDTypeList, VectorPixelIDTypeList, 2, ToVectorAddressor<MemberFunctionType>>();
 }
 
 } // namespace itk::simple

--- a/Code/BasicFilters/src/sitkCastImageFilter-3.cxx
+++ b/Code/BasicFilters/src/sitkCastImageFilter-3.cxx
@@ -24,19 +24,17 @@ namespace itk::simple
 
 
 void
-CastImageFilter::RegisterMemberFactory3()
+CastImageFilter::RegisterMemberFactory3(detail::DualMemberFunctionFactory<MemberFunctionType> & factory)
 {
   // cast between complex pixels and complex pixel
-  m_DualMemberFactory
-    ->RegisterMemberFunctions<ComplexPixelIDTypeList, ComplexPixelIDTypeList, 3, CastAddressor<MemberFunctionType>>();
+  factory
+    .RegisterMemberFunctions<ComplexPixelIDTypeList, ComplexPixelIDTypeList, 3, CastAddressor<MemberFunctionType>>();
 
   // cast between basic pixels and complex number pixels
-  m_DualMemberFactory
-    ->RegisterMemberFunctions<BasicPixelIDTypeList, ComplexPixelIDTypeList, 3, CastAddressor<MemberFunctionType>>();
+  factory.RegisterMemberFunctions<BasicPixelIDTypeList, ComplexPixelIDTypeList, 3, CastAddressor<MemberFunctionType>>();
 
   // cast between basic images
-  m_DualMemberFactory
-    ->RegisterMemberFunctions<BasicPixelIDTypeList, BasicPixelIDTypeList, 3, CastAddressor<MemberFunctionType>>();
+  factory.RegisterMemberFunctions<BasicPixelIDTypeList, BasicPixelIDTypeList, 3, CastAddressor<MemberFunctionType>>();
 }
 
 } // namespace itk::simple

--- a/Code/BasicFilters/src/sitkCastImageFilter-3l.cxx
+++ b/Code/BasicFilters/src/sitkCastImageFilter-3l.cxx
@@ -24,15 +24,15 @@ namespace itk::simple
 
 
 void
-CastImageFilter::RegisterMemberFactory3l()
+CastImageFilter::RegisterMemberFactory3l(detail::DualMemberFunctionFactory<MemberFunctionType> & factory)
 {
   // basic to Label
-  m_DualMemberFactory
-    ->RegisterMemberFunctions<IntegerPixelIDTypeList, LabelPixelIDTypeList, 3, ToLabelAddressor<MemberFunctionType>>();
+  factory
+    .RegisterMemberFunctions<IntegerPixelIDTypeList, LabelPixelIDTypeList, 3, ToLabelAddressor<MemberFunctionType>>();
 
   // Label to basic
-  m_DualMemberFactory
-    ->RegisterMemberFunctions<LabelPixelIDTypeList, IntegerPixelIDTypeList, 3, LabelToAddressor<MemberFunctionType>>();
+  factory
+    .RegisterMemberFunctions<LabelPixelIDTypeList, IntegerPixelIDTypeList, 3, LabelToAddressor<MemberFunctionType>>();
 }
 
 } // namespace itk::simple

--- a/Code/BasicFilters/src/sitkCastImageFilter-3v.cxx
+++ b/Code/BasicFilters/src/sitkCastImageFilter-3v.cxx
@@ -24,16 +24,14 @@ namespace itk::simple
 
 
 void
-CastImageFilter::RegisterMemberFactory3v()
+CastImageFilter::RegisterMemberFactory3v(detail::DualMemberFunctionFactory<MemberFunctionType> & factory)
 {
-
   // cast between vector images
-  m_DualMemberFactory
-    ->RegisterMemberFunctions<VectorPixelIDTypeList, VectorPixelIDTypeList, 3, CastAddressor<MemberFunctionType>>();
+  factory.RegisterMemberFunctions<VectorPixelIDTypeList, VectorPixelIDTypeList, 3, CastAddressor<MemberFunctionType>>();
 
   // basic to vector
-  m_DualMemberFactory
-    ->RegisterMemberFunctions<BasicPixelIDTypeList, VectorPixelIDTypeList, 3, ToVectorAddressor<MemberFunctionType>>();
+  factory
+    .RegisterMemberFunctions<BasicPixelIDTypeList, VectorPixelIDTypeList, 3, ToVectorAddressor<MemberFunctionType>>();
 }
 
 } // namespace itk::simple

--- a/Code/BasicFilters/src/sitkCastImageFilter-4.cxx
+++ b/Code/BasicFilters/src/sitkCastImageFilter-4.cxx
@@ -24,23 +24,21 @@ namespace itk::simple
 
 
 void
-CastImageFilter::RegisterMemberFactory4()
+CastImageFilter::RegisterMemberFactory4(detail::DualMemberFunctionFactory<MemberFunctionType> & factory
+                                        [[maybe_unused]])
 {
 #if SITK_MAX_DIMENSION >= 4 && defined(SITK_USE_ELASTIX)
-  m_DualMemberFactory
-    ->RegisterMemberFunctions<ComplexPixelIDTypeList, ComplexPixelIDTypeList, 4, CastAddressor<MemberFunctionType>>();
-  m_DualMemberFactory
-    ->RegisterMemberFunctions<BasicPixelIDTypeList, ComplexPixelIDTypeList, 4, CastAddressor<MemberFunctionType>>();
-  m_DualMemberFactory
-    ->RegisterMemberFunctions<BasicPixelIDTypeList, BasicPixelIDTypeList, 4, CastAddressor<MemberFunctionType>>();
-  m_DualMemberFactory
-    ->RegisterMemberFunctions<IntegerPixelIDTypeList, LabelPixelIDTypeList, 4, ToLabelAddressor<MemberFunctionType>>();
-  m_DualMemberFactory
-    ->RegisterMemberFunctions<LabelPixelIDTypeList, IntegerPixelIDTypeList, 4, LabelToAddressor<MemberFunctionType>>();
-  m_DualMemberFactory
-    ->RegisterMemberFunctions<VectorPixelIDTypeList, VectorPixelIDTypeList, 4, CastAddressor<MemberFunctionType>>();
-  m_DualMemberFactory
-    ->RegisterMemberFunctions<BasicPixelIDTypeList, VectorPixelIDTypeList, 4, ToVectorAddressor<MemberFunctionType>>();
+  factory
+    .RegisterMemberFunctions<ComplexPixelIDTypeList, ComplexPixelIDTypeList, 4, CastAddressor<MemberFunctionType>>();
+  factory.RegisterMemberFunctions<BasicPixelIDTypeList, ComplexPixelIDTypeList, 4, CastAddressor<MemberFunctionType>>();
+  factory.RegisterMemberFunctions<BasicPixelIDTypeList, BasicPixelIDTypeList, 4, CastAddressor<MemberFunctionType>>();
+  factory
+    .RegisterMemberFunctions<IntegerPixelIDTypeList, LabelPixelIDTypeList, 4, ToLabelAddressor<MemberFunctionType>>();
+  factory
+    .RegisterMemberFunctions<LabelPixelIDTypeList, IntegerPixelIDTypeList, 4, LabelToAddressor<MemberFunctionType>>();
+  factory.RegisterMemberFunctions<VectorPixelIDTypeList, VectorPixelIDTypeList, 4, CastAddressor<MemberFunctionType>>();
+  factory
+    .RegisterMemberFunctions<BasicPixelIDTypeList, VectorPixelIDTypeList, 4, ToVectorAddressor<MemberFunctionType>>();
 #endif
 }
 

--- a/Code/BasicFilters/src/sitkCastImageFilter.cxx
+++ b/Code/BasicFilters/src/sitkCastImageFilter.cxx
@@ -33,7 +33,7 @@ CastImageFilter::~CastImageFilter() = default;
 const detail::DualMemberFunctionFactory<CastImageFilter::MemberFunctionType> &
 CastImageFilter::GetMemberFunctionFactory()
 {
-  static detail::DualMemberFunctionFactory<MemberFunctionType> factory = [] {
+  static detail::DualMemberFunctionFactory<MemberFunctionType> static_factory = [] {
     detail::DualMemberFunctionFactory<MemberFunctionType> factory;
     RegisterMemberFactory2(factory);
     RegisterMemberFactory2v(factory);
@@ -45,7 +45,7 @@ CastImageFilter::GetMemberFunctionFactory()
     return factory;
   }();
 
-  return factory;
+  return static_factory;
 }
 
 CastImageFilter::CastImageFilter() = default;

--- a/Code/BasicFilters/src/sitkCastImageFilter.cxx
+++ b/Code/BasicFilters/src/sitkCastImageFilter.cxx
@@ -30,21 +30,26 @@ CastImageFilter::~CastImageFilter() = default;
 //
 // Default constructor that initializes parameters
 //
-CastImageFilter::CastImageFilter()
+const detail::DualMemberFunctionFactory<CastImageFilter::MemberFunctionType> &
+CastImageFilter::GetMemberFunctionFactory()
 {
-  this->m_OutputPixelType = sitkFloat32;
+  static detail::DualMemberFunctionFactory<MemberFunctionType> factory = [] {
+    detail::DualMemberFunctionFactory<MemberFunctionType> factory;
+    RegisterMemberFactory2(factory);
+    RegisterMemberFactory2v(factory);
+    RegisterMemberFactory2l(factory);
+    RegisterMemberFactory3(factory);
+    RegisterMemberFactory3v(factory);
+    RegisterMemberFactory3l(factory);
+    RegisterMemberFactory4(factory);
+    return factory;
+  }();
 
-  m_DualMemberFactory.reset(new detail::DualMemberFunctionFactory<MemberFunctionType>());
-
-  this->RegisterMemberFactory2();
-  this->RegisterMemberFactory2v();
-  this->RegisterMemberFactory2l();
-  this->RegisterMemberFactory3();
-  this->RegisterMemberFactory3v();
-  this->RegisterMemberFactory3l();
-
-  this->RegisterMemberFactory4();
+  return factory;
 }
+
+CastImageFilter::CastImageFilter() = default;
+
 
 //
 // ToString
@@ -87,9 +92,9 @@ CastImageFilter::Execute(const Image & image)
   const PixelIDValueEnum outputType = this->m_OutputPixelType;
   const unsigned int     dimension = image.GetDimension();
 
-  if (this->m_DualMemberFactory->HasMemberFunction(inputType, outputType, dimension))
+  if (GetMemberFunctionFactory().HasMemberFunction(inputType, outputType, dimension))
   {
-    return this->m_DualMemberFactory->GetMemberFunction(inputType, outputType, dimension, this)(image);
+    return GetMemberFunctionFactory().GetMemberFunction(inputType, outputType, dimension, this)(image);
   }
 
   sitkExceptionMacro(<< "Filter does not support casting from casting "

--- a/Code/BasicFilters/src/sitkCenteredTransformInitializerFilter.cxx
+++ b/Code/BasicFilters/src/sitkCenteredTransformInitializerFilter.cxx
@@ -47,14 +47,14 @@ CenteredTransformInitializerFilter::CenteredTransformInitializerFilter() = defau
 const detail::MemberFunctionFactory<CenteredTransformInitializerFilter::MemberFunctionType> &
 CenteredTransformInitializerFilter::GetMemberFunctionFactory()
 {
-  static detail::MemberFunctionFactory<MemberFunctionType> factory = [] {
+  static detail::MemberFunctionFactory<MemberFunctionType> static_factory = [] {
     detail::MemberFunctionFactory<MemberFunctionType> factory;
     factory.RegisterMemberFunctions<PixelIDTypeList, 3>();
     factory.RegisterMemberFunctions<PixelIDTypeList, 2>();
     return factory;
   }();
 
-  return factory;
+  return static_factory;
 }
 
 //

--- a/Code/BasicFilters/src/sitkCenteredVersorTransformInitializerFilter.cxx
+++ b/Code/BasicFilters/src/sitkCenteredVersorTransformInitializerFilter.cxx
@@ -43,14 +43,18 @@ namespace itk::simple
 //
 // Default constructor that initializes parameters
 //
-CenteredVersorTransformInitializerFilter::CenteredVersorTransformInitializerFilter()
+CenteredVersorTransformInitializerFilter::CenteredVersorTransformInitializerFilter() = default;
+
+const detail::MemberFunctionFactory<CenteredVersorTransformInitializerFilter::MemberFunctionType> &
+CenteredVersorTransformInitializerFilter::GetMemberFunctionFactory()
 {
+  static detail::MemberFunctionFactory<MemberFunctionType> factory = [] {
+    detail::MemberFunctionFactory<MemberFunctionType> factory;
+    factory.RegisterMemberFunctions<PixelIDTypeList, 3>();
+    return factory;
+  }();
 
-  this->m_ComputeRotation = false;
-
-  this->m_MemberFactory = std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>();
-
-  this->m_MemberFactory->RegisterMemberFunctions<PixelIDTypeList, 3>();
+  return factory;
 }
 
 //
@@ -83,8 +87,8 @@ CenteredVersorTransformInitializerFilter::Execute(const Image &     fixedImage,
                                                   const Image &     movingImage,
                                                   const Transform & transform)
 {
-  PixelIDValueEnum type = fixedImage.GetPixelID();
-  unsigned int     dimension = fixedImage.GetDimension();
+  const PixelIDValueType type = fixedImage.GetPixelIDValue();
+  const unsigned int     dimension = fixedImage.GetDimension();
 
   if (type != movingImage.GetPixelIDValue() || dimension != movingImage.GetDimension())
   {
@@ -94,8 +98,12 @@ CenteredVersorTransformInitializerFilter::Execute(const Image &     fixedImage,
   {
     sitkExceptionMacro("Transform parameter for " << this->GetName() << " doesn't match dimension!");
   }
-
-  return this->m_MemberFactory->GetMemberFunction(type, dimension, this)(&fixedImage, &movingImage, &transform);
+  if (!GetMemberFunctionFactory().HasMemberFunction(type, dimension))
+  {
+    sitkExceptionMacro("Filter does not support image type: " << GetPixelIDValueAsString(type) << " with dimension "
+                                                              << dimension << ".");
+  }
+  return GetMemberFunctionFactory().GetMemberFunction(type, dimension, this)(&fixedImage, &movingImage, &transform);
 }
 
 

--- a/Code/BasicFilters/src/sitkCenteredVersorTransformInitializerFilter.cxx
+++ b/Code/BasicFilters/src/sitkCenteredVersorTransformInitializerFilter.cxx
@@ -48,13 +48,13 @@ CenteredVersorTransformInitializerFilter::CenteredVersorTransformInitializerFilt
 const detail::MemberFunctionFactory<CenteredVersorTransformInitializerFilter::MemberFunctionType> &
 CenteredVersorTransformInitializerFilter::GetMemberFunctionFactory()
 {
-  static detail::MemberFunctionFactory<MemberFunctionType> factory = [] {
+  static detail::MemberFunctionFactory<MemberFunctionType> static_factory = [] {
     detail::MemberFunctionFactory<MemberFunctionType> factory;
     factory.RegisterMemberFunctions<PixelIDTypeList, 3>();
     return factory;
   }();
 
-  return factory;
+  return static_factory;
 }
 
 //

--- a/Code/BasicFilters/src/sitkExtractImageFilter.cxx
+++ b/Code/BasicFilters/src/sitkExtractImageFilter.cxx
@@ -43,13 +43,13 @@ ExtractImageFilter::ExtractImageFilter() = default;
 const detail::MemberFunctionFactory<ExtractImageFilter::MemberFunctionType> &
 ExtractImageFilter::GetMemberFunctionFactory()
 {
-  static detail::MemberFunctionFactory<MemberFunctionType> factory = [] {
+  static detail::MemberFunctionFactory<MemberFunctionType> static_factory = [] {
     detail::MemberFunctionFactory<MemberFunctionType> factory;
     factory.RegisterMemberFunctions<PixelIDTypeList, 2, SITK_MAX_DIMENSION>();
     return factory;
   }();
 
-  return factory;
+  return static_factory;
 }
 
 //

--- a/Code/BasicFilters/src/sitkHashImageFilter.cxx
+++ b/Code/BasicFilters/src/sitkHashImageFilter.cxx
@@ -32,7 +32,7 @@ namespace itk::simple
 const detail::MemberFunctionFactory<HashImageFilter::MemberFunctionType> &
 HashImageFilter::GetMemberFunctionFactory()
 {
-  static detail::MemberFunctionFactory<MemberFunctionType> factory = [] {
+  static detail::MemberFunctionFactory<MemberFunctionType> static_factory = [] {
     detail::MemberFunctionFactory<MemberFunctionType> factory;
     factory.RegisterMemberFunctions<PixelIDTypeList, 2, SITK_MAX_DIMENSION>();
     factory.RegisterMemberFunctions<LabelPixelIDTypeList,
@@ -41,7 +41,7 @@ HashImageFilter::GetMemberFunctionFactory()
                                     detail::ExecuteInternalLabelImageAddressor<MemberFunctionType>>();
     return factory;
   }();
-  return factory;
+  return static_factory;
 }
 
 

--- a/Code/BasicFilters/src/sitkHashImageFilter.cxx
+++ b/Code/BasicFilters/src/sitkHashImageFilter.cxx
@@ -29,20 +29,25 @@
 namespace itk::simple
 {
 
+const detail::MemberFunctionFactory<HashImageFilter::MemberFunctionType> &
+HashImageFilter::GetMemberFunctionFactory()
+{
+  static detail::MemberFunctionFactory<MemberFunctionType> factory = [] {
+    detail::MemberFunctionFactory<MemberFunctionType> factory;
+    factory.RegisterMemberFunctions<PixelIDTypeList, 2, SITK_MAX_DIMENSION>();
+    factory.RegisterMemberFunctions<LabelPixelIDTypeList,
+                                    2,
+                                    SITK_MAX_DIMENSION,
+                                    detail::ExecuteInternalLabelImageAddressor<MemberFunctionType>>();
+    return factory;
+  }();
+  return factory;
+}
+
+
 HashImageFilter::~HashImageFilter() = default;
 
-HashImageFilter::HashImageFilter()
-{
-  this->m_HashFunction = SHA1;
-
-  this->m_MemberFactory.reset(new detail::MemberFunctionFactory<MemberFunctionType>());
-
-  this->m_MemberFactory->RegisterMemberFunctions<PixelIDTypeList, 2, SITK_MAX_DIMENSION>();
-  this->m_MemberFactory->RegisterMemberFunctions<LabelPixelIDTypeList,
-                                                 2,
-                                                 SITK_MAX_DIMENSION,
-                                                 detail::ExecuteInternalLabelImageAddressor<MemberFunctionType>>();
-}
+HashImageFilter::HashImageFilter() = default;
 
 std::string
 HashImageFilter::ToString() const
@@ -83,7 +88,7 @@ HashImageFilter::Execute(const Image & image)
   PixelIDValueEnum type = image.GetPixelID();
   unsigned int     dimension = image.GetDimension();
 
-  return this->m_MemberFactory->GetMemberFunction(type, dimension, this)(image);
+  return GetMemberFunctionFactory().GetMemberFunction(type, dimension, this)(image);
 }
 
 template <class TLabelImageType>

--- a/Code/BasicFilters/src/sitkLandmarkBasedTransformInitializerFilter.cxx
+++ b/Code/BasicFilters/src/sitkLandmarkBasedTransformInitializerFilter.cxx
@@ -48,15 +48,16 @@ LandmarkBasedTransformInitializerFilter::LandmarkBasedTransformInitializerFilter
 const detail::MemberFunctionFactory<LandmarkBasedTransformInitializerFilter::MemberFunctionType> &
 LandmarkBasedTransformInitializerFilter::GetMemberFunctionFactory()
 {
-  static detail::MemberFunctionFactory<MemberFunctionType> factory = [] {
+  static detail::MemberFunctionFactory<MemberFunctionType> static_factory = [] {
     detail::MemberFunctionFactory<MemberFunctionType> factory;
     factory.RegisterMemberFunctions<PixelIDTypeList, 3>();
     factory.RegisterMemberFunctions<PixelIDTypeList, 2>();
     return factory;
   }();
 
-  return factory;
+  return static_factory;
 }
+
 
 //
 // Destructor

--- a/Code/BasicFilters/src/sitkLandmarkBasedTransformInitializerFilter.cxx
+++ b/Code/BasicFilters/src/sitkLandmarkBasedTransformInitializerFilter.cxx
@@ -43,19 +43,19 @@ namespace itk::simple
 //
 // Default constructor that initializes parameters
 //
-LandmarkBasedTransformInitializerFilter::LandmarkBasedTransformInitializerFilter()
+LandmarkBasedTransformInitializerFilter::LandmarkBasedTransformInitializerFilter() = default;
+
+const detail::MemberFunctionFactory<LandmarkBasedTransformInitializerFilter::MemberFunctionType> &
+LandmarkBasedTransformInitializerFilter::GetMemberFunctionFactory()
 {
+  static detail::MemberFunctionFactory<MemberFunctionType> factory = [] {
+    detail::MemberFunctionFactory<MemberFunctionType> factory;
+    factory.RegisterMemberFunctions<PixelIDTypeList, 3>();
+    factory.RegisterMemberFunctions<PixelIDTypeList, 2>();
+    return factory;
+  }();
 
-  this->m_FixedLandmarks = std::vector<double>();
-  this->m_MovingLandmarks = std::vector<double>();
-  this->m_LandmarkWeight = std::vector<double>();
-  this->m_ReferenceImage = Image();
-  this->m_BSplineNumberOfControlPoints = 4u;
-
-  this->m_MemberFactory = std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>();
-
-  this->m_MemberFactory->RegisterMemberFunctions<PixelIDTypeList, 3>();
-  this->m_MemberFactory->RegisterMemberFunctions<PixelIDTypeList, 2>();
+  return factory;
 }
 
 //
@@ -98,7 +98,7 @@ LandmarkBasedTransformInitializerFilter::ToString() const
 Transform
 LandmarkBasedTransformInitializerFilter::Execute(const Transform & transform)
 {
-  unsigned int dimension = transform.GetDimension();
+  const unsigned int dimension = transform.GetDimension();
 
   // The dimension of the reference image which the user explicitly
   // set (GetSize()!=[0...0]), and the dimension of the transform do not match
@@ -109,7 +109,7 @@ LandmarkBasedTransformInitializerFilter::Execute(const Transform & transform)
       "ReferenceImage for LandmarkBasedTransformInitializerFilter does not match dimension of the transform!");
   }
 
-  return this->m_MemberFactory->GetMemberFunction(sitkFloat32, dimension, this)(&transform);
+  return GetMemberFunctionFactory().GetMemberFunction(sitkFloat32, dimension, this)(&transform);
 }
 
 

--- a/Code/BasicFilters/src/sitkPasteImageFilter.cxx
+++ b/Code/BasicFilters/src/sitkPasteImageFilter.cxx
@@ -46,14 +46,30 @@ namespace itk::simple
 //
 // Default constructor that initializes parameters
 //
-PasteImageFilter::PasteImageFilter()
+PasteImageFilter::PasteImageFilter() = default;
+
+const detail::MemberFunctionFactory<PasteImageFilter::MemberFunctionType> &
+PasteImageFilter::GetMemberFunctionFactory()
 {
-  this->m_MemberFactory = std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>();
+  static detail::MemberFunctionFactory<MemberFunctionType> factory = [] {
+    detail::MemberFunctionFactory<MemberFunctionType> factory;
+    factory.RegisterMemberFunctions<PixelIDTypeList, 2, SITK_MAX_DIMENSION>();
+    return factory;
+  }();
 
-  this->m_MemberFactory->RegisterMemberFunctions<PixelIDTypeList, 2, SITK_MAX_DIMENSION>();
+  return factory;
+}
 
-  this->m_MemberFactory2 = std::make_unique<detail::MemberFunctionFactory<MemberFunction2Type>>();
-  this->m_MemberFactory2->RegisterMemberFunctions<PixelIDTypeList, 2, SITK_MAX_DIMENSION>();
+const detail::MemberFunctionFactory<PasteImageFilter::MemberFunction2Type> &
+PasteImageFilter::GetMemberFunctionFactory2()
+{
+  static detail::MemberFunctionFactory<MemberFunction2Type> factory = [] {
+    detail::MemberFunctionFactory<MemberFunction2Type> factory;
+    factory.RegisterMemberFunctions<PixelIDTypeList, 2, SITK_MAX_DIMENSION>();
+    return factory;
+  }();
+
+  return factory;
 }
 
 //
@@ -97,15 +113,27 @@ PasteImageFilter::Execute(const Image & destinationImage, const Image & sourceIm
   const unsigned int     dimension = destinationImage.GetDimension();
   CheckImageMatchingPixelType(destinationImage, sourceImage, "sourceImage");
 
-  return this->m_MemberFactory->GetMemberFunction(type, dimension, this)(&destinationImage, &sourceImage);
+  if (GetMemberFunctionFactory().HasMemberFunction(type, dimension))
+  {
+    return GetMemberFunctionFactory().GetMemberFunction(type, dimension, this)(&destinationImage, &sourceImage);
+  }
+
+  sitkExceptionMacro("Filter does not support image type: " << GetPixelIDValueAsString(type) << " with dimension "
+                                                            << dimension << ".");
 }
 Image
 PasteImageFilter::Execute(const Image & destinationImage, double constant)
 {
-  const PixelIDValueEnum type = destinationImage.GetPixelID();
+  const PixelIDValueType type = destinationImage.GetPixelIDValue();
   const unsigned int     dimension = destinationImage.GetDimension();
 
-  return this->m_MemberFactory2->GetMemberFunction(type, dimension, this)(&destinationImage, constant);
+  if (GetMemberFunctionFactory2().HasMemberFunction(type, dimension))
+  {
+    return GetMemberFunctionFactory2().GetMemberFunction(type, dimension, this)(&destinationImage, constant);
+  }
+
+  sitkExceptionMacro("Filter does not support image type: " << GetPixelIDValueAsString(type) << " with dimension "
+                                                            << dimension << ".");
 }
 Image
 PasteImageFilter::Execute(Image && destinationImage, const Image & sourceImage)

--- a/Code/BasicFilters/src/sitkPasteImageFilter.cxx
+++ b/Code/BasicFilters/src/sitkPasteImageFilter.cxx
@@ -51,25 +51,25 @@ PasteImageFilter::PasteImageFilter() = default;
 const detail::MemberFunctionFactory<PasteImageFilter::MemberFunctionType> &
 PasteImageFilter::GetMemberFunctionFactory()
 {
-  static detail::MemberFunctionFactory<MemberFunctionType> factory = [] {
+  static detail::MemberFunctionFactory<MemberFunctionType> static_factory = [] {
     detail::MemberFunctionFactory<MemberFunctionType> factory;
     factory.RegisterMemberFunctions<PixelIDTypeList, 2, SITK_MAX_DIMENSION>();
     return factory;
   }();
 
-  return factory;
+  return static_factory;
 }
 
 const detail::MemberFunctionFactory<PasteImageFilter::MemberFunction2Type> &
 PasteImageFilter::GetMemberFunctionFactory2()
 {
-  static detail::MemberFunctionFactory<MemberFunction2Type> factory = [] {
+  static detail::MemberFunctionFactory<MemberFunction2Type> static_factory = [] {
     detail::MemberFunctionFactory<MemberFunction2Type> factory;
     factory.RegisterMemberFunctions<PixelIDTypeList, 2, SITK_MAX_DIMENSION>();
     return factory;
   }();
 
-  return factory;
+  return static_factory;
 }
 
 //

--- a/Code/BasicFilters/templates/sitkBinaryFunctorFilterTemplate.cxx.jinja
+++ b/Code/BasicFilters/templates/sitkBinaryFunctorFilterTemplate.cxx.jinja
@@ -30,20 +30,30 @@ namespace itk::simple {
 
 //-----------------------------------------------------------------------------
 
-// Default constructor that initializes parameters
-{% include "ConstructorSignature.cxx.jinja" %}
+{% include "ConstructorMemberFunctionSetup.cxx.jinja" %}
+
+const detail::MemberFunctionFactory<{{ name }}::MemberFunction1Type> &{{ name }}::GetMemberFunctionFactory1()
 {
-  {% include "ConstructorMemberFunctionSetup.cxx.jinja" %}
-  {% include "ConstructorVectorPixels.cxx.jinja" %}
-
-  this->m_MemberFactory1.reset( new detail::MemberFunctionFactory<MemberFunction1Type> );
-  this->m_MemberFactory1->RegisterMemberFunctions< PixelIDTypeList, 3 >();
-  this->m_MemberFactory1->RegisterMemberFunctions< PixelIDTypeList, 2 >();
-
-  this->m_MemberFactory2.reset( new detail::MemberFunctionFactory<MemberFunction2Type> );
-  this->m_MemberFactory2->RegisterMemberFunctions< PixelIDTypeList, 3 >();
-  this->m_MemberFactory2->RegisterMemberFunctions< PixelIDTypeList, 2 >();
+  static detail::MemberFunctionFactory<MemberFunction1Type> static_factory = [] {
+    detail::MemberFunctionFactory<MemberFunction1Type> factory;
+    factory.RegisterMemberFunctions< PixelIDTypeList, 2, 3 >();
+    return factory;
+  }();
+  return static_factory;
 }
+
+const detail::MemberFunctionFactory<{{ name }}::MemberFunction2Type> &{{ name }}::GetMemberFunctionFactory2()
+{
+  static detail::MemberFunctionFactory<MemberFunction2Type> factory = [] {
+    detail::MemberFunctionFactory<MemberFunction2Type> factory;
+    factory.RegisterMemberFunctions< PixelIDTypeList, 2, 3 >();
+    return factory;
+  }();
+  return factory;
+}
+
+// Default constructor that initializes parameters
+{% include "ConstructorSignature.cxx.jinja" %} = default;
 
 {% include "DestructorDefinition.cxx.jinja" %}
 
@@ -87,14 +97,14 @@ Image {{ name }}::Execute ( {{ constant_type }} constant, const Image& image2 )
 {
   PixelIDValueEnum type = image2.GetPixelID();
   unsigned int dimension = image2.GetDimension();
-  return this->m_MemberFactory1->GetMemberFunction( type, dimension, this )( constant, image2 );
+  return GetMemberFunctionFactory1().GetMemberFunction( type, dimension, this )( constant, image2 );
 }
 
 Image {{ name }}::Execute ( const Image& image1, {{ constant_type }} constant )
 {
   PixelIDValueEnum type = image1.GetPixelID();
   unsigned int dimension = image1.GetDimension();
-  return this->m_MemberFactory2->GetMemberFunction( type, dimension, this )( image1, constant );
+  return GetMemberFunctionFactory2().GetMemberFunction( type, dimension, this )( image1, constant );
 }
 
 Image {{ name }}::Execute ( Image&& image1, {{ constant_type }} constant )

--- a/Code/BasicFilters/templates/sitkBinaryFunctorFilterTemplate.h.jinja
+++ b/Code/BasicFilters/templates/sitkBinaryFunctorFilterTemplate.h.jinja
@@ -58,12 +58,12 @@ Image Execute({{ constant_type }} constant, const Image& image2{{ macros.member_
   using MemberFunction1Type = Image (Self::*)({{ constant_type }} constant, const Image& image2);
   template <class TImageType> Image ExecuteInternal({{ constant_type }} constant, const Image& image2);
   friend struct detail::MemberFunctionAddressor<MemberFunction1Type>;
-  std::unique_ptr<detail::MemberFunctionFactory<MemberFunction1Type>> m_MemberFactory1;
+  static const detail::MemberFunctionFactory<MemberFunction1Type> &GetMemberFunctionFactory1();
 
   using MemberFunction2Type = Image (Self::*)(const Image& image1, {{ constant_type }} constant);
   template <class TImageType> Image ExecuteInternal(const Image& image1, {{ constant_type }} constant);
   friend struct detail::MemberFunctionAddressor<MemberFunction2Type>;
-  std::unique_ptr<detail::MemberFunctionFactory<MemberFunction2Type>> m_MemberFactory2;
+  static const detail::MemberFunctionFactory<MemberFunction2Type> &GetMemberFunctionFactory2();
 
 {% include "MemberFunctionDispatch.h.jinja" %}
 {% include "PrivateMemberDeclarations.h.jinja" %}

--- a/Code/BasicFilters/templates/sitkDualImageFilterTemplate.cxx.jinja
+++ b/Code/BasicFilters/templates/sitkDualImageFilterTemplate.cxx.jinja
@@ -24,32 +24,39 @@ namespace itk::simple {
 
 //-----------------------------------------------------------------------------
 
-// Default constructor that initializes parameters
-{% include "ConstructorSignature.cxx.jinja" %}
-{
-  this->m_DualMemberFactory.reset( new detail::DualMemberFunctionFactory<MemberFunctionType> );
-  {% if pixel_types2 %}
-  using PixelIDTypeList2 = {{ pixel_types2 }};
-  {% endif %}
-  {% if custom_register %}
-  {{ custom_register }}
-  {% else %}
-  this->m_DualMemberFactory->RegisterMemberFunctions< PixelIDTypeList, PixelIDTypeList2, 3 >();
-  this->m_DualMemberFactory->RegisterMemberFunctions< PixelIDTypeList, PixelIDTypeList2, 2 >();
-  {% endif %}
 
-  {% if vector_pixel_types_by_component %}
+ const detail::DualMemberFunctionFactory<{{ name }}::MemberFunctionType> &{{ name }}::GetMemberFunctionFactory() {
+   static detail::DualMemberFunctionFactory<MemberFunctionType> static_factory = [] {
+     detail::DualMemberFunctionFactory<MemberFunctionType> factory;
+{% if pixel_types2 %}
+    using PixelIDTypeList2 = {{ pixel_types2 }};
+{% endif %}
+{% if custom_register %}
+  {{ custom_register | indent(4) }}
+{% else %}
+    factory.RegisterMemberFunctions< PixelIDTypeList, PixelIDTypeList2, 3 >();
+    factory.RegisterMemberFunctions< PixelIDTypeList, PixelIDTypeList2, 2 >();
+{% endif %}
+
+{% if vector_pixel_types_by_component %}
     using VectorByComponentsPixelIDTypeList = {{ vector_pixel_types_by_component }};
-    {% if vector_pixel_types_by_component2 %}
+{% if vector_pixel_types_by_component2 %}
       using VectorByComponentsPixelIDTypeList2 = {{ vector_pixel_types_by_component2 }};
-    {% else %}
+{% else %}
       using VectorByComponentsPixelIDTypeList2 = PixelIDTypeList2;
-    {% endif %}
+{% endif %}
     using VectorAddressorType = detail::DualExecuteInternalVectorAddressor<MemberFunctionType>;
-    this->m_DualMemberFactory->RegisterMemberFunctions< VectorByComponentsPixelIDTypeList, VectorByComponentsPixelIDTypeList2, 3, VectorAddressorType >();
-    this->m_DualMemberFactory->RegisterMemberFunctions< VectorByComponentsPixelIDTypeList, VectorByComponentsPixelIDTypeList2, 2, VectorAddressorType >();
-  {% endif %}
-}
+    factory.RegisterMemberFunctions< VectorByComponentsPixelIDTypeList, VectorByComponentsPixelIDTypeList2, 3, VectorAddressorType >();
+    factory.RegisterMemberFunctions< VectorByComponentsPixelIDTypeList, VectorByComponentsPixelIDTypeList2, 2, VectorAddressorType >();
+{% endif %}
+
+      return factory;
+    }();
+    return static_factory;
+    }
+
+// Default constructor that initializes parameters
+{% include "ConstructorSignature.cxx.jinja" %} = default;
 
 {% include "DestructorDefinition.cxx.jinja" %}
 
@@ -100,7 +107,7 @@ namespace itk::simple {
         {{ custom_type2 }}
     {% endif %}
 
-    return this->m_DualMemberFactory->GetMemberFunction(type1, type2, dimension, this)(
+    return GetMemberFunctionFactory().GetMemberFunction(type1, type2, dimension, this)(
         {%- for inum in range(1, number_of_inputs+1) -%}
             {%- if inum > 1 %}, {% endif -%}image{{ inum }}
         {%- endfor -%}

--- a/Code/BasicFilters/templates/sitkDualImageFilterTemplate.h.jinja
+++ b/Code/BasicFilters/templates/sitkDualImageFilterTemplate.h.jinja
@@ -59,7 +59,7 @@ private:
   );
   {% endif %}
 
-  std::unique_ptr<detail::DualMemberFunctionFactory<MemberFunctionType>> m_DualMemberFactory;
+  static const detail::DualMemberFunctionFactory<MemberFunctionType> &GetMemberFunctionFactory();
 
 {% include "PrivateMemberDeclarations.h.jinja" %}
 };

--- a/Code/BasicFilters/templates/sitkImageFilterTemplate.cxx.jinja
+++ b/Code/BasicFilters/templates/sitkImageFilterTemplate.cxx.jinja
@@ -24,15 +24,13 @@ namespace itk::simple {
 
 //-----------------------------------------------------------------------------
 
+
+{% include "ConstructorMemberFunctionSetup.cxx.jinja" %}
+
 //
 // Default constructor that initializes parameters
 //
-{% include "ConstructorSignature.cxx.jinja" %}
-{
-{% include "ConstructorMemberFunctionSetup.cxx.jinja" %}
-
-{%- include "ConstructorVectorPixels.cxx.jinja" %}
-}
+{% include "ConstructorSignature.cxx.jinja" %} = default;
 
 {% include "DestructorDefinition.cxx.jinja" %}
 

--- a/Code/BasicFilters/templates/sitkImageSourceTemplate.cxx.jinja
+++ b/Code/BasicFilters/templates/sitkImageSourceTemplate.cxx.jinja
@@ -24,15 +24,13 @@ namespace itk::simple {
 
 //-----------------------------------------------------------------------------
 
+
+{% include "ConstructorMemberFunctionSetup.cxx.jinja" %}
+
 //
 // Default constructor that initializes parameters
 //
-{% include "ConstructorSignature.cxx.jinja" %}
-{
-{% include "ConstructorMemberFunctionSetup.cxx.jinja" %}
-
-{% include "ConstructorVectorPixels.cxx.jinja" %}
-}
+{% include "ConstructorSignature.cxx.jinja" %} = default;
 
 {% include "DestructorDefinition.cxx.jinja" %}
 
@@ -59,7 +57,7 @@ Image {{ name }}::Execute ( {{ macros.image_parameters(number_of_inputs) }}{{ ma
     if ( type != image{{ inum }}.GetPixelIDValue() || dimension != image{{ inum }}.GetDimension() ) { sitkExceptionMacro ( "Image{{ inum }} for {{ name }} doesn't match type or dimension!" ); }
   {%- endfor %}
 
-  return this->m_MemberFactory->GetMemberFunction( type, dimension, this )(
+  return GetMemberFunctionFactory().GetMemberFunction( type, dimension, this )(
     {%- for inum in range(1, number_of_inputs+1) -%}
       {%- if inum > 1 %}, {% endif -%}
       image{{ inum }}

--- a/Code/BasicFilters/templates/sitkMultiInputImageFilterTemplate.cxx.jinja
+++ b/Code/BasicFilters/templates/sitkMultiInputImageFilterTemplate.cxx.jinja
@@ -24,15 +24,13 @@ namespace itk::simple {
 
 //-----------------------------------------------------------------------------
 
+
+{% include "ConstructorMemberFunctionSetup.cxx.jinja" %}
+
 //
 // Default constructor that initializes parameters
 //
-{% include "ConstructorSignature.cxx.jinja" %}
-{
-{% include "ConstructorMemberFunctionSetup.cxx.jinja" %}
-
-{% include "ConstructorVectorPixels.cxx.jinja" %}
-}
+{% include "ConstructorSignature.cxx.jinja" %} = default;
 
 {% include "DestructorDefinition.cxx.jinja" %}
 
@@ -79,7 +77,7 @@ Image {{ name }}::Execute ( const std::vector<Image> &images )
     ++inputIndex;
     }
 
-  return this->m_MemberFactory->GetMemberFunction( type, dimension, this )( images );
+  return GetMemberFunctionFactory().GetMemberFunction( type, dimension, this )( images );
 }
 
 //-----------------------------------------------------------------------------

--- a/Code/Common/src/sitkImageExplicit.cxx
+++ b/Code/Common/src/sitkImageExplicit.cxx
@@ -70,13 +70,13 @@ Image::InternalInitialization(PixelIDValueType type, unsigned int dimension, itk
 {
   using PixelIDTypeList = AllPixelIDTypeList;
   using Addressor = DispatchedInternalInitialiationAddressor;
-
-
   typedef PimpleImageBase * (Self::*MemberFunctionType)(itk::DataObject *);
 
-  detail::MemberFunctionFactory<MemberFunctionType> memberFactory;
-
-  memberFactory.RegisterMemberFunctions<PixelIDTypeList, 2, SITK_MAX_DIMENSION, Addressor>();
+  static const auto memberFactory = []() {
+    detail::MemberFunctionFactory<MemberFunctionType> factory;
+    factory.RegisterMemberFunctions<PixelIDTypeList, 2, SITK_MAX_DIMENSION, Addressor>();
+    return factory;
+  }();
 
   this->m_PimpleImage.reset(memberFactory.GetMemberFunction(type, dimension, this)(image));
 }
@@ -84,17 +84,16 @@ Image::InternalInitialization(PixelIDValueType type, unsigned int dimension, itk
 void
 Image::Allocate(const std::vector<unsigned int> & _size, PixelIDValueEnum ValueEnum, unsigned int numberOfComponents)
 {
-  // initialize member function factory for allocating images
-
   // The pixel IDs supported
   using PixelIDTypeList = AllPixelIDTypeList;
-
   typedef void (Self::*MemberFunctionType)(const std::vector<unsigned int> &, unsigned int);
-
   using AllocateAddressor = AllocateMemberFunctionAddressor;
 
-  detail::MemberFunctionFactory<MemberFunctionType> allocateMemberFactory;
-  allocateMemberFactory.RegisterMemberFunctions<PixelIDTypeList, 2, SITK_MAX_DIMENSION, AllocateAddressor>();
+  static const auto allocateMemberFactory = []() {
+    detail::MemberFunctionFactory<MemberFunctionType> factory;
+    factory.RegisterMemberFunctions<PixelIDTypeList, 2, SITK_MAX_DIMENSION, AllocateAddressor>();
+    return factory;
+  }();
 
   if (ValueEnum == sitkUnknown)
   {
@@ -118,13 +117,14 @@ Image::ToVectorImage(bool inPlace)
   assert(m_PimpleImage);
 
   using PixelIDTypeList = typelist2::append<ScalarPixelIDTypeList, VectorPixelIDTypeList>::type;
-
   typedef Image (Self::*MemberFunctionType)(bool);
 
-  detail::MemberFunctionFactory<MemberFunctionType> toVectorMemberFactory;
-
-  toVectorMemberFactory.RegisterMemberFunctions<PixelIDTypeList, 3, SITK_MAX_DIMENSION, ToVectorAddressor>();
-  toVectorMemberFactory.RegisterMemberFunctions<VectorPixelIDTypeList, 2, 2, ToVectorAddressor>();
+  static const auto toVectorMemberFactory = []() {
+    detail::MemberFunctionFactory<MemberFunctionType> factory;
+    factory.RegisterMemberFunctions<PixelIDTypeList, 3, SITK_MAX_DIMENSION, ToVectorAddressor>();
+    factory.RegisterMemberFunctions<VectorPixelIDTypeList, 2, 2, ToVectorAddressor>();
+    return factory;
+  }();
 
   if (!toVectorMemberFactory.HasMemberFunction(this->GetPixelID(), this->GetDimension()))
   {
@@ -141,14 +141,14 @@ Image::ToScalarImage(bool inPlace)
   assert(m_PimpleImage);
 
   using PixelIDTypeList = typelist2::append<ScalarPixelIDTypeList, VectorPixelIDTypeList>::type;
-
   typedef Image (Self::*MemberFunctionType)(bool);
 
-  detail::MemberFunctionFactory<MemberFunctionType> toScalarMemberFactory;
-
-  toScalarMemberFactory.RegisterMemberFunctions<PixelIDTypeList, 2, SITK_MAX_DIMENSION - 1, ToScalarAddressor>();
-  toScalarMemberFactory
-    .RegisterMemberFunctions<ScalarPixelIDTypeList, SITK_MAX_DIMENSION, SITK_MAX_DIMENSION, ToScalarAddressor>();
+  static const auto toScalarMemberFactory = []() {
+    detail::MemberFunctionFactory<MemberFunctionType> factory;
+    factory.RegisterMemberFunctions<PixelIDTypeList, 2, SITK_MAX_DIMENSION - 1, ToScalarAddressor>();
+    factory.RegisterMemberFunctions<ScalarPixelIDTypeList, SITK_MAX_DIMENSION, SITK_MAX_DIMENSION, ToScalarAddressor>();
+    return factory;
+  }();
 
   if (!toScalarMemberFactory.HasMemberFunction(this->GetPixelID(), this->GetDimension()))
   {

--- a/Code/IO/include/sitkImageFileReader.h
+++ b/Code/IO/include/sitkImageFileReader.h
@@ -230,7 +230,7 @@ protected:
   UpdateImageInformationFromImageIO(const itk::ImageIOBase * iobase);
 
 private:
-  // Internal method used implement extracting a region from the reader
+  // Internal method used implements extracting a region from the reader
   template <class TImageType, class TInternalImageType>
   Image
   ExecuteExtract(TInternalImageType * itkImage);
@@ -240,7 +240,8 @@ private:
 
   // friend to get access to executeInternal member
   friend struct detail::MemberFunctionAddressor<MemberFunctionType>;
-  std::unique_ptr<detail::MemberFunctionFactory<MemberFunctionType>> m_MemberFactory;
+  static const detail::MemberFunctionFactory<MemberFunctionType> &
+  GetMemberFunctionFactory();
 
 
   std::function<std::vector<std::string>()>       m_pfGetMetaDataKeys;
@@ -251,9 +252,9 @@ private:
 
   std::unique_ptr<MetaDataDictionary> m_MetaDataDictionary;
 
-  PixelIDValueEnum    m_PixelType;
-  unsigned int        m_Dimension;
-  unsigned int        m_NumberOfComponents;
+  PixelIDValueEnum    m_PixelType{ sitkUnknown };
+  unsigned int        m_Dimension{ 0 };
+  unsigned int        m_NumberOfComponents{ 0 };
   std::vector<double> m_Direction;
   std::vector<double> m_Origin;
   std::vector<double> m_Spacing;

--- a/Code/IO/include/sitkImageFileWriter.h
+++ b/Code/IO/include/sitkImageFileWriter.h
@@ -187,12 +187,12 @@ private:
   void
   ExecuteInternal(const Image &);
 
-  bool        m_UseCompression;
-  int         m_CompressionLevel;
+  bool        m_UseCompression{ false };
+  int         m_CompressionLevel{ -1 };
   std::string m_Compressor;
 
   PathType    m_FileName;
-  bool        m_KeepOriginalImageUID;
+  bool        m_KeepOriginalImageUID{ false };
   std::string m_ImageIOName;
 
   // function pointer type
@@ -201,7 +201,8 @@ private:
   // friend to get access to executeInternal member
   friend struct detail::MemberFunctionAddressor<MemberFunctionType>;
 
-  std::unique_ptr<detail::MemberFunctionFactory<MemberFunctionType>> m_MemberFactory;
+  static const detail::MemberFunctionFactory<MemberFunctionType> &
+  GetMemberFunctionFactory();
 };
 
 /**

--- a/Code/IO/include/sitkImageSeriesReader.h
+++ b/Code/IO/include/sitkImageSeriesReader.h
@@ -259,7 +259,8 @@ private:
 
   // friend to get access to executeInternal member
   friend struct detail::MemberFunctionAddressor<MemberFunctionType>;
-  std::unique_ptr<detail::MemberFunctionFactory<MemberFunctionType>> m_MemberFactory;
+  static const detail::MemberFunctionFactory<MemberFunctionType> &
+  GetMemberFunctionFactory();
 
 
   std::function<std::vector<std::string>(int)>         m_pfGetMetaDataKeys;

--- a/Code/IO/include/sitkImageSeriesWriter.h
+++ b/Code/IO/include/sitkImageSeriesWriter.h
@@ -170,10 +170,11 @@ private:
 
   // friend to get access to executeInternal member
   friend struct detail::MemberFunctionAddressor<MemberFunctionType>;
-  std::unique_ptr<detail::MemberFunctionFactory<MemberFunctionType>> m_MemberFactory;
+  static const detail::MemberFunctionFactory<MemberFunctionType> &
+  GetMemberFunctionFactory();
 
-  bool        m_UseCompression;
-  int         m_CompressionLevel;
+  bool        m_UseCompression{ false };
+  int         m_CompressionLevel{ -1 };
   std::string m_Compressor;
 
   std::vector<PathType> m_FileNames;

--- a/Code/IO/include/sitkImportImageFilter.h
+++ b/Code/IO/include/sitkImportImageFilter.h
@@ -120,17 +120,18 @@ private:
 
   // friend to get access to executeInternal member
   friend struct detail::MemberFunctionAddressor<MemberFunctionType>;
-  std::unique_ptr<detail::MemberFunctionFactory<MemberFunctionType>> m_MemberFactory;
+  static const detail::MemberFunctionFactory<MemberFunctionType> &
+  GetMemberFunctionFactory();
 
-  unsigned int     m_NumberOfComponentsPerPixel;
-  PixelIDValueType m_PixelIDValue;
+  unsigned int     m_NumberOfComponentsPerPixel{ 0 };
+  PixelIDValueType m_PixelIDValue{ sitkUnknown };
 
-  std::vector<double>       m_Origin;
-  std::vector<double>       m_Spacing;
+  std::vector<double>       m_Origin{ std::vector<double>(3, 0.0) };
+  std::vector<double>       m_Spacing{ std::vector<double>(3, 1.0) };
   std::vector<unsigned int> m_Size;
   std::vector<double>       m_Direction;
 
-  void * m_Buffer;
+  void * m_Buffer{ nullptr };
 };
 
 Image SITKIO_EXPORT

--- a/Code/IO/src/sitkImageFileReader.cxx
+++ b/Code/IO/src/sitkImageFileReader.cxx
@@ -83,13 +83,13 @@ ImageFileReader::~ImageFileReader() = default;
 const detail::MemberFunctionFactory<ImageFileReader::MemberFunctionType> &
 ImageFileReader::GetMemberFunctionFactory()
 {
-  static detail::MemberFunctionFactory<MemberFunctionType> factory = [] {
+  static detail::MemberFunctionFactory<MemberFunctionType> static_factory = [] {
     detail::MemberFunctionFactory<MemberFunctionType> factory;
     using PixelIDTypeList = NonLabelPixelIDTypeList;
     factory.RegisterMemberFunctions<PixelIDTypeList, 2, SITK_IO_INPUT_MAX_DIMENSION>();
     return factory;
   }();
-  return factory;
+  return static_factory;
 }
 
 ImageFileReader::ImageFileReader() = default;

--- a/Code/IO/src/sitkImageFileReader.cxx
+++ b/Code/IO/src/sitkImageFileReader.cxx
@@ -80,18 +80,19 @@ ReadImage(const PathType & filename, PixelIDValueEnum outputPixelType, const std
 
 ImageFileReader::~ImageFileReader() = default;
 
-ImageFileReader::ImageFileReader()
-  : m_PixelType(sitkUnknown)
-  , m_Dimension(0)
-  , m_NumberOfComponents(0)
+const detail::MemberFunctionFactory<ImageFileReader::MemberFunctionType> &
+ImageFileReader::GetMemberFunctionFactory()
 {
-  // list of pixel types supported
-  using PixelIDTypeList = NonLabelPixelIDTypeList;
-
-  this->m_MemberFactory = std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>();
-
-  this->m_MemberFactory->RegisterMemberFunctions<PixelIDTypeList, 2, SITK_MAX_DIMENSION>();
+  static detail::MemberFunctionFactory<MemberFunctionType> factory = [] {
+    detail::MemberFunctionFactory<MemberFunctionType> factory;
+    using PixelIDTypeList = NonLabelPixelIDTypeList;
+    factory.RegisterMemberFunctions<PixelIDTypeList, 2, SITK_IO_INPUT_MAX_DIMENSION>();
+    return factory;
+  }();
+  return factory;
 }
+
+ImageFileReader::ImageFileReader() = default;
 
 std::string
 ImageFileReader::ToString() const
@@ -330,14 +331,14 @@ ImageFileReader::Execute()
   }
 
 
-  if (!this->m_MemberFactory->HasMemberFunction(type, dimension))
+  if (!GetMemberFunctionFactory().HasMemberFunction(type, dimension))
   {
     sitkExceptionMacro(<< "PixelType is not supported!" << std::endl
                        << "Pixel Type: " << GetPixelIDValueAsString(type) << std::endl
                        << "Refusing to load! " << std::endl);
   }
 
-  return this->m_MemberFactory->GetMemberFunction(type, dimension, this)(imageio.GetPointer());
+  return GetMemberFunctionFactory().GetMemberFunction(type, dimension, this)(imageio.GetPointer());
 }
 
 template <class TImageType>
@@ -352,7 +353,7 @@ ImageFileReader::ExecuteInternal(itk::ImageIOBase * imageio)
     typename ImageType::template RebindImageType<typename ImageType::PixelType, SITK_IO_INPUT_MAX_DIMENSION>;
   using InternalReader = itk::ImageFileReader<InternalImageType>;
 
-  // if the InstantiatedToken is correctly implemented this should
+  // if the InstantiatedToken is correctly implemented, this should
   // not occur
   assert(ImageTypeToPixelIDValue<ImageType>::Result != (int)sitkUnknown);
   assert(imageio != nullptr);

--- a/Code/IO/src/sitkImageFileWriter.cxx
+++ b/Code/IO/src/sitkImageFileWriter.cxx
@@ -29,6 +29,18 @@
 namespace itk::simple
 {
 
+const detail::MemberFunctionFactory<ImageFileWriter::MemberFunctionType> &
+ImageFileWriter::GetMemberFunctionFactory()
+{
+  static detail::MemberFunctionFactory<MemberFunctionType> factory = [] {
+    detail::MemberFunctionFactory<MemberFunctionType> factory;
+    factory.RegisterMemberFunctions<PixelIDTypeList, 1, SITK_MAX_DIMENSION>();
+    return factory;
+  }();
+  return factory;
+}
+
+
 void
 WriteImage(const Image & image, const PathType & inFileName, bool useCompression, int compressionLevel)
 {
@@ -39,16 +51,7 @@ WriteImage(const Image & image, const PathType & inFileName, bool useCompression
 
 ImageFileWriter::~ImageFileWriter() = default;
 
-ImageFileWriter::ImageFileWriter()
-{
-  this->m_UseCompression = false;
-  this->m_KeepOriginalImageUID = false;
-  this->m_CompressionLevel = -1;
-
-  this->m_MemberFactory = std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>();
-
-  this->m_MemberFactory->RegisterMemberFunctions<PixelIDTypeList, 1, SITK_MAX_DIMENSION>();
-}
+ImageFileWriter::ImageFileWriter() = default;
 
 
 std::string
@@ -167,10 +170,10 @@ ImageFileWriter::Execute(const Image & image, const PathType & inFileName, bool 
 void
 ImageFileWriter::Execute(const Image & image)
 {
-  PixelIDValueType type = image.GetPixelIDValue();
-  unsigned int     dimension = image.GetDimension();
+  const PixelIDValueType type = image.GetPixelIDValue();
+  const unsigned int     dimension = image.GetDimension();
 
-  return this->m_MemberFactory->GetMemberFunction(type, dimension, this)(image);
+  return GetMemberFunctionFactory().GetMemberFunction(type, dimension, this)(image);
 }
 
 

--- a/Code/IO/src/sitkImageFileWriter.cxx
+++ b/Code/IO/src/sitkImageFileWriter.cxx
@@ -32,12 +32,12 @@ namespace itk::simple
 const detail::MemberFunctionFactory<ImageFileWriter::MemberFunctionType> &
 ImageFileWriter::GetMemberFunctionFactory()
 {
-  static detail::MemberFunctionFactory<MemberFunctionType> factory = [] {
+  static detail::MemberFunctionFactory<MemberFunctionType> static_factory = [] {
     detail::MemberFunctionFactory<MemberFunctionType> factory;
     factory.RegisterMemberFunctions<PixelIDTypeList, 1, SITK_MAX_DIMENSION>();
     return factory;
   }();
-  return factory;
+  return static_factory;
 }
 
 

--- a/Code/IO/src/sitkImageSeriesReader.cxx
+++ b/Code/IO/src/sitkImageSeriesReader.cxx
@@ -35,14 +35,14 @@ namespace itk::simple
 const detail::MemberFunctionFactory<ImageSeriesReader::MemberFunctionType> &
 ImageSeriesReader::GetMemberFunctionFactory()
 {
-  static detail::MemberFunctionFactory<MemberFunctionType> factory = [] {
+  static detail::MemberFunctionFactory<MemberFunctionType> static_factory = [] {
     detail::MemberFunctionFactory<MemberFunctionType> factory;
 
     using PixelIDTypeList = NonLabelPixelIDTypeList;
     factory.RegisterMemberFunctions<PixelIDTypeList, 2, SITK_MAX_DIMENSION>();
     return factory;
   }();
-  return factory;
+  return static_factory;
 }
 
 Image

--- a/Code/IO/src/sitkImageSeriesWriter.cxx
+++ b/Code/IO/src/sitkImageSeriesWriter.cxx
@@ -40,22 +40,23 @@ WriteImage(const Image & inImage, const std::vector<PathType> & filenames, bool 
   writer.Execute(inImage, filenames, useCompression, compressionLevel);
 }
 
+const detail::MemberFunctionFactory<ImageSeriesWriter::MemberFunctionType> &
+ImageSeriesWriter::GetMemberFunctionFactory()
+{
+  static detail::MemberFunctionFactory<MemberFunctionType> factory = [] {
+    detail::MemberFunctionFactory<MemberFunctionType> factory;
+
+    using PixelIDTypeList = NonLabelPixelIDTypeList;
+    factory.RegisterMemberFunctions<PixelIDTypeList, 3>();
+    // factory.RegisterMemberFunctions< PixelIDTypeList, 2 > ();
+    return factory;
+  }();
+  return factory;
+}
+
 ImageSeriesWriter::~ImageSeriesWriter() = default;
 
-ImageSeriesWriter::ImageSeriesWriter()
-{
-
-  this->m_UseCompression = false;
-  this->m_CompressionLevel = -1;
-
-  // list of pixel types supported
-  using PixelIDTypeList = NonLabelPixelIDTypeList;
-
-  this->m_MemberFactory = std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>();
-
-  this->m_MemberFactory->RegisterMemberFunctions<PixelIDTypeList, 3>();
-  // this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 2 > ();
-}
+ImageSeriesWriter::ImageSeriesWriter() = default;
 
 std::string
 ImageSeriesWriter::ToString() const
@@ -201,10 +202,10 @@ ImageSeriesWriter::Execute(const Image & image)
 {
 
   // check that the number of file names match the slice size
-  PixelIDValueType type = image.GetPixelIDValue();
-  unsigned int     dimension = image.GetDimension();
+  const PixelIDValueType type = image.GetPixelIDValue();
+  const unsigned int     dimension = image.GetDimension();
 
-  this->m_MemberFactory->GetMemberFunction(type, dimension, this)(image);
+  GetMemberFunctionFactory().GetMemberFunction(type, dimension, this)(image);
 }
 
 template <class TImageType>

--- a/Code/IO/src/sitkImageSeriesWriter.cxx
+++ b/Code/IO/src/sitkImageSeriesWriter.cxx
@@ -43,7 +43,7 @@ WriteImage(const Image & inImage, const std::vector<PathType> & filenames, bool 
 const detail::MemberFunctionFactory<ImageSeriesWriter::MemberFunctionType> &
 ImageSeriesWriter::GetMemberFunctionFactory()
 {
-  static detail::MemberFunctionFactory<MemberFunctionType> factory = [] {
+  static detail::MemberFunctionFactory<MemberFunctionType> static_factory = [] {
     detail::MemberFunctionFactory<MemberFunctionType> factory;
 
     using PixelIDTypeList = NonLabelPixelIDTypeList;
@@ -51,7 +51,7 @@ ImageSeriesWriter::GetMemberFunctionFactory()
     // factory.RegisterMemberFunctions< PixelIDTypeList, 2 > ();
     return factory;
   }();
-  return factory;
+  return static_factory;
 }
 
 ImageSeriesWriter::~ImageSeriesWriter() = default;

--- a/Code/Registration/include/sitkImageRegistrationMethod.h
+++ b/Code/Registration/include/sitkImageRegistrationMethod.h
@@ -832,8 +832,6 @@ private:
   typedef Transform (ImageRegistrationMethod::*MemberFunctionType)(const Image & fixed, const Image & moving);
   typedef double (ImageRegistrationMethod::*EvaluateMemberFunctionType)(const Image & fixed, const Image & moving);
   friend struct detail::MemberFunctionAddressor<MemberFunctionType>;
-  detail::MemberFunctionFactory<MemberFunctionType>         m_MemberFactory;
-  detail::MemberFunctionFactory<EvaluateMemberFunctionType> m_EvaluateMemberFactory;
 
   InterpolatorEnum m_Interpolator;
   Transform        m_InitialTransform;

--- a/Code/Registration/include/sitkImageRegistrationMethod.h
+++ b/Code/Registration/include/sitkImageRegistrationMethod.h
@@ -832,8 +832,8 @@ private:
   typedef Transform (ImageRegistrationMethod::*MemberFunctionType)(const Image & fixed, const Image & moving);
   typedef double (ImageRegistrationMethod::*EvaluateMemberFunctionType)(const Image & fixed, const Image & moving);
   friend struct detail::MemberFunctionAddressor<MemberFunctionType>;
-  std::unique_ptr<detail::MemberFunctionFactory<MemberFunctionType>>         m_MemberFactory;
-  std::unique_ptr<detail::MemberFunctionFactory<EvaluateMemberFunctionType>> m_EvaluateMemberFactory;
+  detail::MemberFunctionFactory<MemberFunctionType>         m_MemberFactory;
+  detail::MemberFunctionFactory<EvaluateMemberFunctionType> m_EvaluateMemberFactory;
 
   InterpolatorEnum m_Interpolator;
   Transform        m_InitialTransform;

--- a/Code/Registration/src/sitkImageRegistrationMethod.cxx
+++ b/Code/Registration/src/sitkImageRegistrationMethod.cxx
@@ -79,19 +79,16 @@ ImageRegistrationMethod::ImageRegistrationMethod()
   , m_SmoothingSigmasAreSpecifiedInPhysicalUnits(true)
   , m_ActiveOptimizer(NULL)
 {
-  m_MemberFactory = std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>();
 
-  m_EvaluateMemberFactory = std::make_unique<detail::MemberFunctionFactory<EvaluateMemberFunctionType>>();
+  // m_MemberFactory.RegisterMemberFunctions< BasicPixelIDTypeList, 3 > ();
+  // m_MemberFactory.RegisterMemberFunctions< BasicPixelIDTypeList, 2 > ();
 
-  // m_MemberFactory->RegisterMemberFunctions< BasicPixelIDTypeList, 3 > ();
-  // m_MemberFactory->RegisterMemberFunctions< BasicPixelIDTypeList, 2 > ();
-
-  m_MemberFactory->RegisterMemberFunctions<RealPixelIDTypeList, 3>();
-  m_MemberFactory->RegisterMemberFunctions<RealPixelIDTypeList, 2>();
+  m_MemberFactory.RegisterMemberFunctions<RealPixelIDTypeList, 3>();
+  m_MemberFactory.RegisterMemberFunctions<RealPixelIDTypeList, 2>();
 
   using EvaluateMemberFunctionAddressorType = EvaluateMemberFunctionAddressor<EvaluateMemberFunctionType>;
-  m_EvaluateMemberFactory->RegisterMemberFunctions<RealPixelIDTypeList, 3, EvaluateMemberFunctionAddressorType>();
-  m_EvaluateMemberFactory->RegisterMemberFunctions<RealPixelIDTypeList, 2, EvaluateMemberFunctionAddressorType>();
+  m_EvaluateMemberFactory.RegisterMemberFunctions<RealPixelIDTypeList, 3, EvaluateMemberFunctionAddressorType>();
+  m_EvaluateMemberFactory.RegisterMemberFunctions<RealPixelIDTypeList, 2, EvaluateMemberFunctionAddressorType>();
 
   this->SetMetricAsMattesMutualInformation();
 }
@@ -757,9 +754,9 @@ ImageRegistrationMethod::Execute(const Image & fixed, const Image & moving)
                        << " and " << moving.GetDimension());
   }
 
-  if (this->m_MemberFactory->HasMemberFunction(fixedType, fixedDim))
+  if (this->m_MemberFactory.HasMemberFunction(fixedType, fixedDim))
   {
-    return this->m_MemberFactory->GetMemberFunction(fixedType, fixedDim, this)(fixed, moving);
+    return this->m_MemberFactory.GetMemberFunction(fixedType, fixedDim, this)(fixed, moving);
   }
 
   sitkExceptionMacro(<< "Filter does not support fixed image type: "
@@ -1013,9 +1010,9 @@ ImageRegistrationMethod::MetricEvaluate(const Image & fixed, const Image & movin
                        << " and " << moving.GetDimension());
   }
 
-  if (this->m_MemberFactory->HasMemberFunction(fixedType, fixedDim))
+  if (this->m_MemberFactory.HasMemberFunction(fixedType, fixedDim))
   {
-    return this->m_EvaluateMemberFactory->GetMemberFunction(fixedType, fixedDim, this)(fixed, moving);
+    return this->m_EvaluateMemberFactory.GetMemberFunction(fixedType, fixedDim, this)(fixed, moving);
   }
 
   sitkExceptionMacro(<< "Filter does not support fixed image type: "

--- a/ExpandTemplateGenerator/templates/ConstructorMemberFunctionSetup.cxx.jinja
+++ b/ExpandTemplateGenerator/templates/ConstructorMemberFunctionSetup.cxx.jinja
@@ -1,7 +1,19 @@
-  this->m_MemberFactory =  std::make_unique<detail::MemberFunctionFactory<MemberFunctionType>>( );
 
+const detail::MemberFunctionFactory<{{name}}::MemberFunctionType> &{{name}}::GetMemberFunctionFactory()
+{
+  static detail::MemberFunctionFactory<MemberFunctionType> factory = [](){
+    detail::MemberFunctionFactory<MemberFunctionType> factory;
 {%- if custom_register %}
-  {{ custom_register }}
+    {{ custom_register | indent(4) }}
 {% else %}
-  this->m_MemberFactory->RegisterMemberFunctions< PixelIDTypeList, 2, 3 > ();
+    factory.RegisterMemberFunctions< PixelIDTypeList, 2, 3 > ();
 {%- endif %}
+{% if vector_pixel_types_by_component %}
+    using VectorByComponentsPixelIDTypeList = {{ vector_pixel_types_by_component }};
+    using VectorAddressorType = detail::ExecuteInternalVectorImageAddressor<MemberFunctionType>;
+    factory.RegisterMemberFunctions< VectorByComponentsPixelIDTypeList, 2, 3, VectorAddressorType> ();
+{% endif %}
+    return factory;
+  }();
+  return factory;
+}

--- a/ExpandTemplateGenerator/templates/ConstructorMemberFunctionSetup.cxx.jinja
+++ b/ExpandTemplateGenerator/templates/ConstructorMemberFunctionSetup.cxx.jinja
@@ -1,7 +1,7 @@
 
 const detail::MemberFunctionFactory<{{name}}::MemberFunctionType> &{{name}}::GetMemberFunctionFactory()
 {
-  static detail::MemberFunctionFactory<MemberFunctionType> factory = [](){
+  static detail::MemberFunctionFactory<MemberFunctionType> static_factory = [](){
     detail::MemberFunctionFactory<MemberFunctionType> factory;
 {%- if custom_register %}
     {{ custom_register | indent(4) }}
@@ -15,5 +15,5 @@ const detail::MemberFunctionFactory<{{name}}::MemberFunctionType> &{{name}}::Get
 {% endif %}
     return factory;
   }();
-  return factory;
+  return static_factory;
 }

--- a/ExpandTemplateGenerator/templates/ConstructorVectorPixels.cxx.jinja
+++ b/ExpandTemplateGenerator/templates/ConstructorVectorPixels.cxx.jinja
@@ -1,5 +1,0 @@
-{% if vector_pixel_types_by_component %}
-  using VectorByComponentsPixelIDTypeList = {{ vector_pixel_types_by_component }};
-  using VectorAddressorType = detail::ExecuteInternalVectorImageAddressor<MemberFunctionType>;
-  this->m_MemberFactory->RegisterMemberFunctions< VectorByComponentsPixelIDTypeList, 2, 3, VectorAddressorType> ();
-{% endif -%}

--- a/ExpandTemplateGenerator/templates/ExecuteNoParameters.cxx.jinja
+++ b/ExpandTemplateGenerator/templates/ExecuteNoParameters.cxx.jinja
@@ -35,7 +35,7 @@
     {%- endfor %}
   {%- endif %}
 
-  return this->m_MemberFactory->GetMemberFunction( type, dimension, this )(
+  return GetMemberFunctionFactory().GetMemberFunction( type, dimension, this )(
     {#- Pass numbered image arguments #}
     {{- range(1, number_of_inputs+1) | format_list('image{}') | join(', ') }}
     {%- set comma = joiner(', ') %}

--- a/ExpandTemplateGenerator/templates/MemberFunctionDispatch.h.jinja
+++ b/ExpandTemplateGenerator/templates/MemberFunctionDispatch.h.jinja
@@ -2,4 +2,4 @@
     {%- if vector_pixel_types_by_component %}
     friend struct detail::ExecuteInternalVectorImageAddressor<MemberFunctionType>;
     {%- endif %}
-    std::unique_ptr<detail::MemberFunctionFactory<MemberFunctionType>> m_MemberFactory;
+    static const detail::MemberFunctionFactory<MemberFunctionType> &GetMemberFunctionFactory();


### PR DESCRIPTION
Replace the member varialbe for the member function factory with a function factory method which returns a singleton of for the function factory. The singleton is now shared between instance and in constant. This reduces the contruction time for each execution of a filter.

Additional, the initialization of some member objects has been moved to inline initialization.