### PR TITLE
In generated C++ tests, static_cast the result value

### DIFF
--- a/Code/BasicFilters/yaml/BinaryImageToLabelMapFilter.yaml
+++ b/Code/BasicFilters/yaml/BinaryImageToLabelMapFilter.yaml
@@ -57,7 +57,7 @@ tests:
   - Input/WhiteDots.png
   measurements_results:
   - name: NumberOfObjects
-    value: 23u
+    value: 23
 - tag: white_dots_full
   description: with foreground some white dots
   md5hash: e40b7cdfc1b34ae2e6b13660d626cc29
@@ -72,7 +72,7 @@ tests:
   - Input/WhiteDots.png
   measurements_results:
   - name: NumberOfObjects
-    value: 21u
+    value: 21
 briefdescription: Label the connected components in a binary image and produce a collection of label objects.
 detaileddescription: >-
   BinaryImageToLabelMapFilter labels the objects in a binary image. Each distinct object is assigned a unique label. The final

--- a/Code/BasicFilters/yaml/ConnectedComponentImageFilter.yaml
+++ b/Code/BasicFilters/yaml/ConnectedComponentImageFilter.yaml
@@ -39,7 +39,7 @@ tests:
   settings: []
   measurements_results:
   - name: ObjectCount
-    value: 23u
+    value: 23
   md5hash: 548f5184428db10d93e3bf377dee5253
   inputs:
   - Input/WhiteDots.png
@@ -48,7 +48,7 @@ tests:
   settings: []
   measurements_results:
   - name: ObjectCount
-    value: 10u
+    value: 10
   md5hash: 769315132e427a391edd779191db446d
   inputs:
   - Input/2th_cthead1.png

--- a/Code/BasicFilters/yaml/DemonsRegistrationFilter.yaml
+++ b/Code/BasicFilters/yaml/DemonsRegistrationFilter.yaml
@@ -146,7 +146,7 @@ tests:
   - Input/BrainProtonDensitySliceBSplined10.png
   measurements_results:
   - name: ElapsedIterations
-    value: 10u
+    value: 10
   - name: RMSChange
     value: 0.28376284179066474
     tolerance: 1.0e-06
@@ -163,7 +163,7 @@ tests:
   - Input/BrainProtonDensitySlice20InitialDisplacement.mha
   measurements_results:
   - name: ElapsedIterations
-    value: 10u
+    value: 10
   - name: RMSChange
     value: 0.2829118
     tolerance: 1.0e-06

--- a/Code/BasicFilters/yaml/DiffeomorphicDemonsRegistrationFilter.yaml
+++ b/Code/BasicFilters/yaml/DiffeomorphicDemonsRegistrationFilter.yaml
@@ -170,7 +170,7 @@ tests:
   - Input/BrainProtonDensitySliceBSplined10.png
   measurements_results:
   - name: ElapsedIterations
-    value: 10u
+    value: 10
   - name: RMSChange
     value: 0.28976
     tolerance: 2.0e-05
@@ -187,7 +187,7 @@ tests:
   - Input/BrainProtonDensitySlice20InitialDisplacement.mha
   measurements_results:
   - name: ElapsedIterations
-    value: 10u
+    value: 10
   - name: RMSChange
     value: 0.2895611
     tolerance: 1.0e-06

--- a/Code/BasicFilters/yaml/FastSymmetricForcesDemonsRegistrationFilter.yaml
+++ b/Code/BasicFilters/yaml/FastSymmetricForcesDemonsRegistrationFilter.yaml
@@ -159,7 +159,7 @@ tests:
   - Input/BrainProtonDensitySliceBSplined10.png
   measurements_results:
   - name: ElapsedIterations
-    value: 10u
+    value: 10
   - name: RMSChange
     value: 0.288325
     tolerance: 1.0e-05
@@ -176,7 +176,7 @@ tests:
   - Input/BrainProtonDensitySlice20InitialDisplacement.mha
   measurements_results:
   - name: ElapsedIterations
-    value: 10u
+    value: 10
   - name: RMSChange
     value: 0.2879341
     tolerance: 1.0e-06

--- a/Code/BasicFilters/yaml/LabelIntensityStatisticsImageFilter.yaml
+++ b/Code/BasicFilters/yaml/LabelIntensityStatisticsImageFilter.yaml
@@ -403,13 +403,13 @@ tests:
     parameters:
     - 1
   - name: NumberOfLabels
-    value: 2u
+    value: 2
   - name: NumberOfPixels
-    value: 24139u
+    value: 24139
     parameters:
     - 1
   - name: NumberOfPixelsOnBorder
-    value: 0u
+    value: 0
     parameters:
     - 1
   - name: Perimeter

--- a/Code/BasicFilters/yaml/LabelShapeStatisticsImageFilter.yaml
+++ b/Code/BasicFilters/yaml/LabelShapeStatisticsImageFilter.yaml
@@ -362,13 +362,13 @@ tests:
     parameters:
     - '50'
   - name: NumberOfLabels
-    value: 2u
+    value: 2
   - name: NumberOfPixels
-    value: 527u
+    value: 527
     parameters:
     - '50'
   - name: NumberOfPixelsOnBorder
-    value: 0u
+    value: 0
     parameters:
     - '50'
   - name: Perimeter

--- a/Code/BasicFilters/yaml/LevelSetMotionRegistrationFilter.yaml
+++ b/Code/BasicFilters/yaml/LevelSetMotionRegistrationFilter.yaml
@@ -156,7 +156,7 @@ tests:
   - Input/BrainProtonDensitySliceBSplined10.png
   measurements_results:
   - name: ElapsedIterations
-    value: 10u
+    value: 10
   - name: RMSChange
     value: 10.422647280222545
     tolerance: 1.0e-06

--- a/Code/BasicFilters/yaml/RelabelComponentImageFilter.yaml
+++ b/Code/BasicFilters/yaml/RelabelComponentImageFilter.yaml
@@ -67,9 +67,9 @@ tests:
   settings: []
   measurements_results:
   - name: NumberOfObjects
-    value: 2u
+    value: 2
   - name: OriginalNumberOfObjects
-    value: 2u
+    value: 2
   - name: SizeOfObjectsInPhysicalUnits
     dim_vec: true
     value:
@@ -88,9 +88,9 @@ tests:
     R_value: 'FALSE'
   measurements_results:
   - name: NumberOfObjects
-    value: 3u
+    value: 3
   - name: OriginalNumberOfObjects
-    value: 3u
+    value: 3
   - name: SizeOfObjectsInPhysicalUnits
     dim_vec: true
     value:
@@ -113,9 +113,9 @@ tests:
     value: '140'
   measurements_results:
   - name: NumberOfObjects
-    value: 2u
+    value: 2
   - name: OriginalNumberOfObjects
-    value: 3u
+    value: 3
   - name: SizeOfObjectsInPhysicalUnits
     dim_vec: true
     value:

--- a/Code/BasicFilters/yaml/ScalarChanAndVeseDenseLevelSetImageFilter.yaml
+++ b/Code/BasicFilters/yaml/ScalarChanAndVeseDenseLevelSetImageFilter.yaml
@@ -123,12 +123,12 @@ tests:
   no_procedure: true
   settings:
   - parameter: NumberOfIterations
-    cxx_value: 2u
+    cxx_value: 2
     value: '2'
   tolerance: 0.001
   measurements_results:
   - name: ElapsedIterations
-    value: 2u
+    value: 2
   - name: RMSChange
     value: 721.33
     tolerance: 0.5

--- a/Code/BasicFilters/yaml/SymmetricForcesDemonsRegistrationFilter.yaml
+++ b/Code/BasicFilters/yaml/SymmetricForcesDemonsRegistrationFilter.yaml
@@ -138,7 +138,7 @@ tests:
   - Input/BrainProtonDensitySliceBSplined10.png
   measurements_results:
   - name: ElapsedIterations
-    value: 10u
+    value: 10
   - name: RMSChange
     value: 0.5697702538367385
     tolerance: 1.0e-06
@@ -155,7 +155,7 @@ tests:
   - Input/BrainProtonDensitySlice20InitialDisplacement.mha
   measurements_results:
   - name: ElapsedIterations
-    value: 10u
+    value: 10
   - name: RMSChange
     value: 0.5598269
     tolerance: 1.0e-06

--- a/Testing/Unit/sitkImageFilterTestTemplate.cxx.jinja
+++ b/Testing/Unit/sitkImageFilterTestTemplate.cxx.jinja
@@ -236,6 +236,7 @@ TEST(BasicFilters, {{ name }}_{{ test.tag }}) {
   {%- endif %}
 
   {% for result in test.measurements_results -%}
+  {% set measurement = measurements | selectattr('name', 'equalto', result.name) | first %}
   {% if result.tolerance %}
   {% if result.dim_vec -%}
   {
@@ -243,7 +244,7 @@ TEST(BasicFilters, {{ name }}_{{ test.tag }}) {
         EXPECT_VECTOR_NEAR(vec1, filter.Get{{ result.name }}({{ result.parameters | join(", ") }}), {{ result.tolerance }}) << "Measurement failure";
   }
   {%- else %}
-  EXPECT_NEAR({{ result.value }}, filter.Get{{ result.name }}({{ result.parameters | join(", ") }}), {{ result.tolerance }}) << "Measurement failure";
+  EXPECT_NEAR({% if measurement and measurement.type %}static_cast<{{ measurement.type }}>({{ result.value }}){% else %}{{ result.value }}{% endif %}, filter.Get{{ result.name }}({{ result.parameters | join(", ") }}), {{ result.tolerance }}) << "Measurement failure";
   {% endif %}
   {% else %}
   {% if result.value == "true" %}
@@ -251,7 +252,7 @@ TEST(BasicFilters, {{ name }}_{{ test.tag }}) {
   {% elif result.value == "false" %}
   EXPECT_FALSE(filter.Get{{ result.name }}({{ result.parameters | join(", ") }})) << "Measurement failure";
   {% else %}
-  EXPECT_EQ({{ result.value }}, filter.Get{{ result.name }}({{ result.parameters | join(", ") }})) << "Measurement failure";
+  EXPECT_EQ({% if measurement and measurement.type %}static_cast<{{ measurement.type }}>({{ result.value }}){% else %}{{ result.value }}{% endif %}, filter.Get{{ result.name }}({{ result.parameters | join(", ") }})) << "Measurement failure";
   {% endif %}
   {% endif %}
   {%- endfor %}


### PR DESCRIPTION
Remove the C++ specific "u" suffix from the values so that the field is just a number. Update the C++ test template to use a static cast with the type from the definition of the measurement.