### PR TITLE
Create BasicFilters/src directory for output of generated code.

### DIFF
--- a/Code/BasicFilters/CMakeLists.txt
+++ b/Code/BasicFilters/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Set up code generation
 include(sitkGenerateFilterSource)
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/src)
 generate_filter_source()
 
 set_source_files_properties(


### PR DESCRIPTION
Addresses issue of unable to open "sitkAbsImageFilter.cxx" error.