### PR TITLE
ENH: Update ITK to v6.0b02 tag

### DIFF
--- a/CMake/sitkITKFetchContent.cmake
+++ b/CMake/sitkITKFetchContent.cmake
@@ -12,8 +12,7 @@ set(
 )
 mark_as_advanced(ITK_GIT_REPOSITORY)
 
-# Merge of Modernization of ITK Modular System
-set(_DEFAULT_ITK_GIT_TAG "5ddc558191b9527c7545849aee6638262d6120a8")
+set(_DEFAULT_ITK_GIT_TAG "v6.0b02")
 set(
   ITK_GIT_TAG
   "${_DEFAULT_ITK_GIT_TAG}"

--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -103,8 +103,7 @@ set(
 mark_as_advanced(ITK_GIT_REPOSITORY)
 sitk_legacy_naming(ITK_GIT_REPOSITORY ITK_REPOSITORY)
 
-# Merge of Modernization of ITK Modular System
-set(_DEFAULT_ITK_GIT_TAG "5ddc558191b9527c7545849aee6638262d6120a8")
+set(_DEFAULT_ITK_GIT_TAG "v6.0b02")
 set(ITK_GIT_TAG "${_DEFAULT_ITK_GIT_TAG}" CACHE STRING "Tag in ITK git repo")
 mark_as_advanced(ITK_GIT_TAG)
 set(


### PR DESCRIPTION
This tag include the update for ITK interface libraries.