### PR TITLE
Align Elastix/Transformix API with elastix PR #1417

### DIFF
--- a/Code/ElastixTransformixWrappers/include/sitkElastixImageFilter.h
+++ b/Code/ElastixTransformixWrappers/include/sitkElastixImageFilter.h
@@ -285,12 +285,7 @@ public:
 
   /** \brief Specifies multiple parameter maps. */
   void
-  SetParameterMap(const std::vector<std::map<std::string, std::vector<std::string>>> parameterMapVector);
-  void
-  SetParameterMaps(const std::vector<std::map<std::string, std::vector<std::string>>> parameterMapVector)
-  {
-    return SetParameterMap(parameterMapVector);
-  }
+  SetParameterMaps(const std::vector<std::map<std::string, std::vector<std::string>>> parameterMapVector);
 
   /** \brief Specifies a single parameter map. */
   void
@@ -302,12 +297,7 @@ public:
 
   /** \brief Returns a copy of the parameter maps. */
   std::vector<std::map<std::string, std::vector<std::string>>>
-  GetParameterMap();
-  std::vector<std::map<std::string, std::vector<std::string>>>
-  GetParameterMaps()
-  {
-    return GetParameterMap();
-  };
+  GetParameterMaps();
 
   /** \brief Returns the default parameter map for the specified function arguments (\p transformName may be
    * "translation", "rigid" , "affine", "nonrigid", or "bspline"). */
@@ -403,7 +393,7 @@ public:
 
   /** \brief Returns all transform parameter maps. */
   std::vector<std::map<std::string, std::vector<std::string>>>
-  GetTransformParameterMap();
+  GetTransformParameterMaps();
 
   /** \brief Returns the transform parameter map at the specified (zero-based) \p index. */
   std::map<std::string, std::vector<std::string>>

--- a/Code/ElastixTransformixWrappers/include/sitkTransformixImageFilter.h
+++ b/Code/ElastixTransformixWrappers/include/sitkTransformixImageFilter.h
@@ -124,23 +124,13 @@ public:
   LogToConsoleOff();
 
   void
-  SetTransformParameterMap(const std::vector<std::map<std::string, std::vector<std::string>>> parameterMapVector);
-  void
-  SetTransformParameterMaps(const std::vector<std::map<std::string, std::vector<std::string>>> parameterMapVector)
-  {
-    return SetTransformParameterMap(parameterMapVector);
-  }
+  SetTransformParameterMaps(const std::vector<std::map<std::string, std::vector<std::string>>> parameterMapVector);
   void
   SetTransformParameterMap(const std::map<std::string, std::vector<std::string>> parameterMap);
   void
   AddTransformParameterMap(const std::map<std::string, std::vector<std::string>> parameterMap);
   std::vector<std::map<std::string, std::vector<std::string>>>
-  GetTransformParameterMap();
-  std::vector<std::map<std::string, std::vector<std::string>>>
-  GetTransformParameterMaps()
-  {
-    return GetTransformParameterMap();
-  }
+  GetTransformParameterMaps();
   unsigned int
   GetNumberOfTransformParameterMaps();
 

--- a/Code/ElastixTransformixWrappers/src/sitkElastixImageFilter.cxx
+++ b/Code/ElastixTransformixWrappers/src/sitkElastixImageFilter.cxx
@@ -355,9 +355,9 @@ ElastixImageFilter ::SetParameterMap(const ParameterMapType parameterMap)
 }
 
 void
-ElastixImageFilter ::SetParameterMap(const ParameterMapVectorType parameterMapVector)
+ElastixImageFilter ::SetParameterMaps(const ParameterMapVectorType parameterMapVector)
 {
-  this->m_Pimple->SetParameterMap(parameterMapVector);
+  this->m_Pimple->SetParameterMaps(parameterMapVector);
 }
 
 void
@@ -367,9 +367,9 @@ ElastixImageFilter ::AddParameterMap(const ParameterMapType parameterMap)
 }
 
 ElastixImageFilter::ParameterMapVectorType
-ElastixImageFilter ::GetParameterMap()
+ElastixImageFilter ::GetParameterMaps()
 {
-  return this->m_Pimple->GetParameterMap();
+  return this->m_Pimple->GetParameterMaps();
 }
 
 unsigned int
@@ -499,9 +499,9 @@ ElastixImageFilter ::Execute()
 }
 
 ElastixImageFilter::ParameterMapVectorType
-ElastixImageFilter ::GetTransformParameterMap()
+ElastixImageFilter ::GetTransformParameterMaps()
 {
-  return this->m_Pimple->GetTransformParameterMap();
+  return this->m_Pimple->GetTransformParameterMaps();
 }
 
 ElastixImageFilter::ParameterMapType
@@ -576,7 +576,7 @@ void
 PrintParameterMap(const ElastixImageFilter::ParameterMapVectorType parameterMapVector)
 {
   ElastixImageFilter selx;
-  selx.SetParameterMap(parameterMapVector);
+  selx.SetParameterMaps(parameterMapVector);
   selx.PrintParameterMap();
 }
 
@@ -654,7 +654,7 @@ Elastix(const Image &                                    fixedImage,
   ElastixImageFilter selx;
   selx.SetFixedImage(fixedImage);
   selx.SetMovingImage(movingImage);
-  selx.SetParameterMap(parameterMapVector);
+  selx.SetParameterMaps(parameterMapVector);
   selx.SetLogToFile(logToFile);
   selx.SetLogToConsole(logToConsole);
   selx.SetOutputDirectory(outputDirectory);
@@ -711,7 +711,7 @@ Elastix(const Image &                              fixedImage,
   ElastixImageFilter selx;
   selx.SetFixedImage(fixedImage);
   selx.SetMovingImage(movingImage);
-  selx.SetParameterMap(parameterMapVector);
+  selx.SetParameterMaps(parameterMapVector);
   selx.SetFixedMask(fixedMask);
   selx.SetMovingMask(movingMask);
   selx.SetLogToFile(logToFile);

--- a/Code/ElastixTransformixWrappers/src/sitkElastixImageFilterImpl.cxx
+++ b/Code/ElastixTransformixWrappers/src/sitkElastixImageFilterImpl.cxx
@@ -44,7 +44,7 @@ ElastixImageFilter::ElastixImageFilterImpl ::ElastixImageFilterImpl(void)
   defaultParameterMap.push_back(ParameterObjectType::GetDefaultParameterMap("translation"));
   defaultParameterMap.push_back(ParameterObjectType::GetDefaultParameterMap("affine"));
   defaultParameterMap.push_back(ParameterObjectType::GetDefaultParameterMap("bspline"));
-  this->SetParameterMap(defaultParameterMap);
+  this->SetParameterMaps(defaultParameterMap);
 }
 
 ElastixImageFilter::ElastixImageFilterImpl ::~ElastixImageFilterImpl(void) {}
@@ -737,11 +737,11 @@ void
 ElastixImageFilter::ElastixImageFilterImpl ::SetParameterMap(const ParameterMapType parameterMap)
 {
   ParameterMapVectorType parameterMapVector = ParameterMapVectorType(1, parameterMap);
-  this->SetParameterMap(parameterMapVector);
+  this->SetParameterMaps(parameterMapVector);
 }
 
 void
-ElastixImageFilter::ElastixImageFilterImpl ::SetParameterMap(const ParameterMapVectorType parameterMapVector)
+ElastixImageFilter::ElastixImageFilterImpl ::SetParameterMaps(const ParameterMapVectorType parameterMapVector)
 {
   this->m_ParameterMapVector = parameterMapVector;
 }
@@ -753,7 +753,7 @@ ElastixImageFilter::ElastixImageFilterImpl ::AddParameterMap(const ParameterMapT
 }
 
 ElastixImageFilter::ElastixImageFilterImpl::ParameterMapVectorType
-ElastixImageFilter::ElastixImageFilterImpl ::GetParameterMap(void)
+ElastixImageFilter::ElastixImageFilterImpl ::GetParameterMaps(void)
 {
   return this->m_ParameterMapVector;
 }
@@ -971,7 +971,7 @@ ElastixImageFilter::ElastixImageFilterImpl ::GetDefaultParameterMap(const std::s
 }
 
 ElastixImageFilter::ElastixImageFilterImpl::ParameterMapVectorType
-ElastixImageFilter::ElastixImageFilterImpl ::GetTransformParameterMap(void)
+ElastixImageFilter::ElastixImageFilterImpl ::GetTransformParameterMaps(void)
 {
   if (this->m_TransformParameterMapVector.size() == 0)
   {
@@ -1017,7 +1017,7 @@ ElastixImageFilter::ElastixImageFilterImpl ::PrintParameterMap(void)
     sitkExceptionMacro("Cannot print parameter maps: Number of parameter maps is 0.")
   }
 
-  this->PrintParameterMap(this->GetParameterMap());
+  this->PrintParameterMap(this->GetParameterMaps());
 }
 
 void

--- a/Code/ElastixTransformixWrappers/src/sitkElastixImageFilterImpl.h
+++ b/Code/ElastixTransformixWrappers/src/sitkElastixImageFilterImpl.h
@@ -162,13 +162,13 @@ public:
                   const unsigned int numberOfResolutions = 4u,
                   const double       finalGridSpacingInPhysicalUnits = 10.0);
   void
-  SetParameterMap(const std::vector<std::map<std::string, std::vector<std::string>>> parameterMapVector);
+  SetParameterMaps(const std::vector<std::map<std::string, std::vector<std::string>>> parameterMapVector);
   void
   SetParameterMap(const std::map<std::string, std::vector<std::string>> parameterMap);
   void
   AddParameterMap(const std::map<std::string, std::vector<std::string>> parameterMap);
   std::vector<std::map<std::string, std::vector<std::string>>>
-  GetParameterMap(void);
+  GetParameterMaps(void);
   std::map<std::string, std::vector<std::string>>
   GetDefaultParameterMap(const std::string  transformName,
                          const unsigned int numberOfResolutions = 4,
@@ -216,7 +216,7 @@ public:
   Image
   Execute(void);
   std::vector<std::map<std::string, std::vector<std::string>>>
-  GetTransformParameterMap(void);
+  GetTransformParameterMaps(void);
   std::map<std::string, std::vector<std::string>>
   GetTransformParameterMap(const unsigned int index);
   Image

--- a/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilter.cxx
+++ b/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilter.cxx
@@ -209,9 +209,9 @@ TransformixImageFilter ::LogToConsoleOff()
 }
 
 void
-TransformixImageFilter ::SetTransformParameterMap(const ParameterMapVectorType transformParameterMapVector)
+TransformixImageFilter ::SetTransformParameterMaps(const ParameterMapVectorType transformParameterMapVector)
 {
-  this->m_Pimple->SetTransformParameterMap(transformParameterMapVector);
+  this->m_Pimple->SetTransformParameterMaps(transformParameterMapVector);
 }
 
 void
@@ -227,9 +227,9 @@ TransformixImageFilter ::AddTransformParameterMap(const ParameterMapType transfo
 }
 
 TransformixImageFilter::ParameterMapVectorType
-TransformixImageFilter ::GetTransformParameterMap()
+TransformixImageFilter ::GetTransformParameterMaps()
 {
-  return this->m_Pimple->GetTransformParameterMap();
+  return this->m_Pimple->GetTransformParameterMaps();
 }
 
 unsigned int
@@ -375,7 +375,7 @@ Transformix(const Image &                                        movingImage,
 {
   TransformixImageFilter stfx;
   stfx.SetMovingImage(movingImage);
-  stfx.SetTransformParameterMap(parameterMapVector);
+  stfx.SetTransformParameterMaps(parameterMapVector);
   stfx.SetOutputDirectory(outputDirectory);
   stfx.LogToFileOn();
   stfx.SetLogToConsole(logToConsole);

--- a/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilterImpl.cxx
+++ b/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilterImpl.cxx
@@ -434,7 +434,7 @@ TransformixImageFilter::TransformixImageFilterImpl ::LogToConsoleOff()
 }
 
 void
-TransformixImageFilter::TransformixImageFilterImpl ::SetTransformParameterMap(
+TransformixImageFilter::TransformixImageFilterImpl ::SetTransformParameterMaps(
   const ParameterMapVectorType parameterMapVector)
 {
   this->m_TransformParameterMapVector = parameterMapVector;
@@ -445,7 +445,7 @@ TransformixImageFilter::TransformixImageFilterImpl ::SetTransformParameterMap(co
 {
   ParameterMapVectorType parameterMapVector;
   parameterMapVector.push_back(parameterMap);
-  this->SetTransformParameterMap(parameterMapVector);
+  this->SetTransformParameterMaps(parameterMapVector);
 }
 
 void
@@ -455,7 +455,7 @@ TransformixImageFilter::TransformixImageFilterImpl ::AddTransformParameterMap(co
 }
 
 TransformixImageFilter::TransformixImageFilterImpl::ParameterMapVectorType
-TransformixImageFilter::TransformixImageFilterImpl ::GetTransformParameterMap()
+TransformixImageFilter::TransformixImageFilterImpl ::GetTransformParameterMaps()
 {
   return this->m_TransformParameterMapVector;
 }
@@ -625,7 +625,7 @@ TransformixImageFilter::TransformixImageFilterImpl ::WriteParameterFile(const Pa
 void
 TransformixImageFilter::TransformixImageFilterImpl ::PrintParameterMap()
 {
-  this->PrintParameterMap(this->GetTransformParameterMap());
+  this->PrintParameterMap(this->GetTransformParameterMaps());
 }
 
 void

--- a/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilterImpl.h
+++ b/Code/ElastixTransformixWrappers/src/sitkTransformixImageFilterImpl.h
@@ -109,13 +109,13 @@ public:
   LogToConsoleOff();
 
   void
-  SetTransformParameterMap(const std::vector<std::map<std::string, std::vector<std::string>>> parameterMapVector);
+  SetTransformParameterMaps(const std::vector<std::map<std::string, std::vector<std::string>>> parameterMapVector);
   void
   SetTransformParameterMap(const std::map<std::string, std::vector<std::string>> parameterMap);
   void
   AddTransformParameterMap(const std::map<std::string, std::vector<std::string>> parameterMap);
   std::vector<std::map<std::string, std::vector<std::string>>>
-  GetTransformParameterMap();
+  GetTransformParameterMaps();
   unsigned int
   GetNumberOfTransformParameterMaps();
 

--- a/Examples/Elastix/elx.cxx
+++ b/Examples/Elastix/elx.cxx
@@ -38,6 +38,6 @@ main(int argc, char * argv[])
   writer.Execute(elastixImageFilter.GetResultImage());
 
   // Write parameter file. This test executable only supports one parameter map and one transform parameter map.
-  sitk::WriteParameterFile(elastixImageFilter.GetTransformParameterMap()[0], std::string(argv[5]));
+  sitk::WriteParameterFile(elastixImageFilter.GetTransformParameterMaps()[0], std::string(argv[5]));
   return 0;
 }

--- a/Testing/Unit/sitkElastixImageFilterTests.cxx
+++ b/Testing/Unit/sitkElastixImageFilterTests.cxx
@@ -306,7 +306,7 @@ TEST(ElastixImageFilter, InitialTransform)
   EXPECT_NO_THROW(silx1.SetMovingImage(movingImage));
   EXPECT_NO_THROW(resultImage1 = silx1.Execute());
   EXPECT_FALSE(silxIsEmpty(resultImage1));
-  WriteParameterFile(silx1.GetTransformParameterMap()[0], initialTransformParameterFileName);
+  WriteParameterFile(silx1.GetTransformParameterMaps()[0], initialTransformParameterFileName);
 
   ElastixImageFilter silx2;
   EXPECT_NO_THROW(silx2.SetFixedImage(fixedImage));

--- a/Testing/Unit/sitkTransformixImageFilterTests.cxx
+++ b/Testing/Unit/sitkTransformixImageFilterTests.cxx
@@ -29,13 +29,13 @@ TEST(TransformixImageFilter, ObjectOrientedInterface)
 
   TransformixImageFilter stfx;
   EXPECT_EQ(stfx.GetName(), "TransformixImageFilter");
-  EXPECT_EQ(stfx.GetTransformParameterMap().size(), 0u);
+  EXPECT_EQ(stfx.GetTransformParameterMaps().size(), 0u);
 
   ASSERT_THROW(stfx.Execute(), GenericException);
   EXPECT_NO_THROW(stfx.SetMovingImage(movingImage));
   ASSERT_THROW(stfx.Execute(), GenericException);
 
-  EXPECT_NO_THROW(stfx.SetTransformParameterMap(silx.GetTransformParameterMap()));
+  EXPECT_NO_THROW(stfx.SetTransformParameterMaps(silx.GetTransformParameterMaps()));
   EXPECT_NO_THROW(stfx.Execute());
   EXPECT_FALSE(stfxIsEmpty(stfx.GetResultImage()));
 
@@ -62,28 +62,28 @@ TEST(TransformixImageFilter, ProceduralInterface)
 
   std::string outputDirectory = ".";
 
-  EXPECT_NO_THROW(resultImage = Transformix(movingImage, silx.GetTransformParameterMap()[0]));
+  EXPECT_NO_THROW(resultImage = Transformix(movingImage, silx.GetTransformParameterMaps()[0]));
   EXPECT_FALSE(stfxIsEmpty(resultImage));
-  EXPECT_NO_THROW(resultImage = Transformix(movingImage, silx.GetTransformParameterMap()[0], true));
+  EXPECT_NO_THROW(resultImage = Transformix(movingImage, silx.GetTransformParameterMaps()[0], true));
   EXPECT_FALSE(stfxIsEmpty(resultImage));
-  EXPECT_NO_THROW(resultImage = Transformix(movingImage, silx.GetTransformParameterMap()[0], true, outputDirectory));
+  EXPECT_NO_THROW(resultImage = Transformix(movingImage, silx.GetTransformParameterMaps()[0], true, outputDirectory));
   EXPECT_FALSE(stfxIsEmpty(resultImage));
-  EXPECT_NO_THROW(resultImage = Transformix(movingImage, silx.GetTransformParameterMap()[0], false, outputDirectory));
-  EXPECT_FALSE(stfxIsEmpty(resultImage));
-
-  EXPECT_NO_THROW(resultImage = Transformix(movingImage, silx.GetTransformParameterMap()));
-  EXPECT_FALSE(stfxIsEmpty(resultImage));
-  EXPECT_NO_THROW(resultImage = Transformix(movingImage, silx.GetTransformParameterMap(), true));
-  EXPECT_FALSE(stfxIsEmpty(resultImage));
-  EXPECT_NO_THROW(resultImage = Transformix(movingImage, silx.GetTransformParameterMap(), true, outputDirectory));
-  EXPECT_FALSE(stfxIsEmpty(resultImage));
-  EXPECT_NO_THROW(resultImage = Transformix(movingImage, silx.GetTransformParameterMap(), false, outputDirectory));
+  EXPECT_NO_THROW(resultImage = Transformix(movingImage, silx.GetTransformParameterMaps()[0], false, outputDirectory));
   EXPECT_FALSE(stfxIsEmpty(resultImage));
 
-  ElastixImageFilter::ParameterMapVectorType parameterMapVector = silx.GetTransformParameterMap();
+  EXPECT_NO_THROW(resultImage = Transformix(movingImage, silx.GetTransformParameterMaps()));
+  EXPECT_FALSE(stfxIsEmpty(resultImage));
+  EXPECT_NO_THROW(resultImage = Transformix(movingImage, silx.GetTransformParameterMaps(), true));
+  EXPECT_FALSE(stfxIsEmpty(resultImage));
+  EXPECT_NO_THROW(resultImage = Transformix(movingImage, silx.GetTransformParameterMaps(), true, outputDirectory));
+  EXPECT_FALSE(stfxIsEmpty(resultImage));
+  EXPECT_NO_THROW(resultImage = Transformix(movingImage, silx.GetTransformParameterMaps(), false, outputDirectory));
+  EXPECT_FALSE(stfxIsEmpty(resultImage));
+
+  ElastixImageFilter::ParameterMapVectorType parameterMapVector = silx.GetTransformParameterMaps();
   parameterMapVector[parameterMapVector.size() - 1]["WriteResultImage"] =
     ElastixImageFilter::ParameterValueVectorType(1, "false");
-  EXPECT_NO_THROW(resultImage = Transformix(movingImage, silx.GetTransformParameterMap()));
+  EXPECT_NO_THROW(resultImage = Transformix(movingImage, silx.GetTransformParameterMaps()));
   EXPECT_FALSE(stfxIsEmpty(resultImage));
 }
 
@@ -101,7 +101,7 @@ TEST(TransformixImageFilter, ComputeDeformationField)
   silx.Execute();
 
   TransformixImageFilter stfx;
-  stfx.SetTransformParameterMap(silx.GetTransformParameterMap());
+  stfx.SetTransformParameterMaps(silx.GetTransformParameterMaps());
   stfx.ComputeDeformationFieldOn();
 
   // Note: SetMovingImage appears necessary for `itk::TransformixFilter` (not for the old
@@ -140,11 +140,11 @@ TEST(TransformixImageFilter, Transformation4D)
   silx.SetMovingImage(movingImage1);
   resultImage1 = silx.Execute();
 
-  silx.PrintParameterMap(silx.GetTransformParameterMap());
+  silx.PrintParameterMap(silx.GetTransformParameterMaps());
 
   TransformixImageFilter stfx;
   stfx.SetMovingImage(movingImage2);
-  stfx.SetTransformParameterMap(silx.GetTransformParameterMap());
+  stfx.SetTransformParameterMaps(silx.GetTransformParameterMaps());
   resultImage2 = stfx.Execute();
 }
 

--- a/Wrapping/Python/tests/sitkTransformixImageFilterTest.py
+++ b/Wrapping/Python/tests/sitkTransformixImageFilterTest.py
@@ -35,8 +35,8 @@ def test_TransformixImageFilter_GetDeformationField():
 
     # Set up transformix filter
     transformixImageFilter = sitk.TransformixImageFilter()
-    transformixImageFilter.SetTransformParameterMap(
-        elastixImageFilter.GetTransformParameterMap()
+    transformixImageFilter.SetTransformParameterMaps(
+        elastixImageFilter.GetTransformParameterMaps()
     )
     transformixImageFilter.ComputeDeformationFieldOn()
 


### PR DESCRIPTION
- Invert delegation: SetParameterMaps/GetParameterMaps now canonical
- Remove deprecated vector-overload aliases for SetParameterMap/GetParameterMap
- Keep single-item overloads SetParameterMap(single)/GetParameterMap(index)
- Rename GetTransformParameterMap() -> GetTransformParameterMaps()
- Update all wrapper implementations, tests, and examples
- Fixes build to match latest elastix deprecation pattern