### PR TITLE
COMP: Update ITK to release-5.4 branch hash 2026-02-26

### DIFF
--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -69,7 +69,7 @@ sitk_legacy_naming(ITK_GIT_REPOSITORY ITK_REPOSITORY)
 
 # ITK release-5.4 branch hash 2026-02-26
 set(_DEFAULT_ITK_GIT_TAG "6dcda761aa8021a06124741b1a88adb88d859b75")
-set(ITK_GIT_TAG "${_DEFAULT_ITK_GIT_TAG}" CACHE STRING "Tag in ITK git repo")
+set(ITK_GIT_TAG "${_DEFAULT_ITK_GIT_TAG}" CACHE STRING "Tag or hash for ITK git repo")
 mark_as_advanced(ITK_GIT_TAG)
 set(ITK_TAG_COMMAND GIT_TAG "${ITK_GIT_TAG}")
 

--- a/SuperBuild/External_ITK.cmake
+++ b/SuperBuild/External_ITK.cmake
@@ -67,8 +67,8 @@ mark_as_advanced(ITK_GIT_REPOSITORY)
 sitk_legacy_naming(ITK_GIT_REPOSITORY ITK_REPOSITORY)
 
 
-# ITK v5.4.5 tag
-set(_DEFAULT_ITK_GIT_TAG "v5.4.5")
+# ITK release-5.4 branch hash 2026-02-26
+set(_DEFAULT_ITK_GIT_TAG "6dcda761aa8021a06124741b1a88adb88d859b75")
 set(ITK_GIT_TAG "${_DEFAULT_ITK_GIT_TAG}" CACHE STRING "Tag in ITK git repo")
 mark_as_advanced(ITK_GIT_TAG)
 set(ITK_TAG_COMMAND GIT_TAG "${ITK_GIT_TAG}")


### PR DESCRIPTION
Update ITK from tag v5.4.5 to the current HEAD of the release-5.4 branch (6dcda761aa8021a06124741b1a88adb88d859b75, 2026-02-26).