### PR TITLE
Set unique file name for the SimpleIO examples.

### DIFF
--- a/Examples/SimpleIO/SimpleIO.R
+++ b/Examples/SimpleIO/SimpleIO.R
@@ -56,8 +56,9 @@ example3 <- function() {
   basic_transform <- Euler2DTransform()
   basic_transform$SetTranslation(c(2,3))
 
-  WriteTransform(basic_transform, 'euler2D.tfm')
-  read_result = ReadTransform('euler2D.tfm')
+  file_name <- 'euler2D_r.tfm'
+  WriteTransform(basic_transform, file_name)
+  read_result = ReadTransform(file_name)
 
   stopifnot(read_result$GetName() != basic_transform$GetName())
   #END_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE

--- a/Examples/SimpleIO/SimpleIO.cs
+++ b/Examples/SimpleIO/SimpleIO.cs
@@ -53,9 +53,10 @@ static void example3() {
   VectorDouble trans = new VectorDouble( new double[] {2.0, 3.0} );
   basic_transform.SetTranslation(trans);
 
-  sitk.WriteTransform(basic_transform, "euler2D.tfm");
+  string file_name = "euler2D_cs.tfm";
+  sitk.WriteTransform(basic_transform, file_name);
 
-  Transform read_result = sitk.ReadTransform("euler2D.tfm");
+  Transform read_result = sitk.ReadTransform(file_name);
 
   Debug.Assert( basic_transform.GetName() != read_result.GetName() );
   //END_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE

--- a/Examples/SimpleIO/SimpleIO.cxx
+++ b/Examples/SimpleIO/SimpleIO.cxx
@@ -63,8 +63,9 @@ example3()
   itk::simple::Euler2DTransform basic_transform;
   basic_transform.SetTranslation(std::vector<double>{ 2.0, 3.0 });
 
-  itk::simple::WriteTransform(basic_transform, "euler2D.tfm");
-  itk::simple::Transform read_result = itk::simple::ReadTransform("euler2D.tfm");
+  std::string file_name = "euler2D_cxx.tfm";
+  itk::simple::WriteTransform(basic_transform, file_name);
+  itk::simple::Transform read_result = itk::simple::ReadTransform(file_name);
 
   assert(typeid(basic_transform) != typeid(read_result));
   // END_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE

--- a/Examples/SimpleIO/SimpleIO.java
+++ b/Examples/SimpleIO/SimpleIO.java
@@ -52,8 +52,9 @@ static void example3() {
   VectorDouble trans = new VectorDouble(t);
   basic_transform.setTranslation(trans);
 
-  SimpleITK.writeTransform(basic_transform, "euler2D.tfm");
-  Transform read_result = SimpleITK.readTransform("euler2D.tfm");
+  String file_name = "euler2D_java.tfm";
+  SimpleITK.writeTransform(basic_transform, file_name);
+  Transform read_result = SimpleITK.readTransform(file_name);
 
   assert basic_transform.getClass() != read_result.getClass();
   //END_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE

--- a/Examples/SimpleIO/SimpleIO.lua
+++ b/Examples/SimpleIO/SimpleIO.lua
@@ -55,8 +55,9 @@ function example3()
   trans:push_back(3.0)
   basic_transform:SetTranslation(trans)
 
-  SimpleITK.WriteTransform(basic_transform, 'euler2D.tfm')
-  read_result = SimpleITK.ReadTransform('euler2D.tfm')
+  file_name = 'euler2D_lua.tfm'
+  SimpleITK.WriteTransform(basic_transform, file_name)
+  read_result = SimpleITK.ReadTransform(file_name)
 
   assert(read_result:GetName() ~= basic_transform:GetName(), "type error")
   --END_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE

--- a/Examples/SimpleIO/SimpleIO.py
+++ b/Examples/SimpleIO/SimpleIO.py
@@ -70,8 +70,9 @@ def example3():
     basic_transform = sitk.Euler2DTransform()
     basic_transform.SetTranslation((2, 3))
 
-    sitk.WriteTransform(basic_transform, "euler2D.tfm")
-    read_result = sitk.ReadTransform("euler2D.tfm")
+    file_name = "euler2D_py.tfm"
+    sitk.WriteTransform(basic_transform, file_name)
+    read_result = sitk.ReadTransform(file_name)
 
     assert isinstance(read_result, sitk.Euler2DTransform)
     #END_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE

--- a/Examples/SimpleIO/SimpleIO.rb
+++ b/Examples/SimpleIO/SimpleIO.rb
@@ -54,8 +54,9 @@ def example3()
   trans << 3.0
   basic_transform.set_translation(trans)
 
-  Simpleitk::write_transform(basic_transform, 'euler2D.tfm')
-  read_result = Simpleitk::read_transform('euler2D.tfm')
+  file_name = 'euler2D_rb.tfm'
+  Simpleitk::write_transform(basic_transform, file_name)
+  read_result = Simpleitk::read_transform(file_name)
 
   raise "This shouldn't happen." unless basic_transform.class != read_result.class
   #END_PROCEDURAL_TRANSFORM_READER_WRITER_EXAMPLE

--- a/Examples/SimpleIO/SimpleIO.tcl
+++ b/Examples/SimpleIO/SimpleIO.tcl
@@ -53,8 +53,9 @@ proc example3 {} {
   set trans { 2.0 3.0 }
   basic_transform SetTranslation $trans
 
-  WriteTransform basic_transform "euler2D.tfm"
-  set read_result [ ReadTransform "euler2D.tfm" ]
+  set file_name "euler2D_tcl.tfm"
+  WriteTransform basic_transform $file_name
+  set read_result [ ReadTransform $file_name ]
 
   if { [basic_transform GetName] == [$read_result GetName] } {
     error "This should not happen" 1


### PR DESCRIPTION
Use unique file names so that example tests can be run in parallel.

resolves #2463