### PR TITLE
DOC: Update requirements and ReadTheDocs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,7 +15,7 @@ sphinx:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.12"
 
 # Optionally set the version of Python and requirements required to build your docs
 python:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,8 @@
 sphinx-tabs
 cmake
 sphinx_rtd_theme
-sphinx~=5.3.0
-sphinx_exec_code==0.8
-simpleitk~=2.5.2
-sphinx-toolbox~=3.4.0
-myst_parser~=5.0.0
+myst_parser
+sphinx~=7.4.7
+sphinx_exec_code~=0.18
+simpleitk~=2.5.3
+sphinx-toolbox~=4.1.2


### PR DESCRIPTION
This PR also addressed the current build error on Read The Docs, due to versions requirement not being able to be meant with python 3.10.

- Update Python version in .readthedocs.yml from 3.10 to 3.12
- Update pinned Sphinx dependencies to latest compatible versions:
  - sphinx: 5.3.0 -> 7.4.7 (sphinx-toolbox not yet compatible with 8+/9+)
  - sphinx_exec_code: ==0.8 -> ~=0.18
  - simpleitk: ~=2.5.2 -> ~=2.5.3
  - sphinx-toolbox: ~=3.4.0 -> ~=4.1.2
  - myst_parser: unpinned (allows resolver to pick version compatible with sphinx~=7.4)