### PR TITLE
Add PyBuffer interface to Image (PEP 688) and numpy array conversion

### DIFF
--- a/.github/workflows/additional_dictionary.txt
+++ b/.github/workflows/additional_dictionary.txt
@@ -952,6 +952,7 @@ buildsystems
 burton
 bwh
 byteorder
+buf
 cacheline
 callables
 cardinality
@@ -1481,6 +1482,7 @@ iteratively
 iterators
 iteritems
 itertools
+itemsize
 ith
 itk
 itkDefaultImageToImageMetricTraitsv
@@ -1582,6 +1584,8 @@ mbox
 md
 mediumblue
 mediumvioletred
+memoryview
+memoryviews
 metaio
 metaprogramming
 metrics
@@ -1832,6 +1836,7 @@ rdbuf
 rdstate
 readme
 readthedocs
+readonly
 reallocations
 recalibrate
 recoded
@@ -1874,6 +1879,7 @@ rindex
 rint
 rjwagner
 rms
+refcount
 roberto
 rockspec
 roi
@@ -1999,6 +2005,7 @@ subdirectory
 subimage
 subn
 subnormals
+suboffsets
 subpixel
 subrange
 subranges
@@ -2230,3 +2237,4 @@ yyy
 yz
 zz
 zzz
+segfault

--- a/Wrapping/Python/CMakeLists.txt
+++ b/Wrapping/Python/CMakeLists.txt
@@ -297,6 +297,7 @@ set(
   SimpleITK_Py_Files
   "__init__.py"
   "extra.py"
+  "_pixel_types.py"
   "py.typed"
 )
 

--- a/Wrapping/Python/CMakeLists.txt
+++ b/Wrapping/Python/CMakeLists.txt
@@ -151,6 +151,7 @@ set(
 swig_add_module( SimpleITK python
   SimpleITK.i
   sitkPyCommand.cxx
+  sitkImageBuffer.cxx
 )
 set(
   SWIG_MODULE_SimpleITKPython_TARGET_NAME

--- a/Wrapping/Python/Python.i
+++ b/Wrapping/Python/Python.i
@@ -23,10 +23,22 @@
 // https://github.com/swig/swig/pull/2856
 #define NOMINMAX
 #include "stdlib.h"
+#include "sitkImageBuffer.h"
 %}
 
 %{
 #include "sitkPyCommand.h"
+%}
+
+%init %{
+    // Initialize the ImageBuffer type when the module loads
+    if (InitImageBufferType(m) < 0) {
+#if PY_VERSION_HEX >= 0x03000000
+        return NULL;
+#else
+        return;
+#endif
+    }
 %}
 
 %include "PythonDocstrings.i"
@@ -54,6 +66,24 @@
 // is declared static.
 %{
 #include "sitkNumpyArrayConversion.cxx"
+
+// Helper function to extract sitk::Image* from a SWIG-wrapped PyObject
+// This function is used by sitkImageBuffer.cxx
+itk::simple::Image* sitk_GetImagePointerFromPyObject(PyObject* pyImage)
+{
+    if (!pyImage) {
+        return nullptr;
+    }
+
+    void* voidImage;
+    int res = SWIG_ConvertPtr(pyImage, &voidImage, SWIGTYPE_p_itk__simple__Image, 0);
+    if (!SWIG_IsOK(res)) {
+        return nullptr;
+    }
+
+    return reinterpret_cast<itk::simple::Image*>(voidImage);
+}
+
 %}
 // Numpy array conversion support
 %native(_GetMemoryViewFromImage) PyObject *sitk_GetMemoryViewFromImage( PyObject *self, PyObject *args );

--- a/Wrapping/Python/Python.i
+++ b/Wrapping/Python/Python.i
@@ -86,7 +86,6 @@ itk::simple::Image* sitk_GetImagePointerFromPyObject(PyObject* pyImage)
 
 %}
 // Numpy array conversion support
-%native(_GetMemoryViewFromImage) PyObject *sitk_GetMemoryViewFromImage( PyObject *self, PyObject *args );
 %native(_SetImageFromArray) PyObject *sitk_SetImageFromArray( PyObject *self, PyObject *args );
 
 // Enable Python classes derived from Command Execute method to be

--- a/Wrapping/Python/SimpleITK/_pixel_types.py
+++ b/Wrapping/Python/SimpleITK/_pixel_types.py
@@ -1,0 +1,177 @@
+# ========================================================================
+#
+#  Copyright NumFOCUS
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+# ========================================================================
+
+"""
+Pixel type classification for SimpleITK.
+
+This module provides constants and functions to classify SimpleITK pixel types
+into categories: Basic, Vector, and Label types.
+"""
+
+from SimpleITK.SimpleITK import (
+    sitkUnknown,
+    sitkUInt8,
+    sitkInt8,
+    sitkUInt16,
+    sitkInt16,
+    sitkUInt32,
+    sitkInt32,
+    sitkUInt64,
+    sitkInt64,
+    sitkFloat32,
+    sitkFloat64,
+    sitkComplexFloat32,
+    sitkComplexFloat64,
+    sitkVectorUInt8,
+    sitkVectorInt8,
+    sitkVectorUInt16,
+    sitkVectorInt16,
+    sitkVectorUInt32,
+    sitkVectorInt32,
+    sitkVectorUInt64,
+    sitkVectorInt64,
+    sitkVectorFloat32,
+    sitkVectorFloat64,
+    sitkLabelUInt8,
+    sitkLabelUInt16,
+    sitkLabelUInt32,
+    sitkLabelUInt64,
+)
+
+# Basic pixel types - scalar pixel types including integers, floats, and complex
+# Filter out any sitkUnknown values in case some types are not instantiated
+BASIC_PIXEL_IDS = frozenset(
+    pixel_id for pixel_id in [
+        sitkUInt8,
+        sitkInt8,
+        sitkUInt16,
+        sitkInt16,
+        sitkUInt32,
+        sitkInt32,
+        sitkUInt64,
+        sitkInt64,
+        sitkFloat32,
+        sitkFloat64,
+        sitkComplexFloat32,
+        sitkComplexFloat64,
+    ]
+    if pixel_id != sitkUnknown
+)
+
+# Vector pixel types - multi-component pixel types
+# Filter out any sitkUnknown values in case some types are not instantiated
+VECTOR_PIXEL_IDS = frozenset(
+    pixel_id for pixel_id in [
+        sitkVectorUInt8,
+        sitkVectorInt8,
+        sitkVectorUInt16,
+        sitkVectorInt16,
+        sitkVectorUInt32,
+        sitkVectorInt32,
+        sitkVectorUInt64,
+        sitkVectorInt64,
+        sitkVectorFloat32,
+        sitkVectorFloat64,
+    ]
+    if pixel_id != sitkUnknown
+)
+
+# Label pixel types - RLE encoded label types
+# Filter out any sitkUnknown values in case some types are not instantiated
+LABEL_PIXEL_IDS = frozenset(
+    pixel_id for pixel_id in [
+        sitkLabelUInt8,
+        sitkLabelUInt16,
+        sitkLabelUInt32,
+        sitkLabelUInt64,
+    ]
+    if pixel_id != sitkUnknown
+)
+
+
+def is_basic(pixel_id: int) -> bool:
+    """
+    Check if a pixel ID is a basic (scalar) type.
+
+    Basic pixel types include unsigned and signed integers, floating-point,
+    and complex floating-point types.
+
+    Parameters
+    ----------
+    pixel_id : int
+        A SimpleITK PixelIDValueEnum value.
+
+    Returns
+    -------
+    bool
+        True if the pixel ID is a basic type, False otherwise.
+    """
+    return pixel_id in BASIC_PIXEL_IDS
+
+
+def is_vector(pixel_id: int) -> bool:
+    """
+    Check if a pixel ID is a vector (multi-component) type.
+
+    Vector pixel types represent multi-component pixels where each pixel
+    contains a fixed-size vector of scalar values.
+
+    Parameters
+    ----------
+    pixel_id : int
+        A SimpleITK PixelIDValueEnum value.
+
+    Returns
+    -------
+    bool
+        True if the pixel ID is a vector type, False otherwise.
+
+    """
+    return pixel_id in VECTOR_PIXEL_IDS
+
+
+def is_label(pixel_id: int) -> bool:
+    """
+    Check if a pixel ID is a label type.
+
+    Label pixel types use Run-Length Encoding (RLE) for efficient storage
+    of label maps, commonly used for segmentation masks.
+
+    Parameters
+    ----------
+    pixel_id : int
+        A SimpleITK PixelIDValueEnum value.
+
+    Returns
+    -------
+    bool
+        True if the pixel ID is a label type, False otherwise.
+
+    """
+    return pixel_id in LABEL_PIXEL_IDS
+
+
+
+__all__ = [
+    'BASIC_PIXEL_IDS',
+    'VECTOR_PIXEL_IDS',
+    'LABEL_PIXEL_IDS',
+    'is_basic',
+    'is_vector',
+    'is_label'
+]

--- a/Wrapping/Python/sitkImageBuffer.cxx
+++ b/Wrapping/Python/sitkImageBuffer.cxx
@@ -1,0 +1,667 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "sitkImageBuffer.h"
+#include "sitkImage.h"
+#include "sitkPixelIDValues.h"
+#include <cstring>
+#include <iostream>
+
+// #define sitkImageBuffer_DEBUG
+
+namespace sitk = itk::simple;
+
+
+// Buffer object structure
+typedef struct
+{
+  PyObject_HEAD PyObject * pyImageRef; // Python Image object reference (stored directly as member)
+  int                      ndim;
+  Py_ssize_t               shape[SITK_MAX_DIMENSION + 1];
+  Py_ssize_t               strides[SITK_MAX_DIMENSION + 1];
+} sitkImageBuffer;
+
+// Helper function to get the sitk::Image from buffer object
+static const sitk::Image *
+GetImageFromBuffer(sitkImageBuffer * self)
+{
+  if (self->pyImageRef)
+  {
+    // Use the helper function defined in Python.i to extract the Image pointer
+    return sitk_GetImagePointerFromPyObject(self->pyImageRef);
+  }
+  return nullptr;
+}
+
+// Helper function to get format string for pixel type
+static const char *
+GetFormatString(sitk::PixelIDValueEnum pixelID)
+{
+  switch (pixelID)
+  {
+    case sitk::sitkUInt8:
+      return "B"; // unsigned char
+    case sitk::sitkInt8:
+      return "b"; // signed char
+    case sitk::sitkUInt16:
+      return "H"; // unsigned short
+    case sitk::sitkInt16:
+      return "h"; // signed short
+    case sitk::sitkUInt32:
+      return "I"; // unsigned int
+    case sitk::sitkInt32:
+      return "i"; // signed int
+    case sitk::sitkUInt64:
+      return "Q"; // unsigned long long
+    case sitk::sitkInt64:
+      return "q"; // signed long long
+    case sitk::sitkFloat32:
+      return "f"; // float
+    case sitk::sitkFloat64:
+      return "d"; // double
+    case sitk::sitkComplexFloat32:
+      return "Zf"; // complex float
+    case sitk::sitkComplexFloat64:
+      return "Zd"; // complex double
+    case sitk::sitkVectorUInt8:
+      return "B";
+    case sitk::sitkVectorInt8:
+      return "b";
+    case sitk::sitkVectorUInt16:
+      return "H";
+    case sitk::sitkVectorInt16:
+      return "h";
+    case sitk::sitkVectorUInt32:
+      return "I";
+    case sitk::sitkVectorInt32:
+      return "i";
+    case sitk::sitkVectorUInt64:
+      return "Q";
+    case sitk::sitkVectorInt64:
+      return "q";
+    case sitk::sitkVectorFloat32:
+      return "f";
+    case sitk::sitkVectorFloat64:
+      return "d";
+    case sitk::sitkLabelUInt8:
+      return "B";
+    case sitk::sitkLabelUInt16:
+      return "H";
+    case sitk::sitkLabelUInt32:
+      return "I";
+    case sitk::sitkLabelUInt64:
+      return "Q";
+    default:
+      return "B"; // fallback to unsigned char
+  }
+}
+
+// Helper function to get item size from format string, with special handling for complex types
+static Py_ssize_t
+GetItemSizeFromFormat(const char * format)
+{
+  if (!format)
+  {
+    PyErr_SetString(PyExc_ValueError, "Format string is NULL");
+    return -1;
+  }
+
+  // Handle complex types that PyBuffer_SizeFromFormat doesn't support
+  if (format[0] == 'Z' && format[1] != '\0')
+  {
+    // spell-check-disable
+    // Complex format: "Zf" -> 2 * sizeof(float), "Zd" -> 2 * sizeof(double)
+    // spell-check-enable
+    Py_ssize_t base_size = PyBuffer_SizeFromFormat(format + 1);
+    if (base_size > 0)
+    {
+      return base_size * 2;
+    }
+    else
+    {
+      // Use hard-coded sizes for complex types as fallback
+      if (format[1] == 'f')
+      {
+        return sizeof(float) * 2; // 8 bytes for complex float
+      }
+      else if (format[1] == 'd')
+      {
+        return sizeof(double) * 2; // 16 bytes for complex double
+      }
+      else
+      {
+        PyErr_Format(PyExc_ValueError, "Unsupported complex format: '%s'", format);
+        return -1;
+      }
+    }
+  }
+
+  // Use Python's official size calculation for standard formats
+  Py_ssize_t size = PyBuffer_SizeFromFormat(format);
+
+  // if SizeFromFormat fails, it returns -1 and sets an error
+  return size;
+}
+
+// Helper function to check if a pixel type is a vector type
+static bool
+IsVectorPixelType(sitk::PixelIDValueEnum pixelID)
+{
+  if (pixelID == sitk::sitkUnknown)
+  {
+    return false;
+  }
+  switch (pixelID)
+  {
+    case sitk::sitkVectorUInt8:
+    case sitk::sitkVectorInt8:
+    case sitk::sitkVectorUInt16:
+    case sitk::sitkVectorInt16:
+    case sitk::sitkVectorUInt32:
+    case sitk::sitkVectorInt32:
+    case sitk::sitkVectorUInt64:
+    case sitk::sitkVectorInt64:
+    case sitk::sitkVectorFloat32:
+    case sitk::sitkVectorFloat64:
+      return true;
+    default:
+      return false;
+  }
+}
+
+// Buffer protocol implementation
+static int
+sitkImageBuffer_getbuffer(PyObject * exporter, Py_buffer * view, int flags)
+{
+  sitkImageBuffer *   self = (sitkImageBuffer *)exporter;
+  const sitk::Image * imagePtr = nullptr;
+
+  // Determine writable vs readonly access
+  bool isWritable = (flags & PyBUF_WRITABLE) == PyBUF_WRITABLE;
+
+  if (isWritable)
+  {
+    PyErr_SetString(PyExc_BufferError, "Cannot create writable buffer for image");
+    return -1;
+  }
+
+  if ((flags & PyBUF_F_CONTIGUOUS) == PyBUF_F_CONTIGUOUS && (flags & PyBUF_ANY_CONTIGUOUS) != PyBUF_ANY_CONTIGUOUS)
+  {
+    PyErr_SetString(PyExc_BufferError, "SimpleITK images are C-contiguous, cannot provide Fortran-contiguous buffer");
+    return -1;
+  }
+
+
+  // if flags is zero set to PyBUF_SIMPLE and produce a warning
+  if (flags == 0)
+  {
+    flags = PyBUF_SIMPLE;
+    PyErr_WarnEx(PyExc_RuntimeWarning, "Buffer flag was zero, using PyBUF_SIMPLE", 1);
+  }
+
+  // Zero-initialize the entire Py_buffer structure
+  memset(view, 0, sizeof(Py_buffer));
+
+  // Read-only access is fine with reference
+  imagePtr = GetImageFromBuffer(self);
+  if (!imagePtr)
+  {
+    PyErr_SetString(PyExc_BufferError, "Buffer object has no associated image");
+    return -1;
+  }
+
+  try
+  {
+    const sitk::Image &    image = *imagePtr;
+    const unsigned int     dimension = image.GetDimension();
+    sitk::PixelIDValueEnum pixelID = image.GetPixelID();
+    const unsigned int     totalDimensions = dimension + (IsVectorPixelType(pixelID) ? 1 : 0);
+
+
+    if (pixelID == sitk::sitkUnknown || pixelID == sitk::sitkLabelUInt8 || pixelID == sitk::sitkLabelUInt16 ||
+        pixelID == sitk::sitkLabelUInt32 || pixelID == sitk::sitkLabelUInt64)
+    {
+      PyErr_SetString(PyExc_BufferError, "Cannot create buffer for image with unknown or label pixel type");
+      return -1;
+    }
+
+    // Get buffer pointer and calculate size
+    const void * buffer_ptr = image.GetBufferAsVoid();
+    if (!buffer_ptr)
+    {
+      PyErr_SetString(PyExc_BufferError, "Image buffer is null");
+      return -1;
+    }
+
+#ifdef sitkImageBuffer_DEBUG
+    // Debug message for buffer creation
+    std::cerr << "[DEBUG] Creating Py_buffer for image size=[";
+
+    std::vector<unsigned int> size = image.GetSize();
+    for (size_t i = 0; i < size.size(); ++i)
+    {
+      if (i > 0)
+        std::cerr << ", ";
+      std::cerr << size[i];
+    }
+    std::cerr << "], pixel_type=" << image.GetPixelIDTypeAsString() << ", ptr=" << buffer_ptr << ", flags=0x"
+              << std::hex << flags << std::dec << ", self=" << (void *)self
+              << ", writable=" << (isWritable ? "yes" : "no") << std::endl;
+    std::cerr.flush();
+#endif
+
+    // Get format string and calculate item size from it
+    const char * format = GetFormatString(pixelID);
+
+    Py_ssize_t itemSize = GetItemSizeFromFormat(format);
+#ifdef sitkImageBuffer_DEBUG
+    std::cerr << "[DEBUG] Format string: '" << format << "'" << std::endl;
+    std::cerr << "[DEBUG] GetItemSizeFromFormat returned: " << itemSize << std::endl;
+#endif
+
+    if (itemSize < 0)
+    {
+      // Error was already set by GetItemSizeFromFormat
+      return -1;
+    }
+
+    // Fill in the required fields (structure already zero-initialized)
+    view->buf = (void *)buffer_ptr;
+    view->itemsize = itemSize;
+    view->ndim = (flags & PyBUF_ND) == PyBUF_ND ? totalDimensions : 1;
+
+    // Calculate total buffer size
+    Py_ssize_t buffer_size = itemSize;
+    for (unsigned int i = 0; i < totalDimensions; ++i)
+    {
+      buffer_size *= self->shape[i];
+    }
+    view->len = buffer_size;
+
+    // Set readonly flag based on writable request
+    view->readonly = !isWritable;
+
+    // Handle format flag
+    if ((flags & PyBUF_FORMAT) == PyBUF_FORMAT)
+    {
+      view->format = (char *)format; // Use the already-computed format string
+    }
+
+    // Use the pre-allocated shape array
+    if ((flags & PyBUF_ND) == PyBUF_ND)
+    {
+      view->shape = self->shape;
+
+      // Handle strides - use the pre-allocated strides array
+      if ((flags & PyBUF_STRIDES) == PyBUF_STRIDES)
+      {
+        view->strides = self->strides;
+      }
+    }
+
+
+    // Increment reference count for the exporter object
+    view->obj = (PyObject *)self;
+    Py_INCREF((PyObject *)self);
+
+    return 0;
+  }
+  catch (const std::exception & e)
+  {
+    PyErr_SetString(PyExc_BufferError, e.what());
+    return -1;
+  }
+}
+
+#ifdef sitkImageBuffer_DEBUG
+static void
+sitkImageBuffer_releasebuffer(PyObject * exporter, Py_buffer * view)
+{
+  sitkImageBuffer * self = (sitkImageBuffer *)exporter;
+  // Debug message for buffer release
+  const sitk::Image * imagePtr = GetImageFromBuffer(self);
+  if (imagePtr)
+  {
+    const sitk::Image &       image = *imagePtr;
+    std::vector<unsigned int> size = image.GetSize();
+    std::cerr << "[DEBUG] Releasing Py_buffer for image size=[";
+    for (size_t i = 0; i < size.size(); ++i)
+    {
+      if (i > 0)
+        std::cerr << ", ";
+      std::cerr << size[i];
+    }
+    std::cerr << "], ptr=" << view->buf << std::endl;
+    std::cerr.flush();
+  }
+  else
+  {
+    std::cerr << "[DEBUG] Releasing Py_buffer (no image)" << std::endl;
+    std::cerr.flush();
+  }
+
+  // Verify that view->obj is the same as self (safety check)
+  if (view->obj && view->obj != (PyObject *)self)
+  {
+    std::cerr << "[WARNING] Buffer release: view->obj != self" << std::endl;
+  }
+}
+#endif
+
+// Object life-cycle methods
+static PyObject *
+sitkImageBuffer_new(PyTypeObject * type, PyObject * args, PyObject * kwds)
+{
+  sitkImageBuffer * self = (sitkImageBuffer *)PyType_GenericAlloc(type, 1);
+  return (PyObject *)self;
+}
+
+static int
+sitkImageBuffer_init(sitkImageBuffer * self, PyObject * args, PyObject * kwds)
+{
+  PyObject * pyImageObj = nullptr;
+
+  // Parse the SimpleITK Image object argument
+  static char * kwlist[] = { (char *)"image", NULL };
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "O", kwlist, &pyImageObj))
+  {
+    return -1;
+  }
+
+  if (!pyImageObj)
+  {
+    PyErr_SetString(PyExc_ValueError, "Image object is required");
+    return -1;
+  }
+
+  try
+  {
+    // Extract SimpleITK Image from SWIG-wrapped Python object using helper function
+    sitk::Image * sitkImage = sitk_GetImagePointerFromPyObject(pyImageObj);
+    if (!sitkImage)
+    {
+      PyErr_SetString(PyExc_TypeError, "Expected a SimpleITK Image object");
+      return -1;
+    }
+
+    // Initialize shape and strides arrays based on the image
+    unsigned int              dimension = sitkImage->GetDimension();
+    std::vector<unsigned int> size = sitkImage->GetSize();
+    sitk::PixelIDValueEnum    pixelID = sitkImage->GetPixelID();
+
+    // Calculate total dimensions (add one for vector images)
+    const unsigned int totalDimensions = dimension + (IsVectorPixelType(pixelID) ? 1 : 0);
+
+    // Store the total dimensions in the struct
+    self->ndim = totalDimensions;
+
+    // Initialize shape array (reverse order for NumPy compatibility)
+    for (unsigned int i = 0; i < dimension; ++i)
+    {
+      self->shape[dimension - 1 - i] = size[i];
+    }
+    if (IsVectorPixelType(pixelID))
+    {
+      self->shape[dimension] = sitkImage->GetNumberOfComponentsPerPixel();
+    }
+    // Clear unused entries
+    for (unsigned int i = totalDimensions; i < SITK_MAX_DIMENSION; ++i)
+    {
+      self->shape[i] = 0;
+    }
+
+    // Initialize strides array using format-based size calculation
+    const char * format = GetFormatString(pixelID);
+    Py_ssize_t   itemSize = GetItemSizeFromFormat(format);
+    if (itemSize < 0)
+    {
+      // Error was already set by GetItemSizeFromFormat
+      return -1;
+    }
+
+    Py_ssize_t stride = itemSize;
+    for (int i = totalDimensions - 1; i >= 0; --i)
+    {
+      self->strides[i] = stride;
+      stride *= self->shape[i];
+    }
+    // Clear unused entries
+    for (unsigned int i = totalDimensions; i < SITK_MAX_DIMENSION; ++i)
+    {
+      self->strides[i] = 0;
+    }
+
+    // Store the Python Image object reference in the member
+    // Increment reference count to keep the image alive
+    Py_INCREF(pyImageObj);
+    self->pyImageRef = pyImageObj;
+
+    return 0; // Success
+  }
+  catch (const std::exception & e)
+  {
+    PyErr_SetString(PyExc_RuntimeError, e.what());
+    return -1;
+  }
+}
+
+static void
+sitkImageBuffer_dealloc(sitkImageBuffer * self)
+{
+#ifdef sitkImageBuffer_DEBUG
+  // Debug message for ImageBuffer deallocation
+  const sitk::Image * imagePtr = GetImageFromBuffer(self);
+  if (imagePtr)
+  {
+    const sitk::Image &       image = *imagePtr;
+    std::vector<unsigned int> size = image.GetSize();
+    std::cerr << "[DEBUG] Deallocating ImageBuffer for image size=[";
+    for (size_t i = 0; i < size.size(); ++i)
+    {
+      if (i > 0)
+        std::cerr << ", ";
+      std::cerr << size[i];
+    }
+    std::cerr << "], pixel_type=" << image.GetPixelIDTypeAsString() << ", self=" << (void *)self << std::endl;
+    std::cerr.flush();
+  }
+  else
+  {
+    std::cerr << "[DEBUG] Deallocating ImageBuffer (no image), self="
+              << ", self=" << (void *)self << std::endl;
+    std::cerr.flush();
+  }
+#endif
+
+  // Decrement reference to Python Image object
+  Py_DECREF(self->pyImageRef);
+  self->pyImageRef = nullptr;
+
+  PyTypeObject * type = Py_TYPE((PyObject *)self);
+#ifdef Py_LIMITED_API
+  freefunc free_func = (freefunc)PyType_GetSlot(type, Py_tp_free);
+  free_func((PyObject *)self);
+#else
+  type->tp_free((PyObject *)self);
+#endif
+  Py_DECREF(type);
+}
+
+// String representation
+static PyObject *
+sitkImageBuffer_repr(sitkImageBuffer * self)
+{
+  const sitk::Image * imagePtr = GetImageFromBuffer(self);
+  if (!imagePtr)
+  {
+    return PyUnicode_FromString("<sitkImageBuffer: no image>");
+  }
+
+  const sitk::Image &       image = *imagePtr;
+  std::vector<unsigned int> size = image.GetSize();
+  std::string               sizeStr = "[";
+  for (size_t i = 0; i < size.size(); ++i)
+  {
+    if (i > 0)
+      sizeStr += ", ";
+    sizeStr += std::to_string(size[i]);
+  }
+  sizeStr += "]";
+
+  std::string repr = "<sitkImageBuffer: " + std::to_string(image.GetDimension()) + "D image, size=" + sizeStr +
+                     ", pixel_type=" + image.GetPixelIDTypeAsString() + ">";
+
+  return PyUnicode_FromString(repr.c_str());
+}
+
+// Method to create a weak memoryview from this buffer object
+// Note: This does NOT keep a strong reference to the ImageBuffer or Image.
+// The caller must ensure the source Image/ImageBuffer remains alive.
+static PyObject *
+sitkImageBuffer_GetWeakMemoryView(sitkImageBuffer * self, PyObject * args)
+{
+  int flags = PyBUF_FULL_RO; // Default to read-only
+
+  // Parse optional flags argument
+  if (!PyArg_ParseTuple(args, "|i", &flags))
+  {
+    return nullptr;
+  }
+
+#ifdef sitkImageBuffer_DEBUG
+  // Add debug printing message
+  std::cerr << "[DEBUG] sitkImageBuffer_GetWeakMemoryView called, self=" << (void *)self << ", flags: 0x" << std::hex
+            << flags << std::dec << std::endl;
+#endif
+
+#if 1
+  Py_buffer view;
+  if (PyObject_GetBuffer((PyObject *)self, &view, flags) < 0)
+  {
+    return nullptr;
+  }
+
+  PyObject * memoryview = PyMemoryView_FromBuffer(&view);
+
+  PyBuffer_Release(&view);
+
+#else
+  PyObject * memoryview = PyMemoryView_FromObject((PyObject *)self);
+#endif
+  if (!memoryview)
+  {
+    PyBuffer_Release(&view);
+    return nullptr;
+  }
+#ifdef sitkImageBuffer_DEBUG
+  std::cerr << "[DEBUG] Created memoryview, self=" << (void *)self << ", memoryview=" << (void *)memoryview
+            << std::endl;
+#endif
+  return memoryview;
+}
+
+// Method definitions
+static PyMethodDef sitkImageBuffer_methods[] = {
+  { "get_weak_memoryview",
+    (PyCFunction)sitkImageBuffer_GetWeakMemoryView,
+    METH_VARARGS,
+    "get_weak_memoryview(flags=PyBUF_RECORDS) -> memoryview\n\n"
+    "Create a weak memoryview from this ImageBuffer.\n\n"
+    "IMPORTANT: This method does NOT keep a strong reference to the ImageBuffer\n"
+    "or the source Image object. The returned memoryview is 'weak' - it does not\n"
+    "prevent the source objects from being garbage collected. The caller must\n"
+    "ensure the source Image remains alive for the lifetime of\n"
+    "the returned memoryview, otherwise accessing the memoryview will result in\n"
+    "undefined behavior (likely a segmentation fault).\n\n"
+    "Parameters:\n"
+    "    flags (int, optional): Buffer protocol flags (default: PyBUF_FULL_RO)\n\n"
+    "Returns:\n"
+    "    memoryview: A memoryview object providing access to the image data.\n"
+    "                This memoryview does NOT hold strong references." },
+  { NULL } // Sentinel
+};
+
+// Getter for _image_ref property (stable API compatible)
+static PyObject *
+sitkImageBuffer_get_image_ref(sitkImageBuffer * self, void * closure)
+{
+  if (self->pyImageRef)
+  {
+    Py_INCREF(self->pyImageRef);
+    return self->pyImageRef;
+  }
+  Py_RETURN_NONE;
+}
+
+// Property definitions (using PyGetSetDef, which is stable API compatible)
+static PyGetSetDef sitkImageBuffer_getsetters[] = {
+  { "_image_ref",
+    (getter)sitkImageBuffer_get_image_ref,
+    NULL, // No setter - read-only
+    "Reference to the Python Image object",
+    NULL },
+  { NULL } // Sentinel
+};
+
+// Type slots for Limited API
+static PyType_Slot sitkImageBuffer_slots[] = {
+  { Py_tp_dealloc, (void *)sitkImageBuffer_dealloc },
+  { Py_tp_repr, (void *)sitkImageBuffer_repr },
+  { Py_tp_doc, (void *)"SimpleITK Image Holder for Buffer Protocol" },
+  { Py_tp_methods, sitkImageBuffer_methods },
+  { Py_tp_getset, sitkImageBuffer_getsetters },
+  { Py_tp_init, (void *)sitkImageBuffer_init },
+  { Py_tp_new, (void *)sitkImageBuffer_new },
+  { Py_bf_getbuffer, (void *)sitkImageBuffer_getbuffer },
+#ifdef sitkImageBuffer_DEBUG
+  { Py_bf_releasebuffer, (void *)sitkImageBuffer_releasebuffer },
+#endif
+  { 0, NULL } // Sentinel
+};
+
+// Type spec for Limited API
+static PyType_Spec sitkImageBufferType_spec = {
+  "simpleitk.ImageBuffer",                  // name
+  sizeof(sitkImageBuffer),                  // basic size
+  0,                                        // item size
+  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HEAPTYPE, // flags
+  sitkImageBuffer_slots                     // slots
+};
+
+extern "C"
+{
+
+  int
+  InitImageBufferType(PyObject * module)
+  {
+    PyObject * type = PyType_FromSpec(&sitkImageBufferType_spec);
+    if (!type)
+    {
+      return -1;
+    }
+
+    if (PyModule_AddObject(module, "ImageBuffer", type) < 0)
+    {
+      Py_DECREF(type);
+      return -1;
+    }
+
+    return 0;
+  }
+
+} // extern "C"

--- a/Wrapping/Python/sitkImageBuffer.h
+++ b/Wrapping/Python/sitkImageBuffer.h
@@ -1,0 +1,57 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#ifndef sitkImageBuffer_h
+#define sitkImageBuffer_h
+
+#include "sitkImage.h"
+#include <Python.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+  /**
+   * @brief Initialize the ImageBuffer type and add it to the Python module
+   *
+   * This function registers the ImageBuffer type with the Python module,
+   * making it publicly available as _SimpleITK.ImageBuffer(image).
+   * The ImageBuffer type implements the Python buffer protocol for efficient
+   * zero-copy access to SimpleITK image data.
+   *
+   * @param module The Python module to register the type with
+   * @return int 0 on success, -1 on failure
+   */
+  int
+  InitImageBufferType(PyObject * module);
+
+#ifdef __cplusplus
+}
+
+// C++ helper function to extract sitk::Image* from SWIG-wrapped PyObject
+// This is defined in Python.i where SWIG macros are available
+namespace itk::simple
+{
+class Image;
+}
+itk::simple::Image *
+sitk_GetImagePointerFromPyObject(PyObject * pyImage);
+#endif
+
+#endif // sitkImageBuffer_h

--- a/Wrapping/Python/tests/CMakeLists.txt
+++ b/Wrapping/Python/tests/CMakeLists.txt
@@ -64,6 +64,11 @@ sitk_add_pytest_test(
   "${CMAKE_CURRENT_SOURCE_DIR}/sitkImageBufferTest.py"
 )
 
+sitk_add_pytest_test(
+  Test.ImageProtocol
+  "${CMAKE_CURRENT_SOURCE_DIR}/sitkImageProtocolTest.py"
+)
+
 if(SimpleITK_USE_ELASTIX)
   sitk_add_pytest_test(
     Test.TransformixImageFilterTest

--- a/Wrapping/Python/tests/CMakeLists.txt
+++ b/Wrapping/Python/tests/CMakeLists.txt
@@ -59,6 +59,11 @@ sitk_add_pytest_test(
   "${CMAKE_CURRENT_SOURCE_DIR}/sitkImageReadWrite.py"
 )
 
+sitk_add_pytest_test(
+  Test.ImageBuffer
+  "${CMAKE_CURRENT_SOURCE_DIR}/sitkImageBufferTest.py"
+)
+
 if(SimpleITK_USE_ELASTIX)
   sitk_add_pytest_test(
     Test.TransformixImageFilterTest

--- a/Wrapping/Python/tests/sitkGetArrayViewFromImageTest.py
+++ b/Wrapping/Python/tests/sitkGetArrayViewFromImageTest.py
@@ -20,6 +20,7 @@ import timeit
 import pytest
 import numpy as np
 import SimpleITK as sitk
+import SimpleITK._pixel_types as pixel_types
 
 # Test dimensions
 sizeX = 4
@@ -40,7 +41,10 @@ def check_sitk_to_numpy_type(sitkType: int, numpyType: np.dtype) -> None:
     image = sitk.Image((9, 10), sitkType, 1)
     a = sitk.GetArrayViewFromImage(image)
     assert numpyType == a.dtype, f"Expected numpy type {numpyType}, got {a.dtype}"
-    assert (10, 9) == a.shape, f"Expected shape (10, 9), got {a.shape}"
+    if pixel_types.is_vector(sitkType):
+        assert (10, 9, 1) == a.shape, f"Expected shape (10, 9, 1), got {a.shape}"
+    else:
+        assert (10, 9) == a.shape, f"Expected shape (10, 9), got {a.shape}"
 
 
 @pytest.mark.parametrize(

--- a/Wrapping/Python/tests/sitkImageBufferTest.py
+++ b/Wrapping/Python/tests/sitkImageBufferTest.py
@@ -1,0 +1,590 @@
+# ==========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ==========================================================================*/
+
+import math
+import pytest
+import SimpleITK as sitk
+import sys
+import gc
+from SimpleITK._SimpleITK import ImageBuffer
+
+# Utility function to calculate expected strides
+def calculate_expected_strides(size, itemsize, num_components=None):
+    """Calculate expected strides for C-contiguous layout (ITK order reversed).
+
+    Args:
+        size: tuple of dimensions in ITK order (x, y, z, ...)
+        itemsize: size of one element in bytes
+        num_components: number of components per pixel (for vector images), or None for scalar
+
+    Returns:
+        tuple of strides in numpy order (reversed from ITK)
+    """
+    # Reverse the size for numpy convention
+    shape = size[::-1]
+    if num_components is not None:
+        shape = shape + (num_components,)
+
+    # Calculate strides from innermost to outermost
+    strides = []
+    stride = itemsize
+    for i in range(len(shape) - 1, -1, -1):
+        strides.insert(0, stride)
+        stride *= shape[i]
+
+    return tuple(strides)
+
+
+# Utility function to get format string for pixel type
+def get_expected_format(pixel_type):
+    """Get expected format string for a given pixel type."""
+    format_map = {
+        sitk.sitkUInt8: 'B',
+        sitk.sitkInt8: 'b',
+        sitk.sitkUInt16: 'H',
+        sitk.sitkInt16: 'h',
+        sitk.sitkUInt32: 'I',
+        sitk.sitkInt32: 'i',
+        sitk.sitkUInt64: 'Q',
+        sitk.sitkInt64: 'q',
+        sitk.sitkFloat32: 'f',
+        sitk.sitkFloat64: 'd',
+        sitk.sitkComplexFloat32: 'Zf',
+        sitk.sitkComplexFloat64: 'Zd',
+        sitk.sitkVectorUInt8: 'B',
+        sitk.sitkVectorInt8: 'b',
+        sitk.sitkVectorUInt16: 'H',
+        sitk.sitkVectorInt16: 'h',
+        sitk.sitkVectorUInt32: 'I',
+        sitk.sitkVectorInt32: 'i',
+        sitk.sitkVectorUInt64: 'Q',
+        sitk.sitkVectorInt64: 'q',
+        sitk.sitkVectorFloat32: 'f',
+        sitk.sitkVectorFloat64: 'd',
+    }
+    return format_map.get(pixel_type, 'B')
+
+
+# Test scalar pixel types
+@pytest.mark.parametrize("pixel_type", [
+    sitk.sitkUInt8,
+    sitk.sitkInt8,
+    sitk.sitkUInt16,
+    sitk.sitkInt16,
+    sitk.sitkUInt32,
+    sitk.sitkInt32,
+    sitk.sitkUInt64,
+    sitk.sitkInt64,
+    sitk.sitkFloat32,
+    sitk.sitkFloat64,
+])
+def test_scalar_types(pixel_type):
+    """Test ImageBuffer creation and memoryview for all scalar types"""
+    # Create image with unambiguous size
+    img = sitk.Image([3, 5, 7], pixel_type)
+
+    # Create ImageBuffer
+    buf = ImageBuffer(img)
+
+    # Check that _image_ref points to the original image
+    assert buf._image_ref is img, "_image_ref should reference the original image"
+
+    # Create memoryview
+    mv = memoryview(buf)
+
+    # Check format
+    expected_format = get_expected_format(pixel_type)
+    assert mv.format == expected_format, \
+        f"Expected format '{expected_format}', got '{mv.format}'"
+
+    # Check shape (should be reversed: z, y, x)
+    assert mv.shape == (7, 5, 3), f"Expected shape (7, 5, 3), got {mv.shape}"
+
+    # Check ndim
+    assert mv.ndim == 3, f"Expected ndim 3, got {mv.ndim}"
+
+    # Check readonly
+    assert mv.readonly, "Buffer should be read-only"
+
+    # Check strides
+    expected_strides = calculate_expected_strides((3, 5, 7), mv.itemsize)
+    assert mv.strides == expected_strides, \
+        f"Expected strides {expected_strides}, got {mv.strides}"
+
+    # Check that buffer is C-contiguous
+    assert mv.c_contiguous, "Buffer should be C-contiguous"
+    assert not mv.f_contiguous or mv.ndim <= 1, "Buffer should not be Fortran-contiguous"
+
+
+# Test complex pixel types
+@pytest.mark.parametrize("pixel_type,expected_itemsize", [
+    (sitk.sitkComplexFloat32, 8),
+    (sitk.sitkComplexFloat64, 16),
+])
+def test_complex_types(pixel_type, expected_itemsize):
+    """Test ImageBuffer creation and memoryview for complex types"""
+    # Create image with unambiguous size
+    img = sitk.Image([2, 4, 6], pixel_type)
+
+    # Create ImageBuffer
+    buf = ImageBuffer(img)
+
+    # Create memoryview
+    mv = memoryview(buf)
+
+    # Check format
+    expected_format = get_expected_format(pixel_type)
+    assert mv.format == expected_format, \
+        f"Expected format '{expected_format}', got '{mv.format}'"
+
+    # Check shape (should be reversed: z, y, x)
+    assert mv.shape == (6, 4, 2), f"Expected shape (6, 4, 2), got {mv.shape}"
+
+    # Check itemsize for complex types
+    assert mv.itemsize == expected_itemsize, \
+        f"Expected itemsize {expected_itemsize}, got {mv.itemsize}"
+
+    # Check readonly
+    assert mv.readonly, "Buffer should be read-only"
+
+
+# Test vector pixel types
+@pytest.mark.parametrize("pixel_type,num_components", [
+    (sitk.sitkVectorUInt8, 3),
+    (sitk.sitkVectorInt8, 2),
+    (sitk.sitkVectorUInt16, 4),
+    (sitk.sitkVectorInt16, 3),
+    (sitk.sitkVectorUInt32, 2),
+    (sitk.sitkVectorInt32, 3),
+    (sitk.sitkVectorUInt64, 2),
+    (sitk.sitkVectorInt64, 2),
+    (sitk.sitkVectorFloat32, 3),
+    (sitk.sitkVectorFloat64, 2),
+    (sitk.sitkVectorFloat32, 1),
+])
+def test_vector_types(pixel_type, num_components):
+    """Test ImageBuffer creation and memoryview for vector types"""
+    # Create image with unambiguous size
+    img = sitk.Image([3, 5, 7], pixel_type, num_components)
+
+    # Create ImageBuffer
+    buf = ImageBuffer(img)
+
+    # Check that _image_ref points to the original image
+    assert buf._image_ref is img, "_image_ref should reference the original image"
+
+    # Create memoryview
+    mv = memoryview(buf)
+
+    # Check format
+    expected_format = get_expected_format(pixel_type)
+    assert mv.format == expected_format, \
+        f"Expected format '{expected_format}', got '{mv.format}'"
+
+    # Check shape (should be reversed with components at end: z, y, x, c)
+    expected_shape = (7, 5, 3, num_components)
+    assert mv.shape == expected_shape, \
+        f"Expected shape {expected_shape}, got {mv.shape}"
+
+    # Check ndim
+    assert mv.ndim == 4, f"Expected ndim 4, got {mv.ndim}"
+
+    # Check readonly
+    assert mv.readonly, "Buffer should be read-only"
+
+    # Check strides
+    expected_strides = calculate_expected_strides((3, 5, 7), mv.itemsize, num_components)
+    assert mv.strides == expected_strides, \
+        f"Expected strides {expected_strides}, got {mv.strides}"
+
+
+# Test label types (should raise exception)
+@pytest.mark.parametrize("pixel_type", [
+    sitk.sitkLabelUInt8,
+    sitk.sitkLabelUInt16,
+    sitk.sitkLabelUInt32,
+    sitk.sitkLabelUInt64,
+])
+def test_label_types_raise_exception(pixel_type):
+    """Test that label types raise an exception"""
+    img = sitk.Image([3, 5, 7], pixel_type)
+
+    # Creating ImageBuffer should succeed
+    buf = ImageBuffer(img)
+
+    # But creating memoryview should fail
+    with pytest.raises(BufferError, match="unknown or label pixel type"):
+        memoryview(buf)
+
+
+# Test _image_ref attribute
+def test_image_ref_attribute():
+    """Test that _image_ref attribute correctly references the source image"""
+    img = sitk.Image([3, 5, 7], sitk.sitkUInt8)
+    buf = ImageBuffer(img)
+
+    # _image_ref should point to the original image object
+    assert buf._image_ref is img, "_image_ref should be the same object as the original image"
+
+    # _image_ref should be a SimpleITK Image
+    assert isinstance(buf._image_ref, sitk.Image), "_image_ref should be a SimpleITK Image"
+
+    # _image_ref should have the same properties as the original
+    assert buf._image_ref.GetSize() == img.GetSize(), "Size should match"
+    assert buf._image_ref.GetPixelID() == img.GetPixelID(), "Pixel type should match"
+    assert buf._image_ref.GetDimension() == img.GetDimension(), "Dimension should match"
+
+    # _image_ref should be read-only (we can access it but the attribute itself is read-only)
+    with pytest.raises(AttributeError):
+        buf._image_ref = sitk.Image([1, 1], sitk.sitkUInt8)
+
+
+# Test different dimensions
+@pytest.mark.parametrize("size,expected_shape", [
+    ([5, 7], (7, 5)),           # 2D
+    ([3, 5, 7], (7, 5, 3)),     # 3D
+    ([2, 3, 5, 7], (7, 5, 3, 2)),     # 4D
+    ([2, 3, 5, 7, 11], (11, 7, 5, 3, 2)),  # 5D
+])
+def test_dimensions(size, expected_shape):
+    """Test ImageBuffer with different dimensionalities"""
+    img = sitk.Image(size, sitk.sitkFloat32)
+    buf = ImageBuffer(img)
+    mv = memoryview(buf)
+
+    assert mv.shape == expected_shape, \
+        f"Expected shape {expected_shape}, got {mv.shape}"
+    assert mv.ndim == len(expected_shape), \
+        f"Expected ndim {len(expected_shape)}, got {mv.ndim}"
+
+
+# Test that buffer remains valid after image deletion
+def test_buffer_survives_image_deletion():
+    """Test that buffer remains valid after the image is deleted"""
+    # Create image and buffer
+    img = sitk.Image([3, 5, 7], sitk.sitkUInt16)
+    buf = ImageBuffer(img)
+
+    # Check that _image_ref points to the original image
+    assert buf._image_ref is img, "_image_ref should reference the original image"
+
+    mv = memoryview(buf)
+
+    # Verify initial state
+    assert mv.shape == (7, 5, 3)
+    assert mv.format == 'H'
+
+    # Delete the image reference
+    del img
+    gc.collect()
+
+    # _image_ref should still be accessible and point to the kept-alive image
+    assert buf._image_ref is not None, "_image_ref should keep the image alive"
+    assert buf._image_ref.GetSize() == (3, 5, 7), "Image should still be accessible via _image_ref"
+
+    # Delete the buffer reference
+    del buf
+    gc.collect()
+
+    # Buffer and memoryview should still be valid
+    assert mv.shape == (7, 5, 3)
+    assert mv.format == 'H'
+    assert mv.readonly
+
+    # Should still be able to access buffer properties
+    assert mv.nbytes == 3 * 5 * 7 * 2  # 2 bytes per uint16
+
+
+# Test that memoryview is read-only
+def test_memoryview_readonly():
+    """Test that memoryview from ImageBuffer is read-only"""
+    img = sitk.Image([3, 5], sitk.sitkFloat32)
+    buf = ImageBuffer(img)
+    mv = memoryview(buf)
+
+    assert mv.readonly, "Memoryview should be read-only"
+
+    # Attempting to write should raise an error
+    with pytest.raises(TypeError, match="cannot modify read-only memory"):
+        mv[0] = 1.0
+
+
+# Test get_weak_memoryview method with different flags
+def test_get_weak_memoryview_default():
+    """Test get_weak_memoryview with default flags"""
+    img = sitk.Image([3, 5, 7], sitk.sitkFloat32)
+    buf = ImageBuffer(img)
+
+    # Call with no arguments (default flags)
+    mv = buf.get_weak_memoryview()
+
+    assert mv.shape == (7, 5, 3)
+    assert mv.format == 'f'
+    assert mv.readonly, "Default should be read-only"
+
+    # Should still work after deleting buf reference
+    # but img must remain alive (weak reference)
+    del buf
+    gc.collect()
+    assert mv.shape == (7, 5, 3)
+
+
+def test_get_weak_memoryview_with_flags():
+    """Test get_weak_memoryview with various buffer protocol flags"""
+    import inspect
+
+    # Only run if BufferFlags is available (Python 3.12+)
+    if not hasattr(inspect, 'BufferFlags'):
+        pytest.skip("BufferFlags not available (requires Python 3.12+)")
+
+    BufferFlags = inspect.BufferFlags
+    img = sitk.Image([4, 6], sitk.sitkInt32)
+
+    # Test with FULL_RO (full read-only)
+    buf = ImageBuffer(img)
+    mv = buf.get_weak_memoryview(BufferFlags.FULL_RO)
+    assert mv.readonly
+    assert mv.shape == (6, 4)
+    assert mv.format == 'i'
+
+    # Test with SIMPLE (simple buffer)
+    buf = ImageBuffer(img)
+    mv = buf.get_weak_memoryview(BufferFlags.SIMPLE)
+    assert mv.readonly
+    assert mv.shape == (6*4, ) # memoryview appears to be using uninitialized value in shape
+    assert mv.ndim == 1
+    assert mv.format == 'B'
+
+    # Test with RECORDS (structured data)
+    buf = ImageBuffer(img)
+    mv = buf.get_weak_memoryview(BufferFlags.RECORDS_RO)
+    assert mv.readonly
+    assert mv.shape == (6, 4)
+    assert mv.format == 'i'
+
+
+def test_get_weak_memoryview_readonly_enforcement():
+    """Test that get_weak_memoryview always returns read-only memoryview"""
+    img = sitk.Image([3, 5], sitk.sitkFloat64)
+    buf = ImageBuffer(img)
+
+    mv = buf.get_weak_memoryview()
+
+    assert mv.readonly, "get_weak_memoryview should always return read-only"
+
+    # Verify write attempts fail
+    with pytest.raises(TypeError, match="cannot modify read-only memory"):
+        mv[0, 0] = 99.0
+
+
+def test_get_weak_memoryview_no_strong_reference():
+    """Test that get_weak_memoryview does NOT keep strong reference to image"""
+    img = sitk.Image([3, 5], sitk.sitkFloat32)
+    initial_refcount = sys.getrefcount(img)
+
+    buf = ImageBuffer(img)
+    buf_refcount = sys.getrefcount(img)
+
+    # ImageBuffer holds a reference
+    assert buf_refcount > initial_refcount
+
+    # get_weak_memoryview should not increase reference count beyond the buffer's reference
+    mv = buf.get_weak_memoryview()
+    mv_refcount = sys.getrefcount(img)
+
+    # The memoryview itself doesn't hold an additional strong reference to img
+    # (it may hold a reference to buf, but that's implementation-dependent)
+    # What matters is that deleting the buf and img leaves mv in a dangerous state
+
+    # Keep img alive, delete buf
+    del buf
+    gc.collect()
+
+    # memoryview should still work while img is alive
+    assert mv.shape == (5, 3)
+
+    # Now delete img - this demonstrates the "weak" nature
+    # The memoryview will have a dangling pointer (undefined behavior if accessed)
+    img_id = id(img)
+    del img
+    gc.collect()
+
+    # We can't safely test accessing mv here as it would be undefined behavior
+    # The test just demonstrates that the references are properly released
+    # In a real scenario, accessing mv after img deletion would likely segfault
+
+
+def test_get_weak_memoryview_multiple_calls():
+    """Test multiple calls to get_weak_memoryview from same ImageBuffer"""
+    img = sitk.Image([3, 5, 7], sitk.sitkUInt16)
+    buf = ImageBuffer(img)
+
+    # Create multiple weak memoryviews
+    mv1 = buf.get_weak_memoryview()
+    mv2 = buf.get_weak_memoryview()
+    mv3 = buf.get_weak_memoryview()
+
+    # All should have same properties
+    assert mv1.shape == mv2.shape == mv3.shape == (7, 5, 3)
+    assert mv1.format == mv2.format == mv3.format == 'H'
+    assert all(mv.readonly for mv in [mv1, mv2, mv3])
+
+    # They may or may not be the same object (implementation-dependent)
+    # but they should all work correctly
+    assert mv1.nbytes == mv2.nbytes == mv3.nbytes
+
+
+def test_get_weak_memoryview_vector_image():
+    """Test get_weak_memoryview with vector pixel types"""
+    img = sitk.Image([4, 6], sitk.sitkVectorFloat32, 3)
+    buf = ImageBuffer(img)
+
+    mv = buf.get_weak_memoryview()
+
+    # Shape should be (y, x, components) = (6, 4, 3)
+    assert mv.shape == (6, 4, 3)
+    assert mv.format == 'f'
+    assert mv.readonly
+    assert mv.ndim == 3
+
+
+def test_get_weak_memoryview_complex_image():
+    """Test get_weak_memoryview with complex pixel types"""
+    img = sitk.Image([3, 5], sitk.sitkComplexFloat64)
+    buf = ImageBuffer(img)
+
+    mv = buf.get_weak_memoryview()
+
+    assert mv.shape == (5, 3)
+    assert mv.format == 'Zd'  # Complex double
+    assert mv.readonly
+    assert mv.itemsize == 16  # 2 * 8 bytes
+
+
+# Test multiple buffers from same image
+def test_multiple_buffers_same_image():
+    """Test creating multiple buffers from the same image"""
+    img = sitk.Image([3, 5, 7], sitk.sitkInt16)
+
+    buf1 = ImageBuffer(img)
+    buf2 = ImageBuffer(img)
+
+    # Both buffers should reference the same image
+    assert buf1._image_ref is img, "buf1._image_ref should reference the original image"
+    assert buf2._image_ref is img, "buf2._image_ref should reference the original image"
+    assert buf1._image_ref is buf2._image_ref, "Both buffers should reference the same image"
+
+    mv1 = memoryview(buf1)
+    mv2 = memoryview(buf2)
+
+    # Both should have same properties
+    assert mv1.shape == mv2.shape
+    assert mv1.format == mv2.format
+    assert mv1.strides == mv2.strides
+    assert mv1.nbytes == mv2.nbytes
+
+
+# Test that ImageBuffer and memoryview hold reference to image
+def test_image_reference_chain():
+    """Test that ImageBuffer and memoryview maintain references to the source image"""
+    img = sitk.Image([3, 5], sitk.sitkFloat32)
+    initial_refcount = sys.getrefcount(img)
+
+    # Create buffer - should increase refcount
+    buf = ImageBuffer(img)
+
+    # Check that _image_ref points to the original image
+    assert buf._image_ref is img, "_image_ref should reference the original image"
+
+    # Reference count should increase
+    assert sys.getrefcount(img) > initial_refcount, \
+        "ImageBuffer should hold a reference to the image"
+
+    buf_refcount = sys.getrefcount(img)
+
+    # Create memoryview - should increase refcount further (holds ref to buffer)
+    mv = memoryview(buf)
+
+    assert sys.getrefcount(img) >= buf_refcount, \
+        "Memoryview should indirectly maintain image reference"
+
+    mv_refcount = sys.getrefcount(img)
+
+    # Delete buffer - image should still be alive due to memoryview
+    del buf
+    gc.collect()
+
+    # Reference count should remain elevated because memoryview holds buffer
+    assert sys.getrefcount(img) >= initial_refcount, \
+        "Image should remain alive while memoryview exists"
+
+    # Memoryview should still work
+    assert mv.shape == (5, 3)
+
+    # Delete memoryview - now image reference should be released
+    del mv
+    gc.collect()
+
+    # Reference count should decrease back to initial
+    assert sys.getrefcount(img) == initial_refcount, \
+        "All references should be released after memoryview deletion"
+
+
+# Test C-contiguous layout
+def test_c_contiguous():
+    """Test that buffer is C-contiguous and flattened view has correct sequence"""
+    img = sitk.Image([3, 5, 7], sitk.sitkUInt32)
+
+    # Set all pixels to sequential values in ITK order (x, y, z)
+    value = 0
+    for z in range(7):
+        for y in range(5):
+            for x in range(3):
+                img[x, y, z] = value
+                value += 1
+
+    buf = ImageBuffer(img)
+    mv = memoryview(buf)
+
+    assert mv.c_contiguous, "Buffer should be C-contiguous"
+    assert not mv.f_contiguous, "Buffer should not be Fortran-contiguous"
+    assert mv.contiguous, "Buffer should be contiguous"
+
+    # Flatten the memoryview and verify the sequence
+    # The memoryview shape is (7, 5, 3) in numpy order (z, y, x)
+    # When flattened, it should be the same sequence as we wrote
+    flat = mv.cast('B')
+    flat = flat.cast(mv.format, [math.prod(mv.shape)])  # Cast to unsigned int (1D view)
+
+    expected_sequence = list(range(3 * 5 * 7))  # 0 to 104
+    actual_sequence = flat.tolist()
+
+    assert actual_sequence == expected_sequence, \
+        f"Flattened sequence doesn't match. First 10: {actual_sequence[:10]}, Last 10: {actual_sequence[-10:]}"
+
+
+# Test suboffsets (should be None for simple layouts)
+def test_no_suboffsets():
+    """Test that buffer has no suboffsets (simple layout)"""
+    img = sitk.Image([3, 5, 7], sitk.sitkInt32)
+    buf = ImageBuffer(img)
+    mv = memoryview(buf)
+
+    # Note: memoryview doesn't expose suboffsets directly in Python,
+    # but we can verify the buffer is contiguous which implies no suboffsets
+    assert mv.contiguous, "Buffer should be contiguous (no suboffsets)"

--- a/Wrapping/Python/tests/sitkImageProtocolTest.py
+++ b/Wrapping/Python/tests/sitkImageProtocolTest.py
@@ -1,0 +1,397 @@
+# ==========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ==========================================================================*/
+
+import pytest
+import sys
+import gc
+import SimpleITK as sitk
+
+# Check Python version for buffer protocol support
+BUFFER_PROTOCOL_AVAILABLE = sys.version_info >= (3, 12)
+
+# Import numpy if available
+try:
+    import numpy as np
+    NUMPY_AVAILABLE = True
+except ImportError:
+    NUMPY_AVAILABLE = False
+    np = None
+
+
+# ============================================================================
+# __buffer__ Protocol Tests (Python 3.12+)
+# ============================================================================
+
+@pytest.mark.skipif(not BUFFER_PROTOCOL_AVAILABLE, reason="Requires Python 3.12+")
+class TestBufferProtocol:
+    """Tests for Image.__buffer__() method using memoryview"""
+
+    def test_buffer_scalar_2d(self):
+        """Test buffer protocol with 2D scalar image"""
+        img = sitk.Image([5, 7], sitk.sitkFloat32)
+        mv = memoryview(img)
+
+        assert mv.shape == (7, 5), f"Expected shape (7, 5), got {mv.shape}"
+        assert mv.format == 'f', f"Expected format 'f', got {mv.format}"
+        assert mv.ndim == 2, f"Expected ndim 2, got {mv.ndim}"
+        assert mv.readonly, "Buffer should be read-only"
+        assert mv.c_contiguous, "Buffer should be C-contiguous"
+
+    def test_buffer_scalar_3d(self):
+        """Test buffer protocol with 3D scalar image"""
+        img = sitk.Image([3, 5, 7], sitk.sitkInt16)
+        mv = memoryview(img)
+
+        assert mv.shape == (7, 5, 3), f"Expected shape (7, 5, 3), got {mv.shape}"
+        assert mv.format == 'h', f"Expected format 'h', got {mv.format}"
+        assert mv.ndim == 3, f"Expected ndim 3, got {mv.ndim}"
+        assert mv.readonly, "Buffer should be read-only"
+
+    def test_buffer_vector_2d(self):
+        """Test buffer protocol with 2D vector image"""
+        img = sitk.Image([5, 7], sitk.sitkVectorFloat32, 3)
+        mv = memoryview(img)
+
+        assert mv.shape == (7, 5, 3), f"Expected shape (7, 5, 3), got {mv.shape}"
+        assert mv.format == 'f', f"Expected format 'f', got {mv.format}"
+        assert mv.ndim == 3, f"Expected ndim 3, got {mv.ndim}"
+        assert mv.readonly, "Buffer should be read-only"
+
+    def test_buffer_vector_1_component(self):
+        """Test buffer protocol with vector image having 1 component"""
+        img = sitk.Image([4, 6], sitk.sitkVectorFloat64, 1)
+        mv = memoryview(img)
+
+        assert mv.shape == (6, 4, 1), f"Expected shape (6, 4, 1), got {mv.shape}"
+        assert mv.format == 'd', f"Expected format 'd', got {mv.format}"
+        assert mv.ndim == 3, f"Expected ndim 3, got {mv.ndim}"
+
+    def test_buffer_complex(self):
+        """Test buffer protocol with complex image"""
+        img = sitk.Image([4, 6], sitk.sitkComplexFloat64)
+        mv = memoryview(img)
+
+        assert mv.shape == (6, 4), f"Expected shape (6, 4), got {mv.shape}"
+        assert mv.format == 'Zd', f"Expected format 'Zd', got {mv.format}"
+        assert mv.ndim == 2, f"Expected ndim 2, got {mv.ndim}"
+        assert mv.itemsize == 16, f"Expected itemsize 16, got {mv.itemsize}"
+
+    @pytest.mark.parametrize("pixel_type,expected_format", [
+        (sitk.sitkUInt8, 'B'),
+        (sitk.sitkInt8, 'b'),
+        (sitk.sitkUInt16, 'H'),
+        (sitk.sitkInt16, 'h'),
+        (sitk.sitkUInt32, 'I'),
+        (sitk.sitkInt32, 'i'),
+        (sitk.sitkUInt64, 'Q'),
+        (sitk.sitkInt64, 'q'),
+        (sitk.sitkFloat32, 'f'),
+        (sitk.sitkFloat64, 'd'),
+    ])
+    def test_buffer_formats(self, pixel_type, expected_format):
+        """Test buffer protocol format strings for all scalar types"""
+        img = sitk.Image([3, 5], pixel_type)
+        mv = memoryview(img)
+        assert mv.format == expected_format, f"Expected format '{expected_format}', got '{mv.format}'"
+
+    def test_buffer_readonly(self):
+        """Test that buffer is read-only"""
+        img = sitk.Image([3, 5], sitk.sitkFloat32)
+        mv = memoryview(img)
+
+        assert mv.readonly, "Buffer should be read-only"
+        with pytest.raises(TypeError, match="cannot modify read-only memory"):
+            mv[0, 0] = 1.0
+
+    def test_buffer_survives_image_deletion(self):
+        """Test that buffer data remains valid after image deletion"""
+        img = sitk.Image([3, 5], sitk.sitkFloat32)
+        mv = memoryview(img)
+
+        # Store original properties
+        original_shape = mv.shape
+        original_format = mv.format
+
+        # Delete image - buffer should keep data alive
+        del img
+        gc.collect()
+
+        # Buffer should still be valid
+        assert mv.shape == original_shape
+        assert mv.format == original_format
+
+    def test_buffer_strides(self):
+        """Test buffer strides are correct for C-contiguous layout"""
+        img = sitk.Image([3, 5, 7], sitk.sitkFloat32)
+        mv = memoryview(img)
+
+        # For shape (7, 5, 3) with itemsize 4:
+        # strides should be (60, 12, 4)
+        expected_strides = (60, 12, 4)
+        assert mv.strides == expected_strides, f"Expected strides {expected_strides}, got {mv.strides}"
+
+    def test_buffer_multiple_views(self):
+        """Test creating multiple memoryviews from same image"""
+        img = sitk.Image([3, 5], sitk.sitkInt32)
+        mv1 = memoryview(img)
+        mv2 = memoryview(img)
+
+        assert mv1.shape == mv2.shape
+        assert mv1.format == mv2.format
+        assert mv1.strides == mv2.strides
+
+
+# ============================================================================
+# __array_interface__ Tests (requires numpy)
+# ============================================================================
+
+@pytest.mark.skipif(not NUMPY_AVAILABLE, reason="Requires numpy")
+class TestArrayInterface:
+    """Tests for Image.__array_interface__ property"""
+
+    @pytest.fixture
+    def disable_buffer_protocol(self):
+        """
+        Context manager fixture to temporarily disable __buffer__ on Image class
+
+        This forces numpy to use __array_interface__ on Python 3.12+
+        """
+        original_buffer = None
+        if hasattr(sitk.Image, '__buffer__'):
+            # Save and temporarily remove __buffer__ from Image class
+            original_buffer = sitk.Image.__buffer__
+            delattr(sitk.Image, '__buffer__')
+
+        yield  # Test runs here
+
+        # Restore __buffer__ if it was removed
+        if original_buffer is not None:
+            sitk.Image.__buffer__ = original_buffer
+
+    def test_array_interface_exists(self):
+        """Test that __array_interface__ attribute exists"""
+        img = sitk.Image([3, 5], sitk.sitkFloat32)
+        assert hasattr(img, '__array_interface__'), "Image should have __array_interface__"
+        assert isinstance(img.__array_interface__, dict), "__array_interface__ should be a dict"
+
+    def test_array_interface_scalar_2d(self):
+        """Test __array_interface__ with 2D scalar image"""
+        img = sitk.Image([5, 7], sitk.sitkFloat32)
+        iface = img.__array_interface__
+
+        assert iface['shape'] == (7, 5), f"Expected shape (7, 5), got {iface['shape']}"
+        assert iface['typestr'] == '|f4', f"Expected typestr '|f4', got {iface['typestr']}"
+        assert iface['version'] == 3, f"Expected version 3, got {iface['version']}"
+        assert 'data' in iface, "Should have 'data' key"
+
+    def test_array_interface_scalar_3d(self):
+        """Test __array_interface__ with 3D scalar image"""
+        img = sitk.Image([3, 5, 7], sitk.sitkInt16)
+        iface = img.__array_interface__
+
+        assert iface['shape'] == (7, 5, 3), f"Expected shape (7, 5, 3), got {iface['shape']}"
+        assert iface['typestr'] == '|i2', f"Expected typestr '|i2', got {iface['typestr']}"
+
+    def test_array_interface_vector_2d(self):
+        """Test __array_interface__ with 2D vector image"""
+        img = sitk.Image([5, 7], sitk.sitkVectorFloat32, 3)
+        iface = img.__array_interface__
+
+        assert iface['shape'] == (7, 5, 3), f"Expected shape (7, 5, 3), got {iface['shape']}"
+        assert iface['typestr'] == '|f4', f"Expected typestr '|f4', got {iface['typestr']}"
+
+    def test_array_interface_vector_1_component(self):
+        """Test __array_interface__ with vector image having 1 component"""
+        img = sitk.Image([4, 6], sitk.sitkVectorFloat64, 1)
+        iface = img.__array_interface__
+
+        # Note: Implementation doesn't include component dimension when num_components == 1
+        assert iface['shape'] == (6, 4, 1), f"Expected shape (6, 4, 1), got {iface['shape']}"
+        assert iface['typestr'] == '|f8', f"Expected typestr '|f8', got {iface['typestr']}"
+
+    def test_array_interface_complex(self):
+        """Test __array_interface__ with complex image"""
+        img = sitk.Image([4, 6], sitk.sitkComplexFloat64)
+        iface = img.__array_interface__
+
+        assert iface['shape'] == (6, 4), f"Expected shape (6, 4), got {iface['shape']}"
+        assert iface['typestr'] == '|c16', f"Expected typestr '|c16', got {iface['typestr']}"
+
+    def test_array_interface_strides(self):
+        """Test __array_interface__ strides are omitted for C-contiguous data"""
+        img = sitk.Image([3, 5, 7], sitk.sitkFloat32)
+        iface = img.__array_interface__
+
+        # For C-contiguous arrays, strides can be omitted
+        # If present, for shape (7, 5, 3) with itemsize 4, strides should be (60, 12, 4)
+        if 'strides' in iface:
+            assert iface['strides'] == (60, 12, 4), f"Expected strides (60, 12, 4), got {iface['strides']}"
+
+    def test_numpy_asarray_via_array_interface(self, disable_buffer_protocol):
+        """Test numpy.asarray uses __array_interface__ when __buffer__ is disabled"""
+        # With __buffer__ temporarily removed, numpy should fall back to __array_interface__
+        img = sitk.Image([5, 7], sitk.sitkFloat32)
+
+        # Verify __buffer__ is not available
+        assert not hasattr(img, '__buffer__'), "__buffer__ should be disabled for this test"
+
+        # NumPy should now use __array_interface__
+        arr = np.asarray(img)
+
+        assert arr.shape == (7, 5), f"Expected shape (7, 5), got {arr.shape}"
+        assert arr.dtype == np.float32, f"Expected dtype float32, got {arr.dtype}"
+        assert not arr.flags['WRITEABLE'], "Array should be read-only"
+
+    def test_array_interface_readonly(self):
+        """Test that __array_interface__ provides read-only data"""
+        img = sitk.Image([3, 5], sitk.sitkFloat32)
+        iface = img.__array_interface__
+
+        # The 'data' field is a memoryview object
+        # NumPy will respect the readonly flag from the buffer protocol
+        assert 'data' in iface, "Should have 'data' key"
+        data = iface['data']
+        assert hasattr(data, 'readonly'), "data should be a memoryview or similar"
+        if hasattr(data, 'readonly'):
+            assert data.readonly, "data should be read-only"
+
+    def test_array_interface_keeps_image_alive(self):
+        """Test that __array_interface__ holds reference to image"""
+        img = sitk.Image([3, 5], sitk.sitkFloat32)
+        initial_refcount = sys.getrefcount(img)
+
+        # Access __array_interface__ - this creates ImageBuffer internally
+        iface = img.__array_interface__
+
+        # Reference count should have increased
+        assert sys.getrefcount(img) > initial_refcount, \
+            "Image refcount should increase when __array_interface__ is accessed"
+
+    @pytest.mark.parametrize("pixel_type,expected_typestr", [
+        (sitk.sitkUInt8, '|u1'),
+        (sitk.sitkInt8, '|i1'),
+        (sitk.sitkUInt16, '|u2'),
+        (sitk.sitkInt16, '|i2'),
+        (sitk.sitkUInt32, '|u4'),
+        (sitk.sitkInt32, '|i4'),
+        (sitk.sitkUInt64, '|u8'),
+        (sitk.sitkInt64, '|i8'),
+        (sitk.sitkFloat32, '|f4'),
+        (sitk.sitkFloat64, '|f8'),
+        (sitk.sitkComplexFloat32, '|c8'),
+        (sitk.sitkComplexFloat64, '|c16'),
+    ])
+    def test_array_interface_typestrs(self, pixel_type, expected_typestr):
+        """Test __array_interface__ typestr for all scalar types (using native byte order)"""
+        img = sitk.Image([3, 5], pixel_type)
+        iface = img.__array_interface__
+        assert iface['typestr'] == expected_typestr, \
+            f"Expected typestr '{expected_typestr}', got '{iface['typestr']}'"
+
+
+# ============================================================================
+# Integration Tests with numpy
+# ============================================================================
+
+@pytest.mark.skipif(not NUMPY_AVAILABLE, reason="Requires numpy")
+class TestNumpyIntegration:
+    """Test interaction between buffer protocol, __array_interface__, and numpy"""
+
+    @pytest.fixture(params=[
+        pytest.param("buffer", marks=pytest.mark.skipif(not BUFFER_PROTOCOL_AVAILABLE,
+                                                        reason="Requires Python 3.12+")),
+        pytest.param("array_interface"),
+    ])
+    def protocol_mode(self, request):
+        """
+        Fixture that runs tests with different protocols:
+        - Python <3.12: runs once with array_interface
+        - Python 3.12+: runs twice, once with buffer and once with array_interface
+        """
+        mode = request.param
+
+        if mode == "array_interface" and BUFFER_PROTOCOL_AVAILABLE:
+            # Temporarily disable __buffer__ to force __array_interface__
+            original_buffer = None
+            if hasattr(sitk.Image, '__buffer__'):
+                original_buffer = sitk.Image.__buffer__
+                delattr(sitk.Image, '__buffer__')
+
+            yield mode
+
+            # Restore __buffer__
+            if original_buffer is not None:
+                sitk.Image.__buffer__ = original_buffer
+        else:
+            yield mode
+
+    def test_numpy_array_readonly(self, protocol_mode):
+        """Test that numpy arrays from SimpleITK images are read-only"""
+        img = sitk.Image([3, 5], sitk.sitkFloat32)
+        arr = np.asarray(img)
+
+        assert not arr.flags['WRITEABLE'], "Array should be read-only"
+        with pytest.raises(ValueError, match="read-only"):
+            arr[0, 0] = 1.0
+
+    def test_numpy_array_vector_shape(self, protocol_mode):
+        """Test numpy array shape for vector images"""
+        img = sitk.Image([3, 5], sitk.sitkVectorFloat32, 4)
+        arr = np.asarray(img)
+
+        assert arr.shape == (5, 3, 4), f"Expected shape (5, 3, 4), got {arr.shape}"
+
+
+        img = sitk.Image([3, 5], sitk.sitkVectorFloat64, 1)
+        arr = np.asarray(img)
+
+        assert arr.shape == (5, 3, 1), f"Expected shape (5, 3, 1), got {arr.shape}"
+
+    def test_numpy_array_complex_dtype(self, protocol_mode):
+        """Test numpy array dtype for complex images"""
+        img = sitk.Image([3, 5], sitk.sitkComplexFloat64)
+        arr = np.asarray(img)
+
+        assert arr.dtype == np.complex128, f"Expected dtype complex128, got {arr.dtype}"
+
+    def test_numpy_shares_memory(self, protocol_mode):
+        """Test that numpy array shares memory with SimpleITK image"""
+        img = sitk.Image([3, 5], sitk.sitkFloat32)
+        img.SetPixel([1, 2], 42.0)
+
+        arr = np.asarray(img)
+
+        # Array should reflect the image data (reversed indices due to order)
+        assert arr[2, 1] == 42.0, f"Expected value 42.0, got {arr[2, 1]}"
+
+    def test_numpy_copy_vs_view(self, protocol_mode):
+        """Test difference between np.asarray (view) and np.array (copy)"""
+        img = sitk.Image([3, 5], sitk.sitkFloat32)
+
+        # asarray creates a view
+        view = np.asarray(img)
+
+        # array creates a copy
+        copy = np.array(img)
+
+        # Both should have same data initially
+        assert np.array_equal(view, copy), "View and copy should have same data"
+
+        # Copy should be writeable
+        assert copy.flags['WRITEABLE'], "Copy should be writeable"
+        assert not view.flags['WRITEABLE'], "View should be read-only"

--- a/Wrapping/Python/tests/sitkNumpyArrayConversionTest.py
+++ b/Wrapping/Python/tests/sitkNumpyArrayConversionTest.py
@@ -19,6 +19,7 @@
 import pytest
 import numpy as np
 import SimpleITK as sitk
+import SimpleITK._pixel_types as pixel_types
 
 # Test dimensions
 sizeX = 4
@@ -28,10 +29,16 @@ sizeZ = 3
 
 def _check_sitk_to_numpy_type(sitkType, numpyType):
     """Helper to check SimpleITK to numpy type conversion"""
+
     image = sitk.Image((9, 10), sitkType, 1)
     a = sitk.GetArrayFromImage(image)
+    # For vector types, create with 1 component and expect 3D shape
+    # For scalar types, don't pass component count
     assert numpyType == a.dtype, f"Expected numpy type {numpyType}, got {a.dtype}"
-    assert (10, 9) == a.shape, f"Expected shape (10, 9), got {a.shape}"
+    if pixel_types.is_vector(sitkType):
+        assert (10, 9, 1) == a.shape, f"Expected shape (10, 9, 1) for vector type, got {a.shape}"
+    else:
+        assert (10, 9) == a.shape, f"Expected shape (10, 9) for scalar type, got {a.shape}"
 
 
 @pytest.mark.parametrize("sitk_type,numpy_type", [


### PR DESCRIPTION
Enables view and conversions to numpy arrays with the following:
```
img = sitk.Image((2,5), sitk.sitkVectorUInt8, 3)
a_view = np.asarray(img, copy=False)
a_copy = np.array(img, copy=True)
```

References to the Python Image object are maintained. 

- Remove internal GetMemoryViewFromImage function
- Add pixel_types module to Python
- Add array interface and buffer protocol to Image class
- Add a CPython ImageBuffer class to have pyBuffer interface

COMPATIBILITY:

Images of vector pixel type with only 1 component now return memory views and arrays of n+1 dimensions. ( Previously the 1 size component dimension was dropped )
