### PR TITLE
BUG: Replace deprecated macos-13 runner with macos-15-intel

### DIFF
--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -90,7 +90,7 @@ jobs:
       max-parallel: 5
       matrix:
         include:
-          - os: macos-13
+          - os: macos-15-intel
             cmake-build-type: "Release"
             cmake-generator: "Ninja"
             ctest-cache: |
@@ -183,7 +183,7 @@ jobs:
 
       - name: Generate Source and Data Archives
         shell: bash
-        if: matrix.os == 'macos-13'
+        if: matrix.os == 'macos-15-intel'
         run: |
           set -xe
 
@@ -200,6 +200,7 @@ jobs:
           rm -rf ${COREBINARYDIRECTORY}/SimpleITK-build
 
       - name: Package CSharp
+        if: runner.os != 'macOS'
         uses: ./.github/actions/package_csharp
         with:
           continue-on-error: true


### PR DESCRIPTION
The macos-13 GitHub-hosted runner is no longer available, causing macOS packaging jobs to be cancelled. Replace with macos-15-intel.

Also disable CSharp packaging on macOS since Mono is not available on macOS 15 runners.