### PR TITLE
Fix unused variable warnings in ImageGridManipulation examples

### DIFF
--- a/Examples/ImageGridManipulation/ImageGridManipulation.R
+++ b/Examples/ImageGridManipulation/ImageGridManipulation.R
@@ -70,3 +70,8 @@ crop <- CropImageFilter()
 crop$SetLowerBoundaryCropSize( list(10, 10, 0) )
 crop$SetUpperBoundaryCropSize( list(composed_image$GetWidth()-40, composed_image$GetHeight()-40, 1) )
 cropped_image <- crop$Execute(composed_image)
+
+# Print image information to demonstrate variable usage
+cat("Sliced image size:", sliced_image$GetWidth(), "x", sliced_image$GetHeight(), "x", sliced_image$GetDepth(), "\n")
+cat("Extracted image size:", extracted_image$GetWidth(), "x", extracted_image$GetHeight(), "x", extracted_image$GetDepth(), "\n")
+cat("Cropped image size:", cropped_image$GetWidth(), "x", cropped_image$GetHeight(), "x", cropped_image$GetDepth(), "\n")

--- a/Examples/ImageGridManipulation/ImageGridManipulation.cs
+++ b/Examples/ImageGridManipulation/ImageGridManipulation.cs
@@ -60,6 +60,11 @@ namespace itk.simple.examples
             ComposeImageFilter compose = new ComposeImageFilter();
             Image composedImage = compose.Execute(channel1Image, channel2Image, channel3Image);
 
+            // Select same subregion using image slicing operator
+            VectorInt32 sliceStart = new VectorInt32(new int[] { 10, 10, 0 });
+            VectorInt32 sliceStop = new VectorInt32(new int[] { 40, 40, 1 });
+            Image slicedImage = SimpleITK.Slice(composedImage, sliceStart, sliceStop);
+
             // Select same subregion using ExtractImageFilter
             ExtractImageFilter extract = new ExtractImageFilter();
             VectorUInt32 size = new VectorUInt32(new uint[] { 30, 30, 0 });
@@ -67,6 +72,7 @@ namespace itk.simple.examples
             extract.SetSize(size);
             extract.SetIndex(index);
             Image extractedImage = extract.Execute(composedImage);
+
 
             // Select same sub-region using CropImageFilter (NOTE: CropImageFilter cannot
             // reduce dimensions unlike ExtractImageFilter, so cropped_image is a three
@@ -81,6 +87,13 @@ namespace itk.simple.examples
             crop.SetLowerBoundaryCropSize(lowerBoundary);
             crop.SetUpperBoundaryCropSize(upperBoundary);
             Image croppedImage = crop.Execute(composedImage);
+
+            Console.WriteLine("Sliced image size: {0}x{1}x{2}",
+                slicedImage.GetWidth(), slicedImage.GetHeight(), slicedImage.GetDepth());
+            Console.WriteLine("Extracted image size: {0}x{1}x{2}",
+                extractedImage.GetWidth(), extractedImage.GetHeight(), extractedImage.GetDepth());
+            Console.WriteLine("Cropped image size: {0}x{1}x{2}",
+                croppedImage.GetWidth(), croppedImage.GetHeight(), croppedImage.GetDepth());
         }
     }
 }

--- a/Examples/ImageGridManipulation/ImageGridManipulation.cxx
+++ b/Examples/ImageGridManipulation/ImageGridManipulation.cxx
@@ -70,5 +70,11 @@ main(int argc, char * argv[])
   crop.SetUpperBoundaryCropSize({ composedImage.GetWidth() - 40, composedImage.GetHeight() - 40, 1 });
   sitk::Image croppedImage = crop.Execute(composedImage);
 
+  // Print image information to demonstrate variable usage
+  std::cout << "Extracted image size: " << extractedImage.GetWidth() << "x" << extractedImage.GetHeight() << "x"
+            << extractedImage.GetDepth() << std::endl;
+  std::cout << "Cropped image size: " << croppedImage.GetWidth() << "x" << croppedImage.GetHeight() << "x"
+            << croppedImage.GetDepth() << std::endl;
+
   return 0;
 }

--- a/Examples/ImageGridManipulation/ImageGridManipulation.java
+++ b/Examples/ImageGridManipulation/ImageGridManipulation.java
@@ -76,5 +76,11 @@ class ImageGridManipulation {
         crop.setLowerBoundaryCropSize(lowerBoundary);
         crop.setUpperBoundaryCropSize(upperBoundary);
         Image croppedImage = crop.execute(composedImage);
+
+        // Print image information to demonstrate variable usage
+        System.out.println("Extracted image size: " + extractedImage.getWidth() + "x" +
+                          extractedImage.getHeight() + "x" + extractedImage.getDepth());
+        System.out.println("Cropped image size: " + croppedImage.getWidth() + "x" +
+                          croppedImage.getHeight() + "x" + croppedImage.getDepth());
     }
 }

--- a/Examples/ImageGridManipulation/ImageGridManipulation.py
+++ b/Examples/ImageGridManipulation/ImageGridManipulation.py
@@ -67,3 +67,8 @@ crop.SetUpperBoundaryCropSize(
     [composed_image.GetWidth() - 40, composed_image.GetHeight() - 40, 1]
 )
 cropped_image = crop.Execute(composed_image)
+
+# Print image information to demonstrate variable usage
+print(f"Sliced image size: {sliced_image.GetWidth()}x{sliced_image.GetHeight()}x{sliced_image.GetDepth()}")
+print(f"Extracted image size: {extracted_image.GetWidth()}x{extracted_image.GetHeight()}x{extracted_image.GetDepth()}")
+print(f"Cropped image size: {cropped_image.GetWidth()}x{cropped_image.GetHeight()}x{cropped_image.GetDepth()}")


### PR DESCRIPTION
## Summary
This PR fixes compiler warnings about unused variables in the ImageGridManipulation examples across all supported languages.

## Changes
- **Add output statements** to demonstrate usage of `extractedImage` and `croppedImage` variables in all language examples
- **Add sliced image functionality** to C# example to match Python and R implementations
- **Resolves compiler warnings** for unused variables (CS0219 in C#, similar warnings in other languages)

## Testing
- All examples now properly demonstrate the three different ways to extract image regions:
  - Image slicing (Python, R, and now C#)
  - ExtractImageFilter (all languages)
  - CropImageFilter (all languages)
- Variables are now actively used in output statements, eliminating unused variable warnings

## Files Modified
- `Examples/ImageGridManipulation/ImageGridManipulation.cs` - Added sliced image functionality and output statements
- `Examples/ImageGridManipulation/ImageGridManipulation.cxx` - Added output statements
- `Examples/ImageGridManipulation/ImageGridManipulation.java` - Added output statements  
- `Examples/ImageGridManipulation/ImageGridManipulation.py` - Added output statements
- `Examples/ImageGridManipulation/ImageGridManipulation.R` - Added output statements