### PR TITLE
Add optional --output flag to expand script

### DIFF
--- a/CMake/sitkGenerateFilterSource.cmake
+++ b/CMake/sitkGenerateFilterSource.cmake
@@ -90,8 +90,7 @@ function(get_config_path out_var config_file path)
     execute_process(
       COMMAND
         ${SimpleITK_Python_EXECUTABLE} -c
-        "import sys, yaml; d=yaml.safe_load(open(sys.argv[1])); v=d;\nfor k in sys.argv[2].split('.'):\n    v = v[k]\nprint(v)"
-        ${config_file} ${path}
+        "import yaml; d=yaml.safe_load(open('${config_file}')); v=d;\nfor k in '${path}'.split('.'):\n    v = v[k]\nprint(v)"
       OUTPUT_VARIABLE value
       RESULT_VARIABLE ret
       ERROR_VARIABLE error_var

--- a/CMake/sitkGenerateFilterSource.cmake
+++ b/CMake/sitkGenerateFilterSource.cmake
@@ -216,7 +216,7 @@ function(expand_template input_config_file input_dir output_dir library_name)
       ${SimpleITK_Python_EXECUTABLE} ${SimpleITK_EXPANSION_SCRIPT}
       ${input_config_file} -D ${input_dir}/templates -D
       ${_sitk_jinja_include_dir} sitk${template_code_filename}Template.h.jinja
-      ${output_h}
+      -o ${output_h}
     DEPENDS
       ${input_config_file}
       ${template_deps}
@@ -232,7 +232,7 @@ function(expand_template input_config_file input_dir output_dir library_name)
       ${SimpleITK_Python_EXECUTABLE} ${SimpleITK_EXPANSION_SCRIPT}
       ${input_config_file} -D ${input_dir}/templates -D
       ${_sitk_jinja_include_dir} sitk${template_code_filename}Template.cxx.jinja
-      ${output_cxx}
+      -o ${output_cxx}
     DEPENDS
       ${input_config_file}
       ${template_deps}

--- a/CMake/sitkGenerateFilterSource.cmake
+++ b/CMake/sitkGenerateFilterSource.cmake
@@ -279,7 +279,7 @@ endfunction()
 #   Sets GENERATED_CONFIG_LIST as a cache variable.
 #
 macro(generate_filter_list)
-  set(GENERATED_CONFIG_LIST "" CACHE INTERNAL "")
+  set(GENERATED_CONFIG_LIST "")
 
   message(CHECK_START "Processing configuration files")
 
@@ -336,15 +336,11 @@ macro(generate_filter_list)
 
       get_filename_component(FILENAME ${input_config_file} NAME_WE)
       # Make the list visible at the global scope
-      set(
-        GENERATED_CONFIG_LIST
-        ${GENERATED_CONFIG_LIST}
-        ${input_config_file}
-        CACHE INTERNAL
-        ""
-      )
+      list(APPEND GENERATED_CONFIG_LIST ${input_config_file})
     endif()
   endforeach()
+
+  set(GENERATED_CONFIG_LIST ${GENERATED_CONFIG_LIST} CACHE INTERNAL "" FORCE)
 
   message(CHECK_PASS "done")
 endmacro(generate_filter_list)

--- a/Testing/Unit/CMakeLists.txt
+++ b/Testing/Unit/CMakeLists.txt
@@ -119,6 +119,7 @@ message(CHECK_START "Configuring test generation...")
 set(_stride 50)
 set(_exec_i 1) # exec 0 is the manual tests
 set(_i 0)
+set(_CMAKE_OUTPUT_CONTENT "")
 
 foreach(filter_config_file ${GENERATED_CONFIG_LIST})
   get_filename_component(FILTERNAME ${filter_config_file} NAME_WE)
@@ -151,10 +152,6 @@ foreach(filter_config_file ${GENERATED_CONFIG_LIST})
 
   if(template_name)
     set(
-      OUTPUT_TEST_FILENAME
-      "${SimpleITK_BINARY_DIR}/Testing/Unit/CTest/${FILTERNAME}.cmake"
-    )
-    set(
       cmd
       ${SimpleITK_Python_EXECUTABLE}
       ${SimpleITK_EXPANSION_SCRIPT}
@@ -162,18 +159,22 @@ foreach(filter_config_file ${GENERATED_CONFIG_LIST})
       -D
       ${SimpleITK_SOURCE_DIR}/Testing/Unit/
       ImageFilterCTestTemplate.cmake.jinja
-      -o
-      "${OUTPUT_TEST_FILENAME}"
     )
-    execute_process(COMMAND ${cmd} RESULT_VARIABLE failed ERROR_VARIABLE error)
+    execute_process(
+      COMMAND
+        ${cmd}
+      RESULT_VARIABLE failed
+      OUTPUT_VARIABLE output
+      ERROR_VARIABLE error
+    )
     if(failed)
       string(REPLACE ";" " " cmd "${cmd}")
       message(
         FATAL_ERROR
-        "Failed to generate \"${OUTPUT_TEST_FILENAME}\"\nCOMMAND: ${cmd} \n${error}"
+        "Failed to generate CMake output for ${FILTERNAME}\nCOMMAND: ${cmd} \n${error}"
       )
     endif()
-    include("${OUTPUT_TEST_FILENAME}")
+    string(APPEND _CMAKE_OUTPUT_CONTENT "${output}")
 
     set(
       OUTPUT_TEST_FILENAME
@@ -349,6 +350,13 @@ foreach(filter_config_file ${GENERATED_CONFIG_LIST})
   endif() # if template_name
   math(EXPR _i "${_i}+1")
 endforeach()
+
+# Write accumulated CMake content to a single file
+set(UNIT_TESTS_CMAKE_FILE "${CMAKE_CURRENT_BINARY_DIR}/AddTests.cmake")
+file(WRITE "${UNIT_TESTS_CMAKE_FILE}" "${_CMAKE_OUTPUT_CONTENT}")
+
+# Include the generated CMake file once
+include("${UNIT_TESTS_CMAKE_FILE}")
 
 message(CHECK_PASS "done")
 

--- a/Testing/Unit/CMakeLists.txt
+++ b/Testing/Unit/CMakeLists.txt
@@ -162,6 +162,7 @@ foreach(filter_config_file ${GENERATED_CONFIG_LIST})
       -D
       ${SimpleITK_SOURCE_DIR}/Testing/Unit/
       ImageFilterCTestTemplate.cmake.jinja
+      -o
       "${OUTPUT_TEST_FILENAME}"
     )
     execute_process(COMMAND ${cmd} RESULT_VARIABLE failed ERROR_VARIABLE error)
@@ -184,7 +185,7 @@ foreach(filter_config_file ${GENERATED_CONFIG_LIST})
       COMMAND
         ${SimpleITK_Python_EXECUTABLE} ${SimpleITK_EXPANSION_SCRIPT}
         ${filter_config_file} -D ${SimpleITK_SOURCE_DIR}/Testing/Unit/
-        ${CXX_TEMPLATE_FILE} "${OUTPUT_TEST_FILENAME}"
+        ${CXX_TEMPLATE_FILE} -o "${OUTPUT_TEST_FILENAME}"
       DEPENDS
         ${filter_config_file}
         ${CXX_TEMPLATE_FILE}
@@ -212,7 +213,7 @@ foreach(filter_config_file ${GENERATED_CONFIG_LIST})
         COMMAND
           ${SimpleITK_Python_EXECUTABLE} ${SimpleITK_EXPANSION_SCRIPT}
           ${filter_config_file} -D ${SimpleITK_SOURCE_DIR}/Testing/Unit/
-          ${LUA_TEMPLATE_FILE} "${OUTPUT_TEST_FILENAME}"
+          ${LUA_TEMPLATE_FILE} -o "${OUTPUT_TEST_FILENAME}"
         DEPENDS
           ${filter_config_file}
           ${LUA_TEMPLATE_FILE}
@@ -235,7 +236,7 @@ foreach(filter_config_file ${GENERATED_CONFIG_LIST})
         COMMAND
           ${SimpleITK_Python_EXECUTABLE} ${SimpleITK_EXPANSION_SCRIPT}
           ${filter_config_file} -D ${SimpleITK_SOURCE_DIR}/Testing/Unit/
-          ${TCL_TEMPLATE_FILE} "${OUTPUT_TEST_FILENAME}"
+          ${TCL_TEMPLATE_FILE} -o "${OUTPUT_TEST_FILENAME}"
         DEPENDS
           ${filter_config_file}
           ${TCL_TEMPLATE_FILE}
@@ -258,7 +259,7 @@ foreach(filter_config_file ${GENERATED_CONFIG_LIST})
         COMMAND
           ${SimpleITK_Python_EXECUTABLE} ${SimpleITK_EXPANSION_SCRIPT}
           ${filter_config_file} -D ${SimpleITK_SOURCE_DIR}/Testing/Unit/
-          ${R_TEMPLATE_FILE} "${OUTPUT_TEST_FILENAME}"
+          ${R_TEMPLATE_FILE} -o "${OUTPUT_TEST_FILENAME}"
         DEPENDS
           ${filter_config_file}
           ${R_TEMPLATE_FILE}
@@ -281,7 +282,7 @@ foreach(filter_config_file ${GENERATED_CONFIG_LIST})
         COMMAND
           ${SimpleITK_Python_EXECUTABLE} ${SimpleITK_EXPANSION_SCRIPT}
           ${filter_config_file} -D ${SimpleITK_SOURCE_DIR}/Testing/Unit/
-          ${RUBY_TEMPLATE_FILE} "${OUTPUT_TEST_FILENAME}"
+          ${RUBY_TEMPLATE_FILE} -o "${OUTPUT_TEST_FILENAME}"
         DEPENDS
           ${filter_config_file}
           ${RUBY_TEMPLATE_FILE}
@@ -307,7 +308,7 @@ foreach(filter_config_file ${GENERATED_CONFIG_LIST})
         COMMAND
           ${SimpleITK_Python_EXECUTABLE} ${SimpleITK_EXPANSION_SCRIPT}
           ${filter_config_file} -D ${SimpleITK_SOURCE_DIR}/Testing/Unit/
-          ${JAVA_TEMPLATE_FILE} "${OUTPUT_TEST_FILENAME}"
+          ${JAVA_TEMPLATE_FILE} -o"${OUTPUT_TEST_FILENAME}"
         DEPENDS
           ${filter_config_file}
           ${JAVA_TEMPLATE_FILE}
@@ -334,7 +335,7 @@ foreach(filter_config_file ${GENERATED_CONFIG_LIST})
         COMMAND
           ${SimpleITK_Python_EXECUTABLE} ${SimpleITK_EXPANSION_SCRIPT}
           ${filter_config_file} -D ${SimpleITK_SOURCE_DIR}/Testing/Unit/
-          ${CSHARP_TEMPLATE_FILE} "${OUTPUT_TEST_FILENAME}"
+          ${CSHARP_TEMPLATE_FILE} -o "${OUTPUT_TEST_FILENAME}"
         DEPENDS
           ${filter_config_file}
           ${CSHARP_TEMPLATE_FILE}

--- a/Wrapping/Python/tests/CMakeLists.txt
+++ b/Wrapping/Python/tests/CMakeLists.txt
@@ -132,6 +132,7 @@ foreach(filter_config_file ${GENERATED_CONFIG_LIST})
     -D
     ${CMAKE_CURRENT_SOURCE_DIR}
     ImageFilterCTestTemplate.cmake.jinja
+    -o
     "${OUTPUT_TEST_FILENAME}"
   )
   execute_process(COMMAND ${cmd} RESULT_VARIABLE failed ERROR_VARIABLE error)
@@ -152,7 +153,7 @@ foreach(filter_config_file ${GENERATED_CONFIG_LIST})
     COMMAND
       ${SimpleITK_Python_EXECUTABLE} ${SimpleITK_EXPANSION_SCRIPT}
       ${filter_config_file} -D ${CMAKE_CURRENT_SOURCE_DIR}
-      ImageFilterTestTemplate.py.jinja "${OUTPUT_TEST_FILENAME}"
+      ImageFilterTestTemplate.py.jinja -o "${OUTPUT_TEST_FILENAME}"
     DEPENDS
       ${filter_config_file}
       ImageFilterTestTemplate.py.jinja

--- a/Wrapping/Python/tests/CMakeLists.txt
+++ b/Wrapping/Python/tests/CMakeLists.txt
@@ -120,10 +120,11 @@ file(
   DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/
 )
 
+set(_CMAKE_OUTPUT_CONTENT "")
+
 foreach(filter_config_file ${GENERATED_CONFIG_LIST})
   get_filename_component(FILTERNAME ${filter_config_file} NAME_WE)
 
-  set(OUTPUT_TEST_FILENAME "${CMAKE_CURRENT_BINARY_DIR}/${FILTERNAME}.cmake")
   set(
     cmd
     ${SimpleITK_Python_EXECUTABLE}
@@ -132,18 +133,22 @@ foreach(filter_config_file ${GENERATED_CONFIG_LIST})
     -D
     ${CMAKE_CURRENT_SOURCE_DIR}
     ImageFilterCTestTemplate.cmake.jinja
-    -o
-    "${OUTPUT_TEST_FILENAME}"
   )
-  execute_process(COMMAND ${cmd} RESULT_VARIABLE failed ERROR_VARIABLE error)
+  execute_process(
+    COMMAND
+      ${cmd}
+    RESULT_VARIABLE failed
+    OUTPUT_VARIABLE output
+    ERROR_VARIABLE error
+  )
   if(failed)
     string(REPLACE ";" " " cmd "${cmd}")
     message(
       FATAL_ERROR
-      "Failed to generate \"${OUTPUT_TEST_FILENAME}\"\nCOMMAND: ${cmd} \n${error}"
+      "Failed to generate CMake output for ${FILTERNAME}\nCOMMAND: ${cmd} \n${error}"
     )
   endif()
-  include("${OUTPUT_TEST_FILENAME}")
+  string(APPEND _CMAKE_OUTPUT_CONTENT "${output}")
 
   set(OUTPUT_TEST_FILENAME "${CMAKE_CURRENT_BINARY_DIR}/${FILTERNAME}Test.py")
 
@@ -164,6 +169,13 @@ foreach(filter_config_file ${GENERATED_CONFIG_LIST})
     ${OUTPUT_TEST_FILENAME}
   )
 endforeach()
+
+# Write accumulated CMake content to a single file
+set(PYTHON_TESTS_CMAKE_FILE "${CMAKE_CURRENT_BINARY_DIR}/PythonTests.cmake")
+file(WRITE "${PYTHON_TESTS_CMAKE_FILE}" "${_CMAKE_OUTPUT_CONTENT}")
+
+# Include the generated CMake file once
+include("${PYTHON_TESTS_CMAKE_FILE}")
 
 add_custom_target(
   PythonGeneratedTests


### PR DESCRIPTION
Default the expand script to output to stdout. Add a `-o` flag to output to a file. This enabled concatenation of outputs in CMake.