### PR TITLE
ENH: Exclude _deps directory from coverage reports

### DIFF
--- a/.github/workflows/Nightly.yml
+++ b/.github/workflows/Nightly.yml
@@ -66,7 +66,7 @@ jobs:
               CMAKE_CXX_FLAGS:STRING=-g -O0 --coverage
               CMAKE_C_FLAGS:STRING=-g -O0 --coverage
               CMAKE_EXE_LINKER_FLAGS:STRING=-g -O0 -lgcov
-              CTEST_CUSTOM_COVERAGE_EXCLUDE:STRING=".*/ITK-prefix/.*" ".*/GTest-prefix/.*"
+              CTEST_CUSTOM_COVERAGE_EXCLUDE:STRING=".*/ITK-prefix/.*" ".*/GTest-prefix/.*" ".*/_deps/.*"
             ctest-extra-args: |
               -Ddashboard_do_coverage=1 \
               -Ddashboard_track="Nightly" \

--- a/CMake/CTestCustom.cmake.in
+++ b/CMake/CTestCustom.cmake.in
@@ -14,6 +14,9 @@ SET(CTEST_CUSTOM_COVERAGE_EXCLUDE
 
  # Exclude files from the Testing directories
  ".*/Testing/.*"
+
+ # Exclude FetchContent dependencies
+ ".*/_deps/.*"
  )
 
 SET(CTEST_CUSTOM_WARNING_EXCEPTION


### PR DESCRIPTION
With the addition of FetchContent, ITK and other dependencies are now fetched into the _deps directory. Exclude this directory from coverage to avoid reporting on third-party source code.