### PR TITLE
ENH: Use Ninja generator for manylinux builds

### DIFF
--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -11,6 +11,7 @@ on:
     branches: [ master, main ]
     paths:
       - .github/workflows/Package.yml
+      - Utilities/Distribution/manylinux/
   workflow_dispatch:
 
 concurrency:

--- a/Utilities/Distribution/manylinux/Dockerfile-2-28-aarch64
+++ b/Utilities/Distribution/manylinux/Dockerfile-2-28-aarch64
@@ -3,7 +3,7 @@ LABEL maintainer="Insight Software Consortium <community@itk.org>"
 
 WORKDIR /tmp/
 RUN yum update -y\
-    && yum -y install java-devel\
+    && yum -y install java-devel ninja-build\
     && yum clean all
 
 

--- a/Utilities/Distribution/manylinux/Dockerfile-2-28-x86_64
+++ b/Utilities/Distribution/manylinux/Dockerfile-2-28-x86_64
@@ -4,7 +4,7 @@ LABEL maintainer="Insight Software Consortium <community@itk.org>"
 WORKDIR /tmp/
 
 RUN yum update -y\
-    && yum -y install java-devel\
+    && yum -y install java-devel ninja-build\
      && yum clean all
 
 # User is expected to mount directory to "/work"

--- a/Utilities/Distribution/manylinux/Dockerfile-2014-aarch64
+++ b/Utilities/Distribution/manylinux/Dockerfile-2014-aarch64
@@ -3,7 +3,7 @@ LABEL maintainer="Insight Software Consortium <community@itk.org>"
 
 WORKDIR /tmp/
 RUN yum update -y\
-    && yum -y install java-devel\
+    && yum -y install java-devel ninja-build\
     && yum clean all
 
 

--- a/Utilities/Distribution/manylinux/Dockerfile-2014-x86_64
+++ b/Utilities/Distribution/manylinux/Dockerfile-2014-x86_64
@@ -4,7 +4,7 @@ LABEL maintainer="Insight Software Consortium <community@itk.org>"
 WORKDIR /tmp/
 
 RUN yum update -y\
-    && yum -y install mono-devel java-devel\
+    && yum -y install mono-devel java-devel ninja-build\
      && yum clean all
 
 # User is expected to mount directory to "/work"

--- a/Utilities/Distribution/manylinux/imagefiles/cmd.sh
+++ b/Utilities/Distribution/manylinux/imagefiles/cmd.sh
@@ -15,7 +15,6 @@ SIMPLEITK_GIT_TAG=${SIMPLEITK_GIT_TAG:-v1.1rc1}
 PYTHON_VERSIONS=${PYTHON_VERSIONS:-$(ls /opt/python | sed -e 's/cp2[^ ]\+ \?//g' -e 's/pp3[^ ]\+ \?//g')}
 
 NPROC=$(grep -c processor /proc/cpuinfo)
-export MAKEFLAGS="-j ${NPROC}"
 
 # if ExternalData_OBJECT_STORES is not set by the driver script then
 # set it here to enable  reuse of downloaded files between python
@@ -39,6 +38,7 @@ build_simpleitk() {
     rm -rf ${BLD_DIR} &&
     mkdir -p ${BLD_DIR} && cd ${BLD_DIR} &&
     cmake \
+        -GNinja \
         -DSimpleITK_BUILD_DISTRIBUTE:BOOL=ON \
         -DSimpleITK_BUILD_STRIP:BOOL=ON \
         -DCMAKE_BUILD_TYPE:STRING=Release \
@@ -50,7 +50,7 @@ build_simpleitk() {
         -DITK_C_OPTIMIZATION_FLAGS:STRING="" \
         -DITK_CXX_OPTIMIZATION_FLAGS:STRING="" \
         ${SRC_DIR}/SuperBuild &&
-    make  &&
+    cmake --build . &&
     find ./ -name \*.o -delete
 }
 
@@ -67,6 +67,7 @@ build_simpleitk_python() {
     mkdir -p ${BLD_PY_DIR} &&
     cd ${BLD_PY_DIR} &&
     cmake \
+        -GNinja \
         -D "CMAKE_CXX_FLAGS:STRING=-fvisibility=hidden -fvisibility-inlines-hidden ${CFLAGS}" \
         -D "CMAKE_C_FLAGS:STRING=-fvisibility=hidden ${CXXFLAGS}" \
         -DCMAKE_MODULE_PATH:PATH=${SRC_DIR} \
@@ -82,8 +83,8 @@ build_simpleitk_python() {
         -DPython_EXECUTABLE:FILEPATH=${Python_EXECUTABLE} \
         -DPython_INCLUDE_DIR:PATH=${Python_INCLUDE_DIR} \
         ${SRC_DIR}/Wrapping/Python &&
-    make &&
-    make dist
+    cmake --build . &&
+    cmake --build . --target dist
 
 }
 


### PR DESCRIPTION
Switch the manylinux Docker image builds from make to Ninja. Add ninja-build to the yum install in all four Dockerfiles and configure CMake with -GNinja in cmd.sh. Replace bare make and make dist calls with cmake --build equivalents. Remove the MAKEFLAGS export since Ninja handles parallelism automatically.