### PR TITLE
Add myst_parser to Sphinx Docs requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,4 @@ sphinx~=5.3.0
 sphinx_exec_code==0.8
 simpleitk~=2.5.2
 sphinx-toolbox~=3.4.0
+myst_parser~=5.0.0


### PR DESCRIPTION
Fixes build error on ReadTheDocs related to missing dependency.