### PR TITLE
Use superbuild python for language builds

### DIFF
--- a/.github/actions/package_python/scripts/mac_build_python.sh
+++ b/.github/actions/package_python/scripts/mac_build_python.sh
@@ -11,6 +11,13 @@ which python
 python --version
 PYTHON_VERSION=$(python -c 'import sys;print ("{0}{1}".format(sys.version_info[0], sys.version_info[1]))')
 
+Python_EXECUTABLE=$(which python)
+SimpleITK_Python_EXECUTABLE=${Python_EXECUTABLE}
+# if COREBINARYDIRECTORY/venv exists use that python
+if [ -f "${COREBINARYDIRECTORY}/venv/bin/python" ]; then
+    SimpleITK_Python_EXECUTABLE="${COREBINARYDIRECTORY}/venv/bin/python"
+fi
+
 # Detect OS
 OS_NAME=$(uname -s)
 
@@ -48,6 +55,7 @@ SimpleITK_BUILD_DISTRIBUTE:BOOL=ON
 SimpleITK_PYTHON_WHEEL:BOOL=1
 SimpleITK_BUILD_STRIP:BOOL=1
 Python_EXECUTABLE:FILEPATH=$(which python)
+SimpleITK_Python_EXECUTABLE:FILEPATH=${SimpleITK_Python_EXECUTABLE}
 SimpleITK_PYTHON_USE_LIMITED_API:BOOL=${USE_LIMITED_API}
 EOM
 

--- a/.github/actions/package_python/scripts/win_build_python.sh
+++ b/.github/actions/package_python/scripts/win_build_python.sh
@@ -14,12 +14,17 @@ PYTHON_VERSION=$(python -c 'import sys;print ("{0}{1}".format(sys.version_info[0
 Python_EXECUTABLE=$(python -c "import sys; print(sys.executable)")
 echo $Python_EXECUTABLE
 
-
+SimpleITK_Python_EXECUTABLE=${Python_EXECUTABLE}
+# if COREBINARYDIRECTORY/venv exists use that python
+if [ -f "${COREBINARYDIRECTORY}/venv/Scripts/python.exe" ]; then
+    SimpleITK_Python_EXECUTABLE="${COREBINARYDIRECTORY}/venv/Scripts/python.exe"
+fi
 
 read -r -d '' CTEST_CACHE << EOM || true
 CMAKE_PREFIX_PATH:PATH=${COREBINARYDIRECTORY}
 SWIG_EXECUTABLE:FILEPATH=${COREBINARYDIRECTORY}\swigwin\swig.exe
 Python_EXECUTABLE:FILEPATH=${Python_EXECUTABLE}
+SimpleITK_Python_EXECUTABLE:FILEPATH=${SimpleITK_Python_EXECUTABLE}
 BUILD_TESTING:BOOL=ON
 BUILD_EXAMPLES:BOOL=ON
 SimpleITK_BUILD_DISTRIBUTE:BOOL=ON

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -146,7 +146,7 @@ jobs:
           restore-keys: |
             external-data-v1-
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         id: cpy
         with:
           python-version: 3.11

--- a/Utilities/Distribution/manylinux/imagefiles/cmd.sh
+++ b/Utilities/Distribution/manylinux/imagefiles/cmd.sh
@@ -56,11 +56,11 @@ build_simpleitk() {
 
 build_simpleitk_python() {
 
-    PYTHON_EXECUTABLE=/opt/python/${PYTHON}/bin/python
-    PYTHON_INCLUDE_DIR="$( find -L /opt/python/${PYTHON}/include/ -name Python.h -exec dirname {} \; )"
+    Python_EXECUTABLE=/opt/python/${PYTHON}/bin/python
+    Python_INCLUDE_DIR="$( find -L /opt/python/${PYTHON}/include/ -name Python.h -exec dirname {} \; )"
 
     echo ""
-    echo "PYTHON_EXECUTABLE:${PYTHON_EXECUTABLE}"
+    echo "Python_EXECUTABLE:${Python_EXECUTABLE}"
 
     BLD_PY_DIR="${BLD_DIR}-${PYTHON}${USE_LIMITED_API:+-abi3}"
     rm -rf  ${BLD_PY_DIR} &&
@@ -79,8 +79,9 @@ build_simpleitk_python() {
         -DSimpleITK_BUILD_STRIP:BOOL=ON \
         -DSimpleITK_PYTHON_WHEEL:BOOL=ON \
         -DSimpleITK_PYTHON_EGG:BOOL=OFF \
-        -DPython_EXECUTABLE:FILEPATH=${PYTHON_EXECUTABLE} \
-        -DPython_INCLUDE_DIR:PATH=${PYTHON_INCLUDE_DIR} \
+        -DSimpleITK_Python_EXECUTABLE:FILEPATH=${SimpleITK_Python_EXECUTABLE} \
+        -DPython_EXECUTABLE:FILEPATH=${Python_EXECUTABLE} \
+        -DPython_INCLUDE_DIR:PATH=${Python_INCLUDE_DIR} \
         ${SRC_DIR}/Wrapping/Python &&
     make &&
     make dist
@@ -89,6 +90,7 @@ build_simpleitk_python() {
 
 build_simpleitk || exit 1
 
+SimpleITK_Python_EXECUTABLE="${BLD_DIR}/venv/bin/python"
 
 if [[ ! -z ${BUILD_CSHARP:+x} && "${BUILD_CSHARP}" -ne 0 ]]; then
     mkdir ${BLD_DIR}-csharp &&
@@ -129,8 +131,8 @@ fi
 if [[ ! -z ${BUILD_PYTHON_LIMITED_API:+x} && "${BUILD_PYTHON_LIMITED_API}" -ne 0 ]]; then
     USE_LIMITED_API=ON
     PYTHON=cp311-cp311
-    PYTHON_EXECUTABLE=/opt/python/${PYTHON}/bin/python
-    PLATFORM=$(${PYTHON_EXECUTABLE} -c "import distutils.util; print(distutils.util.get_platform())")
+    Python_EXECUTABLE=/opt/python/${PYTHON}/bin/python
+    PLATFORM=$(${Python_EXECUTABLE} -c "import distutils.util; print(distutils.util.get_platform())")
     build_simpleitk_python &&
        ( auditwheel repair $(find ${BLD_DIR}-${PYTHON}${USE_LIMITED_API:+-abi3}/ -name *.whl) -w ${OUT_DIR}/wheelhouse/;
          ctest -j ${NPROC} -LE UNSTABLE | tee ${OUT_DIR}/ctest_${PLATFORM}_${PYTHON}${USE_LIMITED_API:+-abi3}.log &&
@@ -141,8 +143,8 @@ fi
 
 
 for PYTHON in ${PYTHON_VERSIONS}; do
-    PYTHON_EXECUTABLE=/opt/python/${PYTHON}/bin/python
-    PLATFORM=$(${PYTHON_EXECUTABLE} -c "import distutils.util; print(distutils.util.get_platform())")
+    Python_EXECUTABLE=/opt/python/${PYTHON}/bin/python
+    PLATFORM=$(${Python_EXECUTABLE} -c "import distutils.util; print(distutils.util.get_platform())")
     build_simpleitk_python &&
         ( auditwheel repair $(find ${BLD_DIR}-${PYTHON}/ -name *.whl) -w ${OUT_DIR}/wheelhouse/;
           ctest -j ${NPROC} -LE UNSTABLE | tee ${OUT_DIR}/ctest_${PLATFORM}_${PYTHON}.log &&


### PR DESCRIPTION
The Python language build now requires a python environment to run the expand templates.