### PR TITLE
Convert to a smart pointer for member.

### DIFF
--- a/Code/BasicFilters/templates/sitkBinaryFunctorFilterTemplate.h.jinja
+++ b/Code/BasicFilters/templates/sitkBinaryFunctorFilterTemplate.h.jinja
@@ -24,6 +24,7 @@
 
 #include "sitkBasicFilters.h"
 #include "sitkImageFilter.h"
+#include "sitkProcessObjectDeleter.h"
 
 {#- Import parameter macros for use in this template -#}
 {% import "macros.jinja" as macros %}

--- a/Code/BasicFilters/templates/sitkDualImageFilterTemplate.h.jinja
+++ b/Code/BasicFilters/templates/sitkDualImageFilterTemplate.h.jinja
@@ -28,6 +28,7 @@
 #include "sitkImageFilter.h"
 #include "sitkDualMemberFunctionFactory.h"
 #include "sitkBasicFilters.h"
+#include "sitkProcessObjectDeleter.h"
 
 namespace itk::simple {
 

--- a/Code/BasicFilters/templates/sitkImageFilterTemplate.h.jinja
+++ b/Code/BasicFilters/templates/sitkImageFilterTemplate.h.jinja
@@ -24,6 +24,7 @@
 
 #include "sitkBasicFilters.h"
 #include "sitkImageFilter.h"
+#include "sitkProcessObjectDeleter.h"
 
 namespace itk::simple {
 

--- a/Code/BasicFilters/templates/sitkImageSourceTemplate.h.jinja
+++ b/Code/BasicFilters/templates/sitkImageSourceTemplate.h.jinja
@@ -23,6 +23,7 @@
 #include <memory>
 
 #include "sitkBasicFilters.h"
+#include "sitkProcessObjectDeleter.h"
 
 {#- Import parameter macros for use in this template -#}
 {% import "macros.jinja" as macros %}

--- a/Code/BasicFilters/templates/sitkMultiInputImageFilterTemplate.h.jinja
+++ b/Code/BasicFilters/templates/sitkMultiInputImageFilterTemplate.h.jinja
@@ -24,6 +24,7 @@
 
 #include "sitkBasicFilters.h"
 #include "sitkImageFilter.h"
+#include "sitkProcessObjectDeleter.h"
 
 namespace itk::simple {
 

--- a/Code/Common/include/sitkLogger.h
+++ b/Code/Common/include/sitkLogger.h
@@ -21,8 +21,9 @@
 
 #include "sitkCommon.h"
 #include "sitkObjectOwnedBase.h"
+#include "sitkProcessObjectDeleter.h"
 
-#include <map>
+#include <memory>
 
 
 namespace itk
@@ -48,7 +49,7 @@ class ITKLogger;
 class SITKCommon_EXPORT LoggerBase : public ObjectOwnedBase
 {
 public:
-  LoggerBase() = default;
+  LoggerBase();
 
   ~LoggerBase() override;
 
@@ -113,7 +114,7 @@ public:
   explicit ITKLogger(itk::OutputWindow *);
   ~ITKLogger() override;
 
-  ITKLogger() = default;
+  ITKLogger();
   ITKLogger(const ITKLogger &);
   ITKLogger & operator=(ITKLogger);
 
@@ -143,7 +144,7 @@ public:
 
 
 private:
-  itk::OutputWindow * m_OutputWindow{ nullptr };
+  std::unique_ptr<itk::OutputWindow, ProcessObjectDeleter> m_OutputWindow;
 };
 
 } // namespace simple

--- a/Code/Common/include/sitkProcessObjectDeleter.h
+++ b/Code/Common/include/sitkProcessObjectDeleter.h
@@ -1,0 +1,39 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef sitkProcessObjectDeleter_h
+#define sitkProcessObjectDeleter_h
+
+
+namespace itk
+{
+
+class LightObject;
+
+namespace simple
+{
+
+struct ProcessObjectDeleter
+{
+  void
+  operator()(itk::LightObject * ptr) const;
+};
+
+} // namespace simple
+} // namespace itk
+
+#endif

--- a/Code/Common/src/CMakeLists.txt
+++ b/Code/Common/src/CMakeLists.txt
@@ -29,6 +29,7 @@ set(
   sitkInterpolator.cxx
   sitkVersion.cxx
   sitkObjectOwnedBase.cxx
+  sitkProcessObjectDeleter.cxx
   ../include/Ancillary/hl_sha1.cxx
 )
 

--- a/Code/Common/src/sitkLogger.cxx
+++ b/Code/Common/src/sitkLogger.cxx
@@ -119,7 +119,10 @@ protected:
 
 } // namespace
 
-LoggerBase::~LoggerBase() {}
+
+LoggerBase::LoggerBase() = default;
+
+LoggerBase::~LoggerBase() = default;
 
 ITKLogger
 LoggerBase::SetAsGlobalITKLogger()
@@ -201,7 +204,7 @@ ITKLogger::ITKLogger(itk::OutputWindow * ow)
 
 ITKLogger::ITKLogger(const ITKLogger & other)
   : LoggerBase(other)
-  , m_OutputWindow(other.m_OutputWindow)
+  , m_OutputWindow(other.m_OutputWindow.get())
 {
   if (m_OutputWindow)
   {
@@ -225,17 +228,13 @@ ITKLogger::operator=(ITKLogger o)
   return *this;
 }
 
+ITKLogger::ITKLogger() = default;
 
 ITKLogger::~ITKLogger()
 {
   if (GetOwnedByObjects())
   {
     sitkWarningMacro("ITKLogger::GetOwnedByObjects is true.")
-  }
-  if (m_OutputWindow)
-  {
-    m_OutputWindow->UnRegister();
-    m_OutputWindow = nullptr;
   }
 }
 
@@ -292,7 +291,7 @@ ITKLogger::SetAsGlobalITKLogger()
     sitkExceptionMacro("Unable to set global ITK logger to nullptr.")
   }
   ITKLogger oldLogger = GetGlobalITKLogger();
-  itk::OutputWindow::SetInstance(m_OutputWindow);
+  itk::OutputWindow::SetInstance(m_OutputWindow.get());
   return oldLogger;
 }
 

--- a/Code/Common/src/sitkProcessObjectDeleter.cxx
+++ b/Code/Common/src/sitkProcessObjectDeleter.cxx
@@ -1,0 +1,36 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#include "sitkProcessObjectDeleter.h"
+#include <itkLightObject.h>
+
+namespace itk
+{
+namespace simple
+{
+
+void
+ProcessObjectDeleter::operator()(itk::LightObject * ptr) const
+{
+  if (ptr != nullptr)
+  {
+    ptr->UnRegister();
+  }
+}
+
+} // namespace simple
+} // namespace itk

--- a/Code/IO/include/sitkImageSeriesReader.h
+++ b/Code/IO/include/sitkImageSeriesReader.h
@@ -22,6 +22,7 @@
 #include "sitkImage.h"
 #include "sitkImageReaderBase.h"
 #include "sitkMemberFunctionFactory.h"
+#include "sitkProcessObjectDeleter.h"
 
 namespace itk::simple
 {
@@ -265,8 +266,8 @@ private:
   std::function<bool(int, const std::string &)>        m_pfHasMetaDataKey;
   std::function<std::string(int, const std::string &)> m_pfGetMetaData;
 
-  // Holder of process object for active measurements
-  itk::ProcessObject * m_Filter{ nullptr };
+  // Holder of a process object for active measurements
+  std::unique_ptr<itk::ProcessObject, ProcessObjectDeleter> m_Filter;
 
 
   std::vector<PathType> m_FileNames;

--- a/Code/IO/src/sitkImageSeriesReader.cxx
+++ b/Code/IO/src/sitkImageSeriesReader.cxx
@@ -147,13 +147,7 @@ ImageSeriesReader::ImageSeriesReader()
   this->m_MemberFactory->RegisterMemberFunctions<PixelIDTypeList, 2, SITK_MAX_DIMENSION>();
 }
 
-ImageSeriesReader::~ImageSeriesReader()
-{
-  if (this->m_Filter != nullptr)
-  {
-    m_Filter->UnRegister();
-  }
-}
+ImageSeriesReader::~ImageSeriesReader() = default;
 
 std::string
 ImageSeriesReader::ToString() const
@@ -268,21 +262,17 @@ ImageSeriesReader::ExecuteInternal(itk::ImageIOBase * imageio)
   reader->SetMetaDataDictionaryArrayUpdate(m_MetaDataDictionaryArrayUpdate);
 
   // release the old filter ( and output data )
-  if (this->m_Filter != nullptr)
-  {
-    this->m_pfGetMetaDataKeys = nullptr;
-    this->m_pfHasMetaDataKey = nullptr;
-    this->m_pfGetMetaData = nullptr;
-    this->m_Filter->UnRegister();
-    this->m_Filter = nullptr;
-  }
+  this->m_pfGetMetaDataKeys = nullptr;
+  this->m_pfHasMetaDataKey = nullptr;
+  this->m_pfGetMetaData = nullptr;
+  this->m_Filter = nullptr;
 
 
   this->PreUpdate(reader.GetPointer());
 
   if (m_MetaDataDictionaryArrayUpdate)
   {
-    this->m_Filter = reader;
+    this->m_Filter.reset(reader);
     this->m_Filter->Register();
     this->m_pfGetMetaDataKeys = [capture0 = reader.GetPointer()](auto && PH1) {
       return GetMetaDataKeysCustomCast<Reader>::CustomCast(capture0, std::forward<decltype(PH1)>(PH1));

--- a/ExpandTemplateGenerator/templates/DestructorDefinition.cxx.jinja
+++ b/ExpandTemplateGenerator/templates/DestructorDefinition.cxx.jinja
@@ -1,14 +1,4 @@
 //
 // Destructor
 //
-{{ name }}::~{{ name }}()
-{% set has_active = measurements | selectattr('active') | list | length > 0 %}
-{% if has_active %}
-{
-  if (this->m_Filter != nullptr)
-    {
-      m_Filter->UnRegister();
-    }
-}
-{% else %} = default;
-{%- endif %}
+{{ name }}::~{{ name }}() = default;

--- a/ExpandTemplateGenerator/templates/ExecuteInternalUpdateAndReturn.cxx.jinja
+++ b/ExpandTemplateGenerator/templates/ExecuteInternalUpdateAndReturn.cxx.jinja
@@ -2,20 +2,14 @@
 {#- Check if any measurement is active #}
 {% set any_active = measurements | selectattr('active') | list | length > 0 %}
 {% if any_active %}
-
   // release the old filter ( and output data )
-  if ( this->m_Filter != nullptr)
-    {
-  {% for m in measurements %}
-    {% if m.active %}
-        this->m_pfGet{{ m.name }} = nullptr;
-    {% endif %}
-  {% endfor %}
-      this->m_Filter->UnRegister();
-      this->m_Filter = nullptr;
-    }
+{% for m in measurements -%}
+  {% if m.active -%}
+   this->m_pfGet{{ m.name }} = nullptr;
+  {% endif %}
+{%- endfor %}
 
-  this->m_Filter = filter;
+  this->m_Filter.reset(filter);
   this->m_Filter->Register();
 {% endif %}
 

--- a/ExpandTemplateGenerator/templates/PrivateMemberDeclarations.h.jinja
+++ b/ExpandTemplateGenerator/templates/PrivateMemberDeclarations.h.jinja
@@ -29,8 +29,9 @@
 {%- endfor %}
 {# If any measurement is active, add m_Filter #}
 {%- if measurements|selectattr('active')|list|length > 0 %}
+
     // Holder of process object for active measurements
-    itk::ProcessObject *m_Filter{nullptr};
+    std::unique_ptr<itk::ProcessObject, ProcessObjectDeleter> m_Filter{nullptr};
 {%- endif %}
 
 {# In-place logic #}


### PR DESCRIPTION
Remove the manual release of the ITK pointer in the destructor, in favor of a RAII unique_ptr configured to call the UnRegister method at scope exit.