### PR TITLE
Use environment varialbe to configure Mac OSX target

### DIFF
--- a/CMake/sitkPythonDistribution.cmake
+++ b/CMake/sitkPythonDistribution.cmake
@@ -32,10 +32,22 @@ Using unknown versions of pip, setuptools and/or wheel packages/"
     "."
   )
 
+  # Configure the platform tag for macOS wheels to contain the OSX deployment target
+  if(CMAKE_OSX_DEPLOYMENT_TARGET)
+    set(
+      CMAKE_ENVIRONMENT_PREFIX
+      ${CMAKE_COMMAND}
+      -E
+      env
+      MACOSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}
+    )
+  endif()
+
   add_custom_target(
     dist.Python
-    ${PYTHON_COMMAND_PREFIX} ${SimpleITK_PYTHON_TEST_EXECUTABLE}
-    ${pip_wheel_commands}
+    COMMAND
+      ${CMAKE_ENVIRONMENT_PREFIX} ${PYTHON_COMMAND_PREFIX}
+      ${SimpleITK_PYTHON_TEST_EXECUTABLE} ${pip_wheel_commands}
     WORKING_DIRECTORY ${SimpleITK_Python_BINARY_DIR}
     DEPENDS
       ${SWIG_MODULE_SimpleITKPython_TARGET_NAME}

--- a/Wrapping/Python/CMakeLists.txt
+++ b/Wrapping/Python/CMakeLists.txt
@@ -341,14 +341,6 @@ if(SimpleITK_PYTHON_USE_LIMITED_API)
   )
 endif()
 
-if(CMAKE_OSX_DEPLOYMENT_TARGET)
-  set(
-    PYPROJECT_TOML_EXTRA
-    "${PYPROJECT_TOML_EXTRA}\n
-    [tool.scikit-build.cmake.define]\nCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}\n"
-  )
-endif()
-
 configure_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/Packaging/pyproject.toml.in"
   "${CMAKE_CURRENT_BINARY_DIR}/pyproject.toml"


### PR DESCRIPTION
To correctly set the platfor tag, the MACOSX_DEPLOYMENT_TARGET is the standard Python build way.

Correctly the Mac Python wheels on to contain a lower, and OSX version in the platform tag.