### PR TITLE
Suppress single_module obsolete warning

### DIFF
--- a/CMake/CTestCustom.cmake.in
+++ b/CMake/CTestCustom.cmake.in
@@ -69,6 +69,8 @@ SET(CTEST_CUSTOM_WARNING_EXCEPTION
 
   # Warning on CircleCI
   "Warning: Permanently added.*to the list of known hosts"
+
+  "checking for.*single_module is obsolete"
 )
 
 SET(CTEST_CUSTOM_ERROR_EXCEPTION


### PR DESCRIPTION
Should address the following build warning during super build:

CUSTOMBUILD : warning : Failed to hardlink files; falling back to full copy. This may lead to degraded performance. [D:\a\SimpleITK\SimpleITK-build\SimpleITK_VENV.vcxproj]