### PR TITLE
Update Google Test to v1.17.0

### DIFF
--- a/SuperBuild/External_GTest.cmake
+++ b/SuperBuild/External_GTest.cmake
@@ -19,7 +19,7 @@ set(
 )
 mark_as_advanced(GTEST_GIT_REPOSITORY)
 
-set(GTEST_GIT_TAG "v1.15.2" CACHE STRING "Tag or hash for GTest git repo")
+set(GTEST_GIT_TAG "v1.17.0" CACHE STRING "Tag or hash for GTest git repo")
 mark_as_advanced(GTEST_GIT_TAG)
 set(
   GTEST_TAG_COMMAND


### PR DESCRIPTION
- Upgrade from v1.15.2 to v1.17.0 to get latest bug fixes and features
- Compatible with existing C++17 requirement
- Includes new DistanceFrom() matcher and --gtest_fail_if_no_test_linked flag