### PR TITLE
Add using ITK with CMake's FetchContent module

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -40,6 +40,7 @@ jobs:
           - os: mac-arm64
             cmake-build-type: "RelMinSize"
             cmake-generator: "Ninja"
+            use-superbuild: true
             ctest-cache: |
               WRAP_PYTHON:BOOL=ON
               WRAP_JAVA:BOOL=ON
@@ -50,14 +51,29 @@ jobs:
               CMAKE_CXX_VISIBILITY_PRESET:STRING=hidden
               CMAKE_VISIBILITY_INLINES_HIDDEN:BOOL=ON
               SimpleITK_EXPLICIT_INSTANTIATION:BOOL=ON
+          - os: mac-arm64
+            cmake-build-type: "Release"
+            cmake-generator: "Ninja"
+            use-superbuild: false
+            ctest-cache: |
+              WRAP_PYTHON:BOOL=ON
           - os: ubuntu-24.04
             cmake-build-type: "Release"
             cmake-generator: "Ninja"
             cmake_build_parallel_level: 6
+            use-superbuild: true
             ctest-cache: |
               WRAP_PYTHON:BOOL=ON
               WRAP_R:BOOL=ON
               SimpleITK_USE_ELASTIX:BOOL=ON
+          - os: ubuntu-24.04-arm
+            cmake-build-type: "Release"
+            cmake-generator: "Ninja"
+            use-superbuild: false
+            ctest-cache: |
+              WRAP_PYTHON:BOOL=ON
+              WRAP_JAVA:BOOL=ON
+              CMAKE_LINKER_TYPE:STRING=GOLD
           - os: ubuntu-24.04-arm
             cmake-build-type: "Release"
             cmake-generator: "Ninja"
@@ -147,4 +163,9 @@ jobs:
       run: |
         cmake --version
         ninja --version
-        ctest -S ${CTEST_SOURCE_DIRECTORY}/.github/workflows/github_actions.cmake -VV
+        if [[ "${{ matrix.use-superbuild }}" == "false" ]]; then
+          DASHBOARD_SOURCE_CONFIG_DIR=""
+        else
+          DASHBOARD_SOURCE_CONFIG_DIR="SuperBuild"
+        fi
+        ctest -D dashboard_source_config_dir="${DASHBOARD_SOURCE_CONFIG_DIR}" -S ${CTEST_SOURCE_DIRECTORY}/.github/workflows/github_actions.cmake -VV

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -33,6 +33,7 @@ jobs:
     env:
       CTEST_SOURCE_DIRECTORY: "${{ github.workspace }}"
     strategy:
+      fail-fast: false
       max-parallel: 5
       matrix:
         include:

--- a/CMake/sitkExternalData.cmake
+++ b/CMake/sitkExternalData.cmake
@@ -44,9 +44,12 @@ if(
   )
 endif()
 
-set(ExternalData_BINARY_ROOT ${CMAKE_BINARY_DIR}/ExternalData)
+set(ExternalData_BINARY_ROOT ${PROJECT_BINARY_DIR}/ExternalData)
 
-set(ExternalData_SOURCE_ROOT ${SimpleITK_SOURCE_DIR})
+if(NOT SimpleITK_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  # need to explicitly set source root for ExternalData when building a wrapping subdirectory
+  set(ExternalData_SOURCE_ROOT ${SimpleITK_SOURCE_DIR})
+endif()
 
 set(
   ExternalData_URL_TEMPLATES

--- a/CMake/sitkITKFetchContent.cmake
+++ b/CMake/sitkITKFetchContent.cmake
@@ -1,0 +1,96 @@
+#-----------------------------------------------------------------------------
+# Get and build ITK using FetchContent
+
+include(FetchContent)
+
+# Set ITK Git repository and tag
+set(
+  ITK_GIT_REPOSITORY
+  "https://github.com/InsightSoftwareConsortium/ITK.git"
+  CACHE STRING
+  "URL of ITK Git repository for FetchContent"
+)
+mark_as_advanced(ITK_GIT_REPOSITORY)
+
+# The commit contains the ExternaData changes to work with SimpleITK
+set(_DEFAULT_ITK_GIT_TAG "92e815d50e897830a899a79e7fe9a80e5734380d")
+set(
+  ITK_GIT_TAG
+  "${_DEFAULT_ITK_GIT_TAG}"
+  CACHE STRING
+  "Tag in ITK git repo for FetchContent"
+)
+mark_as_advanced(ITK_GIT_TAG)
+
+if(NOT DEFINED ITK_BUILD_DEFAULT_MODULES)
+  set(ITK_BUILD_DEFAULT_MODULES ON)
+endif()
+
+set(
+  _SimpleITK_DEFAULT_MODULES
+  "Module_SimpleITKFilters"
+  "Module_ITKIOTransformMINC"
+  "Module_GenericLabelInterpolator"
+  "Module_LabelErodeDilate"
+  "Module_ITKReview"
+)
+foreach(_module ${_SimpleITK_DEFAULT_MODULES})
+  if(NOT DEFINED ${_module})
+    set(${_module} ON CACHE INTERNAL "")
+  endif()
+endforeach()
+
+if(NOT DEFINED ITK_DEFAULT_THREADER)
+  set(ITK_DEFAULT_THREADER "Pool")
+endif()
+
+# Configure ITK-specific options that need to be set before FetchContent_Declare
+if(NOT ${BUILD_SHARED_LIBS})
+  set(CMAKE_C_VISIBILITY_PRESET "hidden" CACHE STRING "" FORCE)
+  set(CMAKE_CXX_VISIBILITY_PRESET "hidden" CACHE STRING "" FORCE)
+  set(ITK_TEMPLATE_VISIBILITY_DEFAULT OFF CACHE BOOL "" FORCE)
+endif()
+
+# Set ITK build options
+set(ITK_USE_KWSTYLE OFF)
+
+# SimpleITK enables ccache by setting COMPILER_LAUNCHER variables. However, ITK_USE_CCACHE
+# enforces additional contraints that are not require for SimpleITK. So we disable the
+# ITK_USE_CCACHE option here, but ITK will still use ccache because the COMPILER_LAUNCHER
+# variables are set.
+set(ITK_USE_CCACHE OFF)
+set(BUILD_TESTING OFF)
+set(BUILD_EXAMPLES OFF)
+
+FetchContent_Declare(
+  ITK
+  GIT_REPOSITORY "${ITK_GIT_REPOSITORY}"
+  GIT_TAG "${ITK_GIT_TAG}"
+  EXCLUDE_FROM_ALL
+  FIND_PACKAGE_ARGS
+    NAMES
+    ITK
+)
+
+FetchContent_MakeAvailable(ITK)
+
+# Check if FetchContent used find_package() or fetched from source
+FetchContent_GetProperties(ITK)
+if(ITK_SOURCE_DIR)
+  message(STATUS "ITK fetched from repository and built from source")
+  message(STATUS "  Source directory: ${ITK_SOURCE_DIR}")
+  message(STATUS "  Binary directory: ${ITK_BINARY_DIR}")
+  set(ITK_DIR "${ITK_BINARY_DIR}")
+
+  include(${ITK_DIR}/ITKConfig.cmake)
+elseif(DEFINED ITK_FOUND)
+  message(STATUS "ITK found via find_package()")
+  # ITK_DIR should already be set by find_package()
+else()
+  message(FATAL_ERROR "ITK configuration failed - no targets available")
+endif()
+
+# These ITK option conflict with SimpleITK.
+# Allow a user's cache variable to be respected.
+unset(BUILD_TESTING)
+unset(BUILD_EXAMPLES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,8 @@ message(STATUS "Building SimpleITK version \"${SimpleITK_VERSION}\"")
 include(sitkCheckRequiredFlags)
 include(sitkCompilerWarningsSettings)
 
+include(sitkITKFetchContent)
+
 include(sitkSITKLegacyNaming)
 include(sitkForbidDownloadsOption)
 include(sitkTargetUseITK)


### PR DESCRIPTION
Documentation on CMake's FetchContent can be found here:
https://cmake.org/cmake/help/latest/module/FetchContent.html

This is an experimental option for SimpleITK as an alternative to the Superbuild. With this change the Superbuild build of ITK still works, and the SimpleITK project still respects ITK_DIR with the FetchContent trying to use `find_package(ITK)` to determine if ITK needs to build built.

If ITK needs to be built with FetchContent, then ITK is downloaded, and configured during SimpleITK's configuration. And ITK shares the same CMake configuration cache with the SimpleITK project to enable consistent, and easier tuning of the ITK build through the SimpleITK project.