### PR TITLE
Move ITK link and flags properties to targets

### DIFF
--- a/CMake/sitkProjectLanguageCommon.cmake
+++ b/CMake/sitkProjectLanguageCommon.cmake
@@ -22,9 +22,7 @@ if(NOT CMAKE_PROJECT_NAME STREQUAL "SimpleITK")
   find_package(SimpleITK REQUIRED)
   include(${SimpleITK_USE_FILE})
 
-  if(MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
-  endif()
+  include(sitkCheckRequiredFlags)
 
   include(CTest)
 

--- a/CMake/sitkTargetUseITK.cmake
+++ b/CMake/sitkTargetUseITK.cmake
@@ -21,7 +21,11 @@ function(sitk_target_use_itk target_name interface_keyword)
   itk_module_config(_itk ${itk_modules})
 
   if(_itk_LIBRARY_DIRS)
-    link_libraries(${_itk_LIBRARY_DIRS})
+    target_link_directories(
+      ${target_name}
+      ${interface_keyword}
+      ${_itk_LIBRARY_DIRS}
+    )
   endif()
 
   if(_itk_LIBRARIES)
@@ -31,11 +35,35 @@ function(sitk_target_use_itk target_name interface_keyword)
       ${_itk_LIBRARIES}
     )
   endif()
+
   if(_itk_INCLUDE_DIRS)
     target_include_directories(
       ${target_name}
       ${interface_keyword}
       ${_itk_INCLUDE_DIRS}
+    )
+  endif()
+
+  # Add ITK required compiler and linker flags
+  if(ITK_REQUIRED_CXX_FLAGS)
+    separate_arguments(_itk_cxx_flags UNIX_COMMAND "${ITK_REQUIRED_CXX_FLAGS}")
+    target_compile_options(
+      ${target_name}
+      ${interface_keyword}
+      ${_itk_cxx_flags}
+    )
+  endif()
+
+  if(ITK_REQUIRED_LINK_FLAGS)
+    separate_arguments(
+      _itk_link_flags
+      UNIX_COMMAND
+      "${ITK_REQUIRED_LINK_FLAGS}"
+    )
+    target_link_options(
+      ${target_name}
+      ${interface_keyword}
+      ${_itk_link_flags}
     )
   endif()
 endfunction()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,32 +70,6 @@ find_package(ITK REQUIRED)
 #we require certain packages be turned on in ITK
 include(sitkCheckForITKModuleDependencies)
 
-if(ITK_FOUND)
-  # NOTE: We are purposely not calling UseITK yet. However, we must make
-  # sure the required compilation and linker flags are set. Since, we
-  # are trying to encapsulate ITK, we need to very carefully control
-  # in access to the headers and libraries, hence each SimpleITK
-  # library will call UseITK.
-
-  # Add compiler flags needed to use ITK.
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${ITK_REQUIRED_C_FLAGS}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ITK_REQUIRED_CXX_FLAGS}")
-  set(
-    CMAKE_EXE_LINKER_FLAGS
-    "${CMAKE_EXE_LINKER_FLAGS} ${ITK_REQUIRED_LINK_FLAGS}"
-  )
-  set(
-    CMAKE_SHARED_LINKER_FLAGS
-    "${CMAKE_SHARED_LINKER_FLAGS} ${ITK_REQUIRED_LINK_FLAGS}"
-  )
-  set(
-    CMAKE_MODULE_LINKER_FLAGS
-    "${CMAKE_MODULE_LINKER_FLAGS} ${ITK_REQUIRED_LINK_FLAGS}"
-  )
-
-  link_directories("${ITK_LIBRARY_DIRS}")
-endif()
-
 list(APPEND SimpleITK_PRIVATE_COMPILE_OPTIONS ${CXX_ADDITIONAL_WARNING_FLAGS})
 
 #----------------------------------------------------------

--- a/Wrapping/CSharp/CMakeLists.txt
+++ b/Wrapping/CSharp/CMakeLists.txt
@@ -122,6 +122,11 @@ target_link_libraries(
   ${SWIG_MODULE_SimpleITKCSharpNative_TARGET_NAME}
   ${SimpleITK_LIBRARIES}
 )
+target_compile_options(
+  ${SWIG_MODULE_SimpleITKCSharpNative_TARGET_NAME}
+  PRIVATE
+    ${SimpleITK_PRIVATE_COMPILE_OPTIONS}
+)
 set_target_properties(
   ${SWIG_MODULE_SimpleITKCSharpNative_TARGET_NAME}
   PROPERTIES

--- a/Wrapping/Java/CMakeLists.txt
+++ b/Wrapping/Java/CMakeLists.txt
@@ -64,7 +64,12 @@ target_include_directories(
     ${JAVA_INCLUDE_PATH}
     ${JNI_INCLUDE_DIRS}
 )
-target_compile_options(${SWIG_MODULE_SimpleITKJava_TARGET_NAME} PRIVATE -w)
+target_compile_options(
+  ${SWIG_MODULE_SimpleITKJava_TARGET_NAME}
+  PRIVATE
+    ${SimpleITK_PRIVATE_COMPILE_OPTIONS}
+    -w
+)
 sitk_strip_target( ${SWIG_MODULE_SimpleITKJava_TARGET_NAME} )
 
 set(JAVA_SOURCE_CODE "${JAVA_SOURCE_DIRECTORY}/org/itk/simple/*.java")

--- a/Wrapping/Lua/CMakeLists.txt
+++ b/Wrapping/Lua/CMakeLists.txt
@@ -57,7 +57,12 @@ if(SimpleITK_LUA_BUILD_EXECUTABLE)
     ${LUA_ADDITIONAL_LIBRARIES}
   )
   target_include_directories(SimpleITKLua PRIVATE ${LUA_INCLUDE_DIR})
-  target_compile_options(SimpleITKLua PRIVATE -w)
+  target_compile_options(
+    SimpleITKLua
+    PRIVATE
+      ${SimpleITK_PRIVATE_COMPILE_OPTIONS}
+      -w
+  )
   sitk_strip_target( SimpleITKLua )
 endif()
 
@@ -82,5 +87,10 @@ target_include_directories(
   PRIVATE
     ${LUA_INCLUDE_DIR}
 )
-target_compile_options(${SWIG_MODULE_SimpleITKLuaModule_TARGET_NAME} PRIVATE -w)
+target_compile_options(
+  ${SWIG_MODULE_SimpleITKLuaModule_TARGET_NAME}
+  PRIVATE
+    ${SimpleITK_PRIVATE_COMPILE_OPTIONS}
+    -w
+)
 sitk_strip_target( ${SWIG_MODULE_SimpleITKLuaModule_TARGET_NAME} )

--- a/Wrapping/Python/CMakeLists.txt
+++ b/Wrapping/Python/CMakeLists.txt
@@ -267,7 +267,12 @@ if(UNIX AND NOT APPLE AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   )
 endif()
 
-target_compile_options(${SWIG_MODULE_SimpleITKPython_TARGET_NAME} PRIVATE -w)
+target_compile_options(
+  ${SWIG_MODULE_SimpleITKPython_TARGET_NAME}
+  PRIVATE
+    ${SimpleITK_PRIVATE_COMPILE_OPTIONS}
+    -w
+)
 sitk_strip_target( ${SWIG_MODULE_SimpleITKPython_TARGET_NAME} )
 
 # Installation

--- a/Wrapping/R/CMakeLists.txt
+++ b/Wrapping/R/CMakeLists.txt
@@ -69,7 +69,12 @@ target_include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-target_compile_options(${SWIG_MODULE_SimpleITK_TARGET_NAME} PRIVATE -w)
+target_compile_options(
+  ${SWIG_MODULE_SimpleITK_TARGET_NAME}
+  PRIVATE
+    ${SimpleITK_PRIVATE_COMPILE_OPTIONS}
+    -w
+)
 
 # set the output directory for the R library to the binary packaging location
 set_target_properties(

--- a/Wrapping/Ruby/CMakeLists.txt
+++ b/Wrapping/Ruby/CMakeLists.txt
@@ -48,7 +48,12 @@ if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
       "-Wno-register"
   )
 endif()
-target_compile_options(${SWIG_MODULE_simpleitk_TARGET_NAME} PRIVATE -w)
+target_compile_options(
+  ${SWIG_MODULE_simpleitk_TARGET_NAME}
+  PRIVATE
+    ${SimpleITK_PRIVATE_COMPILE_OPTIONS}
+    -w
+)
 
 sitk_target_link_libraries_with_dynamic_lookup( ${SWIG_MODULE_simpleitk_TARGET_NAME} ${Ruby_LIBRARY})
 target_include_directories(

--- a/Wrapping/Tcl/CMakeLists.txt
+++ b/Wrapping/Tcl/CMakeLists.txt
@@ -46,5 +46,10 @@ target_link_libraries(
   ${TCL_LIBRARY}
 )
 target_include_directories(SimpleITKTclsh PRIVATE ${TCL_INCLUDE_PATH})
-target_compile_options(SimpleITKTclsh PRIVATE -w)
+target_compile_options(
+  SimpleITKTclsh
+  PRIVATE
+    ${SimpleITK_PRIVATE_COMPILE_OPTIONS}
+    -w
+)
 sitk_strip_target( SimpleITKTclsh )


### PR DESCRIPTION
Remove the global options and replace with library target options.