### PR TITLE
COMP: Move TransformIO factory registration from IO to Common

### DIFF
--- a/Code/Common/src/CMakeLists.txt
+++ b/Code/Common/src/CMakeLists.txt
@@ -40,6 +40,7 @@ set(
   ITKImageIntensity
   ITKLabelMap
   ITKTransform
+  ITKTransformIO
   ITKIOTransformBase
   ITKDisplacementField
 )
@@ -57,6 +58,8 @@ add_library(
   ${SimpleITKCommonSource}
   ${SimpleITKAncillarySource}
 )
+
+sitk_target_use_itk_factory(SimpleITKCommon TransformIO)
 sitk_target_use_itk(SimpleITKCommon PRIVATE ${ITK_MODULES_REQUESTED})
 if(SimpleITK_EXPLICIT_INSTANTIATION)
   target_link_libraries(SimpleITKCommon PRIVATE SimpleITKExplicit)

--- a/Code/IO/src/CMakeLists.txt
+++ b/Code/IO/src/CMakeLists.txt
@@ -21,7 +21,6 @@ set(
   ITKIOTransformBase
   ITKIOGDCM
   ITKImageIO
-  ITKTransformIO
 )
 
 find_package(ITK COMPONENTS ${use_itk_modules})
@@ -29,7 +28,6 @@ find_package(ITK COMPONENTS ${use_itk_modules})
 add_library(SimpleITKIO ${SimpleITKIOSource})
 sitk_target_use_itk(SimpleITKIO PRIVATE ${use_itk_modules})
 sitk_target_use_itk_factory(SimpleITKIO ImageIO)
-sitk_target_use_itk_factory(SimpleITKIO TransformIO)
 target_link_libraries(SimpleITKIO PUBLIC SimpleITKCommon)
 if(SimpleITK_EXPLICIT_INSTANTIATION)
   target_link_libraries(SimpleITKIO PRIVATE SimpleITKExplicit)


### PR DESCRIPTION
## Problem
The TransformIO factory registration was being optimized away during dead code removal when placed in the IO module. This caused runtime errors in examples that write transform files, such as the LandmarkRegistration example, which failed with:

```
ITK ERROR TransformFileWriterTemplate: Could not create Transform IO object for writing file
There are no registered Transform IO factories.
```

## Solution
Move the TransformIO factory registration from the IO module to the Common module. Since the Common module contains the transform methods that actually use the TransformIO factory (like `WriteTransform`), placing the registration there prevents it from being removed during linking optimization.

## Changes
- Move `ITKTransformIO` dependency from IO to Common module
- Move `sitk_target_use_itk_factory(SimpleITKCommon TransformIO)` call from IO to Common

## Testing
This fixes the runtime error that was occurring in PR #2386 where the C++ LandmarkRegistration example would crash when trying to write transform files.

Fixes the issue identified in CI where `CXX.Example.LandmarkRegistration` test was failing with "Subprocess aborted".