### PR TITLE
GHA in Build and Test CI, use pip for SimpleITK python build environment.

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -118,11 +118,10 @@ jobs:
       id: cpy
       with:
         python-version: 3.11
-
     - name: Install build dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install -r ./.github/workflows/requirements-build.txt
+        python -m pip install -r ./.github/workflows/requirements-build.txt jinja2~=3.1 jsonschema~=4.24 pyyaml~=6.0 swig~=4.4.0
     - name: Build and Test
       shell: bash
       env:
@@ -137,6 +136,8 @@ jobs:
           BUILD_EXAMPLES:BOOL=ON
           BUILD_TESTING:BOOL=ON
           Python_EXECUTABLE:FILEPATH=${{ steps.cpy.outputs.python-path }}
+          SimpleITK_USE_SYSTEM_SWIG:BOOL=ON
+          SimpleITK_Python_EXECUTABLE:FILEPATH=${{ steps.cpy.outputs.python-path }}
           ${{ matrix.ctest-cache }}
       run: |
         if [ ! -z "${{ matrix.cmake_build_parallel_level }}" ]; then


### PR DESCRIPTION
 Use pip to install SWIG, and other python packages needed to build simpleITK in the experimental CI. Stop using the SWIG and uv setup Superbuild components in the "build and test" action.