### PR TITLE
Improve formatting of generated doxygen code blocks

### DIFF
--- a/Code/BasicFilters/templates/sitkImageSourceTemplate.h.jinja
+++ b/Code/BasicFilters/templates/sitkImageSourceTemplate.h.jinja
@@ -53,18 +53,18 @@ namespace itk::simple {
 
 
 
-   /**
+/**
 {% if briefdescription and (briefdescription|length > 0) %}
-     * \brief {{ briefdescription }}
-{% else %}
-     * \brief itk::simple::{{ name }} Procedural Interface
-{% endif %}
-     *
-     * This function directly calls the execute method of {{ name }}
-     * in order to support a procedural API
-     *
-     * \sa itk::simple::{{ name }} for the object oriented interface
-     */
+ * \brief {{ briefdescription }}
+{%- else %}
+ * \brief itk::simple::{{ name }} Procedural Interface
+{%- endif %}
+ *
+ * This function directly calls the execute method of {{ name }}
+ * in order to support a procedural API
+ *
+ * \sa itk::simple::{{ name }} for the object oriented interface
+ */
 SITKBasicFilters_EXPORT Image {{ name|regex_replace("ImageSource$", "Source")|regex_replace("(ImageFilter|Filter)$", "") }} (
   {{ macros.image_parameters(number_of_inputs) }}
   {{ macros.input_parameters(inputs, number_of_inputs, name, no_optional) }}

--- a/Code/BasicFilters/templates/sitkMultiInputImageFilterTemplate.h.jinja
+++ b/Code/BasicFilters/templates/sitkMultiInputImageFilterTemplate.h.jinja
@@ -28,30 +28,30 @@
 
 namespace itk::simple {
 
-   /**\class {{ name }}
-{% if briefdescription and briefdescription|length > 0 %}
-\brief {{ briefdescription }}
-{% endif %}
-{% if detaileddescription and detaileddescription|length > 0 %}
-{{ detaileddescription }}
-{% endif %}
-\sa itk::simple::{{ name|regex_replace('(ImageFilter|Filter)$', '') }} for the procedural interface
-   */
-    class SITKBasicFilters_EXPORT {{ name }}
-      : public ImageFilter
-    {
-    public:
-      using Self = {{ name }};
+/**
+ * \class {{ name }}
+{%- if briefdescription %}
+ * \brief {{ briefdescription }}
+{%- endif %}
+ *
+{%- if detaileddescription %}
+ * {{ detaileddescription | wordwrap(117) | indent(" * ", blank=True) }}
+{%- endif %}
+ * \sa itk::simple::{{ name|regex_replace('(ImageFilter|Filter)$', '') }} for the procedural interface
+ */
+class SITKBasicFilters_EXPORT {{ name }} : public ImageFilter {
+public:
+  using Self = {{ name }};
 
-      /** Destructor */
-      virtual ~{{ name }}();
+  /** Destructor */
+  virtual ~{{ name }}();
 
-      /** Default Constructor that takes no arguments and initializes
-       * default parameters */
-      {{ name }}();
+  /** Default Constructor that takes no arguments and initializes
+   * default parameters */
+  {{ name }}();
 
-      /** Define the pixels types supported by this filter */
-      using PixelIDTypeList = {{ pixel_types }};
+  /** Define the pixels types supported by this filter */
+  using PixelIDTypeList = {{ pixel_types }};
 
 {% include "PublicDeclarations.h.jinja" %}
 {% include "MemberGetSetDeclarations.h.jinja" %}
@@ -81,23 +81,23 @@ namespace itk::simple {
 };
 
 
-   /**
-{% if briefdescription and briefdescription|length > 0 %}
-     * \brief {{ briefdescription }}
-{% else %}
-     * \brief itk::simple::{{ name }} Procedural Interface
-{% endif %}
-     *
-     * This function directly calls the execute method of {{ name }}
-     * in order to support a procedural API
-     *
-     * \sa itk::simple::{{ name }} for the object oriented interface
-     * @{ */
-     SITKBasicFilters_EXPORT Image {{ name|regex_replace('(ImageFilter|Filter)$', '') }}(const std::vector<Image> &images{% include "MemberParametersWithDefaults.jinja" %});
+/**
+{%- if briefdescription %}
+ * \brief {{ briefdescription }}
+{%- else %}
+ * \brief itk::simple::{{ name }} Procedural Interface
+{%- endif %}
+ *
+ * This function directly calls the execute method of {{ name }}
+ * in order to support a procedural API
+ *
+ * \sa itk::simple::{{ name }} for the object oriented interface
+ * @{ */
+SITKBasicFilters_EXPORT Image {{ name|regex_replace('(ImageFilter|Filter)$', '') }}(const std::vector<Image> &images{% include "MemberParametersWithDefaults.jinja" %});
 {% for inum in range(1, 6) %}
-     SITKBasicFilters_EXPORT Image {{ name|regex_replace('(ImageFilter|Filter)$', '') }}(const Image& image1{% for jnum in range(2, inum+1) %}, const Image& image{{ jnum }}{% endfor %}{% include "MemberParametersWithDefaults.jinja" %});
+SITKBasicFilters_EXPORT Image {{ name|regex_replace('(ImageFilter|Filter)$', '') }}(const Image& image1{% for jnum in range(2, inum+1) %}, const Image& image{{ jnum }}{% endfor %}{% include "MemberParametersWithDefaults.jinja" %});
 {% endfor %}
-     /** @{ */
+/** @{ */
 
 }
 #endif

--- a/ExpandTemplateGenerator/templates/ClassDeclaration.h.jinja
+++ b/ExpandTemplateGenerator/templates/ClassDeclaration.h.jinja
@@ -1,14 +1,15 @@
 /**
  * \class {{ name }}
-{% if briefdescription %}
+{%- if briefdescription %}
  * \brief {{ briefdescription }}
-{% endif %}
-{% if detaileddescription %}
- * {{ detaileddescription }}
-{% endif %}
-{% if not no_procedure %}
+{%- endif %}
+ *
+{%- if detaileddescription %}
+ * {{ detaileddescription | wordwrap(117) | indent(" * ", blank=True) }}
+{%- endif %}
+{%- if not no_procedure %}
  * \sa itk::simple::{{ name|regex_replace('ImageSource$', 'Source')|regex_replace('(ImageFilter|Filter)$', '') }} for the procedural interface
-{% endif %}
+{%- endif %}
  * \sa {% if itk_name %}itk::{{ itk_name }}{% elif filter_type %}{{ filter_type|regex_replace('<.*>', '') }}{% else %}itk::{{ name }}{% endif %} for the Doxygen on the original ITK class.
  */
 class SITKBasicFilters_EXPORT {{ name }} : public ImageFilter {

--- a/ExpandTemplateGenerator/templates/MemberGetSetDeclarations.h.jinja
+++ b/ExpandTemplateGenerator/templates/MemberGetSetDeclarations.h.jinja
@@ -14,7 +14,7 @@
    * \brief {{ member.briefdescriptionSet }}
     {%- endif %}
     {%- if member.detaileddescriptionSet %}
-   * {{ member.detaileddescriptionSet }}
+   * {{ member.detaileddescriptionSet | wordwrap(117) | indent(" * ", blank=True)  }}
     {%- endif %}
    */
   void
@@ -57,7 +57,7 @@
    * \brief {{ member.briefdescriptionGet }}
     {%- endif %}
     {%- if member.detaileddescriptionGet %}
-   * {{ member.detaileddescriptionGet }}
+   * {{ member.detaileddescriptionGet | wordwrap(117) | indent(" * ", blank=True) }}
     {%- endif %}
    */
     {%- if not member.type and member.enum %}

--- a/ExpandTemplateGenerator/templates/ProceduralAPI.h.jinja
+++ b/ExpandTemplateGenerator/templates/ProceduralAPI.h.jinja
@@ -1,18 +1,18 @@
 /**
-{% if briefdescription %}
-     * \brief {{ briefdescription }}
-{% else %}
-     * \brief itk::simple::{{ name }} Procedural Interface
-{% endif %}
-     *
-     * This function directly calls the execute method of {{ name }}
-     * in order to support a procedural API
-     *
-     * \sa itk::simple::{{ name }} for the object oriented interface
-     * @{ */
-{% import "macros.jinja" as macros %}
+{%- if briefdescription %}
+ * \brief {{ briefdescription }}
+{%- else %}
+ * \brief itk::simple::{{ name }} Procedural Interface
+{%- endif %}
+ *
+ * This function directly calls the execute method of {{ name }}
+ * in order to support a procedural API
+ *
+ * \sa itk::simple::{{ name }} for the object oriented interface
+ * @{ */
+{%- import "macros.jinja" as macros -%}
 {%- set has_optional_inputs = inputs | selectattr('optional') | list | length > 0 %}
-{% if in_place %}
+{%- if in_place %}
 #ifndef SWIG
 SITKBasicFilters_EXPORT Image {{ name|regex_replace('(ImageFilter|Filter)$', '') }}(
     {{ macros.image_parameters(number_of_inputs, True) }}{{ macros.input_parameters(inputs, number_of_inputs, name, no_optional, True) }}{% include "MemberParametersWithDefaults.jinja" %}
@@ -22,9 +22,9 @@ SITKBasicFilters_EXPORT Image {{ name|regex_replace('(ImageFilter|Filter)$', '')
 SITKBasicFilters_EXPORT Image {{ name|regex_replace('(ImageFilter|Filter)$', '') }}(
     {{ macros.image_parameters(number_of_inputs, True) }}{{ macros.input_parameters(inputs, number_of_inputs, name, 1, True) }}{% include "MemberParametersWithDefaults.jinja" %}
 );
-{% endif %}
+{%- endif %}
 #endif
-{% endif %}
+{%- endif %}
 SITKBasicFilters_EXPORT Image {{ name|regex_replace('(ImageFilter|Filter)$', '') }}(
     {{ macros.image_parameters(number_of_inputs) }}{{ macros.input_parameters(inputs, number_of_inputs, name, no_optional) }}{% include "MemberParametersWithDefaults.jinja" %}
 );


### PR DESCRIPTION
Use the "indent" filter to add "*" to the prefix of multi-line doxygen comments. Additionally remove extra new lines in doxygen blocks.