### PR TITLE
COMP: Remove unused field in C# ImageRegistrationMethodBSpline2

### DIFF
--- a/Examples/ImageRegistrationMethodBSpline2/ImageRegistrationMethodBSpline2.cs
+++ b/Examples/ImageRegistrationMethodBSpline2/ImageRegistrationMethodBSpline2.cs
@@ -43,11 +43,8 @@ namespace itk.simple.examples
 
     class MultiResolutionIterationUpdate : Command
     {
-        private ImageRegistrationMethod m_Method;
-
-        public MultiResolutionIterationUpdate(ImageRegistrationMethod m)
+        public MultiResolutionIterationUpdate()
         {
-            m_Method = m;
         }
 
         public override void Execute()
@@ -110,7 +107,7 @@ namespace itk.simple.examples
             IterationUpdate cmd1 = new IterationUpdate(R);
             R.AddCommand(EventEnum.sitkIterationEvent, cmd1);
 
-            MultiResolutionIterationUpdate cmd2 = new MultiResolutionIterationUpdate(R);
+            MultiResolutionIterationUpdate cmd2 = new MultiResolutionIterationUpdate();
             R.AddCommand(EventEnum.sitkMultiResolutionIterationEvent, cmd2);
 
             Transform outTx = R.Execute(fixedImage, movingImage);


### PR DESCRIPTION
## Problem
The C# ImageRegistrationMethodBSpline2 example produces a compiler warning:
```
ImageRegistrationMethodBSpline2.cs(46,41): warning CS0414: The private field 'itk.simple.examples.MultiResolutionIterationUpdate.m_Method' is assigned but its value is never used
```

## Solution
Remove the unused `m_Method` field from the `MultiResolutionIterationUpdate` class. The field was assigned in the constructor but never used in the `Execute()` method.

## Analysis
The C++ version of this example shows the correct intent - the `MultiResolutionIterationEvent` handler uses a simple lambda that only prints the resolution changing message without accessing the registration method object. The C# version should follow the same pattern.

## Changes
- Remove unused `m_Method` field and constructor parameter
- Update instantiation to use parameterless constructor