### PR TITLE
FOR RELEASE - Update docker based package builds to use external source

### DIFF
--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -41,7 +41,6 @@ jobs:
           docker build --pull=true --rm=true -t simpleitk_manylinux -f "${{ matrix.dockerfile }}"   .
       - name: Build ${{ matrix.dockerfile }}
         shell: bash
-        working-directory: Utilities/Distribution/manylinux
         env:
           PYTHON_VERSIONS: "cp39-cp39 cp310-cp310"
           BUILD_CSHARP: ${{ contains(matrix.os, 'arm') && '0' || '1' }}
@@ -52,12 +51,13 @@ jobs:
           echo "BUILD_JAVA: ${BUILD_JAVA}"
           docker run --rm \
                --user "$(id -u):$(id -g)" \
-               --env SIMPLEITK_GIT_TAG=${{github.ref}} \
                --env PYTHON_VERSIONS \
                --env BUILD_CSHARP \
                --env BUILD_JAVA \
                --env BUILD_PYTHON_LIMITED_API \
-               -v "$(pwd):/work/io" \
+               --env SIMPLEITK_SRC_DIR="/work/src" \
+               -v "${{ github.workspace }}:/work/src" \
+               -v "${{ github.workspace }}/Utilities/Distribution/manylinux:/work/io" \
                -t simpleitk_manylinux
       - name: ls
         shell: bash

--- a/Utilities/Distribution/manylinux/imagefiles/cmd.sh
+++ b/Utilities/Distribution/manylinux/imagefiles/cmd.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-export SRC_DIR="/tmp/SimpleITK"
+export SRC_DIR="${SIMPLEITK_SRC_DIR:-"/tmp/SimpleITK"}"
 export BLD_DIR="/tmp/SimpleITK-build"
 export OUT_DIR="/work/io"
 
@@ -24,9 +24,7 @@ export ExternalData_OBJECT_STORES=${ExternalData_OBJECT_STORES:-/tmp/.ExternalDa
 mkdir -p ${ExternalData_OBJECT_STORES}
 
 
-export PYTHONUSERBASE=${PYTHONUSERBASE:-/tmp/.pylocal}
-mkdir -p ${PYTHONUSERBASE}
-export PATH=${PATH}:/tmp/.pylocal/bin
+export HOME=/tmp
 
 function build_simpleitk {
 


### PR DESCRIPTION
Use the SimpleITK source code cloned by the action, and not internal to the docker image.

Also remove the Python_EXECUTABLE variable being explicitly set during transition of Python virtual environment.

Set HOME to the /tmp directory to avoid writing in the root of the file system for user configuration.