### PR TITLE
fix pre commit setup

### DIFF
--- a/Utilities/GitSetup/setup-precommit
+++ b/Utilities/GitSetup/setup-precommit
@@ -50,6 +50,6 @@ fi
 (
     echo "Setting up pre-commit..." &&
     source ${git_dir}/hooks/venv/bin/activate &&
-    python -m pip install --disable-pip-version-check -q -U "pre-commit>=$MIN_PRECOMMIT_VERSION" &&
+    python3 -m pip install --disable-pip-version-check -q -U "pre-commit>=$MIN_PRECOMMIT_VERSION" &&
     pre-commit install -f -t pre-commit -t prepare-commit-msg -t commit-msg
 )


### PR DESCRIPTION
The executable name on some platforms *MUST* be python3. 

There was one case where it continued to be "python".