### PR TITLE
Update elastix to af47e22, and use target based properties

### DIFF
--- a/CMake/sitkElastixGitOptions.cmake
+++ b/CMake/sitkElastixGitOptions.cmake
@@ -13,7 +13,7 @@ set(
 )
 mark_as_advanced(ELASTIX_GIT_REPOSITORY)
 
-set(_DEFAULT_ELASTIX_GIT_TAG "5.3.1") # March 21, 2026
+set(_DEFAULT_ELASTIX_GIT_TAG "af47e22") # April, 10 2026
 set(
   ELASTIX_GIT_TAG
   "${_DEFAULT_ELASTIX_GIT_TAG}"

--- a/Code/ElastixTransformixWrappers/CMakeLists.txt
+++ b/Code/ElastixTransformixWrappers/CMakeLists.txt
@@ -2,14 +2,6 @@ if(NOT TARGET elastix_lib)
   find_package(Elastix CONFIG REQUIRED)
 endif()
 
-set(
-  use_itk_modules
-  ITK::ITKCommonModule
-  ITK::ITKImageGridModule
-  ITK::ITKRegistrationCommonModule
-  ITK::ITKIOMeshBaseModule
-)
-
 add_library(
   SimpleElastix
   src/sitkElastixImageFilter.cxx
@@ -36,16 +28,14 @@ target_sources(
         ${CMAKE_CURRENT_SOURCE_DIR}/src/sitkTransformixImageFilterImpl.h
 )
 
-target_include_directories(SimpleElastix PRIVATE ${ELASTIX_INCLUDE_DIRS})
-
 target_link_libraries(
   SimpleElastix
   PUBLIC
     SimpleITKCommon
   PRIVATE
     SimpleITK_ITKCommon
-    ${ELASTIX_LIBRARIES}
-    ${use_itk_modules}
+    transformix_lib
+    elastix_lib
 )
 target_compile_options(
   SimpleElastix


### PR DESCRIPTION
This update to elastix added target based includes. Update SimpleITK usage to only link to the elastix library targets.