### PR TITLE
DOC: correct referencing of code in the rst file.

### DIFF
--- a/Examples/SimpleIO/SimpleIO.R
+++ b/Examples/SimpleIO/SimpleIO.R
@@ -28,6 +28,7 @@
 example1 <- function(inputImageFileName, outputImageFileName) {
   library(SimpleITK)
 
+  #START_OO_IMAGE_READER_WRITER_EXAMPLE
   reader <- ImageFileReader()
   reader$SetImageIO("PNGImageIO")
   reader$SetFileName(inputImageFileName)
@@ -36,18 +37,22 @@ example1 <- function(inputImageFileName, outputImageFileName) {
   writer <- ImageFileWriter()
   writer$SetFileName(outputImageFileName)
   writer$Execute(image)
+  #END_OO_IMAGE_READER_WRITER_EXAMPLE
 }
 
 example2 <- function(inputImageFileName, outputImageFileName) {
   library(SimpleITK)
 
+  #START_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
   image <- ReadImage(inputImageFileName)
   WriteImage(image, outputImageFileName)
+  #END_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
 }
 
 example3 <- function() {
   library(SimpleITK)
 
+  #START_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
   basic_transform <- Euler2DTransform()
   basic_transform$SetTranslation(c(2,3))
 
@@ -55,6 +60,7 @@ example3 <- function() {
   read_result = ReadTransform('euler2D.tfm')
 
   stopifnot(read_result$GetName() != basic_transform$GetName())
+  #END_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
 }
 
 args <- commandArgs( TRUE )

--- a/Examples/SimpleIO/SimpleIO.cs
+++ b/Examples/SimpleIO/SimpleIO.cs
@@ -28,6 +28,7 @@ namespace itk.simple.examples {
     class SimpleIO {
 
 static void example1(string inputImageFileName, string outputImageFileName) {
+  //START_OO_IMAGE_READER_WRITER_EXAMPLE
   ImageFileReader reader = new ImageFileReader();
   reader.SetImageIO("PNGImageIO");
   reader.SetFileName(inputImageFileName);
@@ -36,14 +37,18 @@ static void example1(string inputImageFileName, string outputImageFileName) {
   ImageFileWriter writer = new ImageFileWriter();
   writer.SetFileName(outputImageFileName);
   writer.Execute(image);
+  //END_OO_IMAGE_READER_WRITER_EXAMPLE
 }
 
 static void example2(string inputImageFileName, string outputImageFileName) {
+  //START_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
   Image image = sitk.ReadImage(inputImageFileName, PixelIDValueEnum.sitkUnknown, "PNGImageIO");
   sitk.WriteImage(image, outputImageFileName);
+  //END_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
 }
 
 static void example3() {
+  //START_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
   Euler2DTransform basic_transform = new Euler2DTransform();
   VectorDouble trans = new VectorDouble( new double[] {2.0, 3.0} );
   basic_transform.SetTranslation(trans);
@@ -53,6 +58,7 @@ static void example3() {
   Transform read_result = sitk.ReadTransform("euler2D.tfm");
 
   Debug.Assert( basic_transform.GetName() != read_result.GetName() );
+  //END_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
 }
 
 static void Main(string[] args) {

--- a/Examples/SimpleIO/SimpleIO.cxx
+++ b/Examples/SimpleIO/SimpleIO.cxx
@@ -31,6 +31,7 @@
 void
 example1(std::string inputImageFileName, std::string outputImageFileName)
 {
+  // START_OO_IMAGE_READER_WRITER_EXAMPLE
   itk::simple::ImageFileReader reader;
   reader.SetImageIO("PNGImageIO");
   reader.SetFileName(inputImageFileName);
@@ -41,20 +42,24 @@ example1(std::string inputImageFileName, std::string outputImageFileName)
   itk::simple::ImageFileWriter writer;
   writer.SetFileName(outputImageFileName);
   writer.Execute(image);
+  // END_OO_IMAGE_READER_WRITER_EXAMPLE
 }
 
 void
 example2(std::string inputImageFileName, std::string outputImageFileName)
 {
+  // START_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
   itk::simple::Image image;
   image = itk::simple::ReadImage(inputImageFileName, itk::simple::sitkUnknown, "PNGImageIO");
 
   itk::simple::WriteImage(image, outputImageFileName);
+  // END_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
 }
 
 void
 example3()
 {
+  // START_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
   itk::simple::Euler2DTransform basic_transform;
   basic_transform.SetTranslation(std::vector<double>{ 2.0, 3.0 });
 
@@ -62,6 +67,7 @@ example3()
   itk::simple::Transform read_result = itk::simple::ReadTransform("euler2D.tfm");
 
   assert(typeid(basic_transform) != typeid(read_result));
+  // END_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
 }
 
 

--- a/Examples/SimpleIO/SimpleIO.java
+++ b/Examples/SimpleIO/SimpleIO.java
@@ -26,6 +26,7 @@ import org.itk.simple.*;
 class SimpleIO {
 
 static void example1(String inputImageFileName, String outputImageFileName) {
+  //START_OO_IMAGE_READER_WRITER_EXAMPLE
   ImageFileReader reader = new ImageFileReader();
   reader.setImageIO("PNGImageIO");
   reader.setFileName(inputImageFileName);
@@ -34,14 +35,18 @@ static void example1(String inputImageFileName, String outputImageFileName) {
   ImageFileWriter writer = new ImageFileWriter();
   writer.setFileName(outputImageFileName);
   writer.execute(image);
+  //END_OO_IMAGE_READER_WRITER_EXAMPLE
 }
 
 static void example2(String inputImageFileName, String outputImageFileName) {
+  //START_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
   Image image = SimpleITK.readImage(inputImageFileName, PixelIDValueEnum.sitkUnknown, "PNGImageIO");
   SimpleITK.writeImage(image, outputImageFileName);
+  //END_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
 }
 
 static void example3() {
+  //START_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
   Euler2DTransform basic_transform = new Euler2DTransform();
   double[] t = {2.0, 3.0};
   VectorDouble trans = new VectorDouble(t);
@@ -51,6 +56,7 @@ static void example3() {
   Transform read_result = SimpleITK.readTransform("euler2D.tfm");
 
   assert basic_transform.getClass() != read_result.getClass();
+  //END_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
 }
 
 public static void main(String argv[]) {

--- a/Examples/SimpleIO/SimpleIO.lua
+++ b/Examples/SimpleIO/SimpleIO.lua
@@ -24,6 +24,7 @@
 function example1(inputImageFileName, outputImageFileName)
   require "SimpleITK"
 
+  --START_OO_IMAGE_READER_WRITER_EXAMPLE
   reader = SimpleITK.ImageFileReader()
   reader:SetImageIO("PNGImageIO")
   reader:SetFileName(inputImageFileName)
@@ -32,18 +33,22 @@ function example1(inputImageFileName, outputImageFileName)
   writer = SimpleITK.ImageFileWriter()
   writer:SetFileName(outputImageFileName)
   writer:Execute(image);
+  --END_OO_IMAGE_READER_WRITER_EXAMPLE
 end
 
 function example2(inputImageFileName, outputImageFileName)
   require "SimpleITK"
 
+  --START_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
   image = SimpleITK.ReadImage(inputImageFileName, SimpleITK.sitkUnknown, "PNGImageIO")
   SimpleITK.WriteImage(image, outputImageFileName)
+  --END_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
 end
 
 function example3()
   require "SimpleITK"
 
+  --START_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
   basic_transform = SimpleITK.Euler2DTransform()
   trans = SimpleITK.VectorDouble()
   trans:push_back(2.0)
@@ -54,6 +59,7 @@ function example3()
   read_result = SimpleITK.ReadTransform('euler2D.tfm')
 
   assert(read_result:GetName() ~= basic_transform:GetName(), "type error")
+  --END_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
 end
 
 if #arg < 2 then

--- a/Examples/SimpleIO/SimpleIO.py
+++ b/Examples/SimpleIO/SimpleIO.py
@@ -34,6 +34,7 @@ def example1(inputImageFileName, outputImageFileName):
 
     import SimpleITK as sitk
 
+    #START_OO_IMAGE_READER_WRITER_EXAMPLE
     reader = sitk.ImageFileReader()
     reader.SetImageIO("PNGImageIO")
     reader.SetFileName(inputImageFileName)
@@ -42,6 +43,7 @@ def example1(inputImageFileName, outputImageFileName):
     writer = sitk.ImageFileWriter()
     writer.SetFileName(outputImageFileName)
     writer.Execute(image)
+    #END_OO_IMAGE_READER_WRITER_EXAMPLE
 
 
 # A simple procedural image input/output example
@@ -51,8 +53,10 @@ def example2(inputImageFileName, outputImageFileName):
 
     import SimpleITK as sitk
 
+    #START_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
     image = sitk.ReadImage(inputImageFileName, imageIO="PNGImageIO")
     sitk.WriteImage(image, outputImageFileName)
+    #END_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
 
 
 # A simple transform input/output example
@@ -62,6 +66,7 @@ def example3():
 
     import SimpleITK as sitk
 
+    #START_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
     basic_transform = sitk.Euler2DTransform()
     basic_transform.SetTranslation((2, 3))
 
@@ -69,6 +74,7 @@ def example3():
     read_result = sitk.ReadTransform("euler2D.tfm")
 
     assert isinstance(read_result, sitk.Euler2DTransform)
+    #END_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
 
 
 if __name__ == "__main__":

--- a/Examples/SimpleIO/SimpleIO.rb
+++ b/Examples/SimpleIO/SimpleIO.rb
@@ -23,6 +23,7 @@
 def example1(inputImageFileName, outputImageFileName)
   require 'simpleitk'
 
+  #START_OO_IMAGE_READER_WRITER_EXAMPLE
   reader = Simpleitk::ImageFileReader.new
   reader.set_image_io("PNGImageIO")
   reader.set_file_name(inputImageFileName)
@@ -31,18 +32,22 @@ def example1(inputImageFileName, outputImageFileName)
   writer = Simpleitk::ImageFileWriter.new
   writer.set_file_name outputImageFileName
   writer.execute image
+  #END_OO_IMAGE_READER_WRITER_EXAMPLE
 end
 
 def example2(inputImageFileName, outputImageFileName)
   require 'simpleitk'
 
+  #START_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
   image = Simpleitk::read_image(inputImageFileName, Simpleitk::SitkUnknown, "PNGImageIO")
   Simpleitk::write_image(image, outputImageFileName)
+  #END_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
 end
 
 def example3()
   require 'simpleitk'
 
+  #START_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
   basic_transform = Simpleitk::Euler2DTransform.new
   trans = Simpleitk::VectorDouble.new
   trans << 2.0
@@ -53,6 +58,7 @@ def example3()
   read_result = Simpleitk::read_transform('euler2D.tfm')
 
   raise "This shouldn't happen." unless basic_transform.class != read_result.class
+  #END_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
 end
 
 if ARGV.length != 2 then

--- a/Examples/SimpleIO/SimpleIO.tcl
+++ b/Examples/SimpleIO/SimpleIO.tcl
@@ -21,6 +21,7 @@
 # change in the line numbers of the code below will break the I/O page.
 
 proc example1 {inputImageFileName outputImageFileName} {
+  #START_OO_IMAGE_READER_WRITER_EXAMPLE
   ImageFileReader reader
   reader SetImageIO "PNGImageIO"
   reader SetFileName $inputImageFileName
@@ -33,17 +34,21 @@ proc example1 {inputImageFileName outputImageFileName} {
   reader -delete
   writer -delete
   $image -delete
+  #END_OO_IMAGE_READER_WRITER_EXAMPLE
 }
 
 proc example2 {inputImageFileName outputImageFileName} {
   global sitkUnknown
+  #START_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
   set image [ ReadImage $inputImageFileName $sitkUnknown "PNGImageIO" ]
   WriteImage $image $outputImageFileName
 
   $image -delete
+  #END_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
 }
 
 proc example3 {} {
+  #START_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
   Euler2DTransform basic_transform
   set trans { 2.0 3.0 }
   basic_transform SetTranslation $trans
@@ -57,6 +62,7 @@ proc example3 {} {
 
   basic_transform -delete
   $read_result -delete
+  #END_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
 }
 
 if { $argc < 2 } {

--- a/docs/source/IO.rst
+++ b/docs/source/IO.rst
@@ -43,49 +43,57 @@ A read and write example using SimpleITK's `ImageFileReader <https://simpleitk.o
 
     .. literalinclude:: ../../Examples/SimpleIO/SimpleIO.cs
        :language: csharp
-       :lines: 31-38
+       :start-after: //START_OO_IMAGE_READER_WRITER_EXAMPLE
+       :end-before: //END_OO_IMAGE_READER_WRITER_EXAMPLE
 
   .. tab:: C++
 
     .. literalinclude:: ../../Examples/SimpleIO/SimpleIO.cxx
        :language: cpp
-       :lines: 33-41
+       :start-after: //START_OO_IMAGE_READER_WRITER_EXAMPLE
+       :end-before: //END_OO_IMAGE_READER_WRITER_EXAMPLE
 
   .. tab:: Java
 
     .. literalinclude:: ../../Examples/SimpleIO/SimpleIO.java
        :language: java
-       :lines: 29-36
+       :start-after: //START_OO_IMAGE_READER_WRITER_EXAMPLE
+       :end-before: //END_OO_IMAGE_READER_WRITER_EXAMPLE
 
   .. tab:: Lua
 
     .. literalinclude:: ../../Examples/SimpleIO/SimpleIO.lua
        :language: lua
-       :lines: 25-34
+       :start-after: --START_OO_IMAGE_READER_WRITER_EXAMPLE
+       :end-before: --END_OO_IMAGE_READER_WRITER_EXAMPLE
 
   .. tab:: Python
 
     .. literalinclude:: ../../Examples/SimpleIO/SimpleIO.py
        :language: python
-       :lines: 31-40
+       :start-after: #START_OO_IMAGE_READER_WRITER_EXAMPLE
+       :end-before: #END_OO_IMAGE_READER_WRITER_EXAMPLE
 
   .. tab:: R
 
     .. literalinclude:: ../../Examples/SimpleIO/SimpleIO.R
        :language: r
-       :lines: 29-38
+       :start-after: #START_OO_IMAGE_READER_WRITER_EXAMPLE
+       :end-before: #END_OO_IMAGE_READER_WRITER_EXAMPLE
 
   .. tab:: Ruby
 
     .. literalinclude:: ../../Examples/SimpleIO/SimpleIO.rb
        :language: ruby
-       :lines: 24-33
+       :start-after: #START_OO_IMAGE_READER_WRITER_EXAMPLE
+       :end-before: #END_OO_IMAGE_READER_WRITER_EXAMPLE
 
   .. tab:: Tcl
 
     .. literalinclude:: ../../Examples/SimpleIO/SimpleIO.tcl
        :language: tcl
-       :lines: 24-35
+       :start-after: #START_OO_IMAGE_READER_WRITER_EXAMPLE
+       :end-before: #END_OO_IMAGE_READER_WRITER_EXAMPLE
 
 The above example specifies using the PNGImageIO to read the file.
 If that line is omitted, SimpleITK would determine which IO to use automatically,
@@ -98,49 +106,57 @@ A more compact example using SimpleITK's procedural interface:
 
     .. literalinclude:: ../../Examples/SimpleIO/SimpleIO.cs
        :language: csharp
-       :lines: 42-43
+       :start-after: //START_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
+       :end-before: //END_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
 
   .. tab:: C++
 
     .. literalinclude:: ../../Examples/SimpleIO/SimpleIO.cxx
        :language: cpp
-       :lines: 47-49
+       :start-after: //START_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
+       :end-before: //END_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
 
   .. tab:: Java
 
     .. literalinclude:: ../../Examples/SimpleIO/SimpleIO.java
        :language: java
-       :lines: 40-41
+       :start-after: //START_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
+       :end-before: //END_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
 
   .. tab:: Lua
 
     .. literalinclude:: ../../Examples/SimpleIO/SimpleIO.lua
        :language: lua
-       :lines: 38-41
+       :start-after: --START_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
+       :end-before: --END_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
 
   .. tab:: Python
 
     .. literalinclude:: ../../Examples/SimpleIO/SimpleIO.py
        :language: python
-       :lines: 47-50
+       :start-after: #START_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
+       :end-before: #END_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
 
   .. tab:: R
 
     .. literalinclude:: ../../Examples/SimpleIO/SimpleIO.R
        :language: r
-       :lines: 42-45
+       :start-after: #START_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
+       :end-before: #END_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
 
   .. tab:: Ruby
 
     .. literalinclude:: ../../Examples/SimpleIO/SimpleIO.rb
        :language: ruby
-       :lines: 37-40
+       :start-after: #START_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
+       :end-before: #END_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
 
   .. tab:: Tcl
 
     .. literalinclude:: ../../Examples/SimpleIO/SimpleIO.tcl
        :language: tcl
-       :lines: 39-43
+       :start-after: #START_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
+       :end-before: #END_PROCEDURAL_IMAGE_READER_WRITER_EXAMPLE
 
 Similarly, if the imageIO parameter is omitted, SimpleITK will determine
 which IO to use automatically.
@@ -194,49 +210,57 @@ reading it back, and then comparing the results.
 
     .. literalinclude:: ../../Examples/SimpleIO/SimpleIO.cs
        :language: csharp
-       :lines: 47-55
+       :start-after: //START_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
+       :end-before: //END_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
 
   .. tab:: C++
 
     .. literalinclude:: ../../Examples/SimpleIO/SimpleIO.cxx
-       :language: python
-       :lines: 55-60
+       :language: c++
+       :start-after: //START_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
+       :end-before: //END_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
 
   .. tab:: Java
 
     .. literalinclude:: ../../Examples/SimpleIO/SimpleIO.java
        :language: java
-       :lines: 45-53
+       :start-after: //START_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
+       :end-before: //END_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
 
   .. tab:: Lua
 
     .. literalinclude:: ../../Examples/SimpleIO/SimpleIO.lua
        :language: lua
-       :lines: 45-56
+       :start-after: --START_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
+       :end-before: --END_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
 
   .. tab:: Python
 
     .. literalinclude:: ../../Examples/SimpleIO/SimpleIO.py
        :language: python
-       :lines: 57-65
+       :start-after: #START_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
+       :end-before: #END_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
 
   .. tab:: R
 
     .. literalinclude:: ../../Examples/SimpleIO/SimpleIO.R
        :language: r
-       :lines: 49-57
+       :start-after: #START_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
+       :end-before: #END_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
 
   .. tab:: Ruby
 
     .. literalinclude:: ../../Examples/SimpleIO/SimpleIO.rb
        :language: ruby
-       :lines: 44-55
+       :start-after: #START_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
+       :end-before: #END_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
 
   .. tab:: Tcl
 
     .. literalinclude:: ../../Examples/SimpleIO/SimpleIO.tcl
        :language: tcl
-       :lines: 47-59
+       :start-after: #START_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
+       :end-before: #END_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE
 
 In all languages, except Python, ``read_result`` returns an object of the
 generic ``sitk.Transform()`` class and ``basic_transform`` creates a


### PR DESCRIPTION
Harmonize the code referencing to exclude the import/library/include parts and only include the relevant operation. Also C++ referencing was off by a couple of rows so didn't show the code correctly.