### PR TITLE
Remove manylinux 2014.

### DIFF
--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -29,22 +29,14 @@ jobs:
       max-parallel: 4
       matrix:
         include:
-          - os: ubuntu-22.04-arm
-            dockerfile: Dockerfile-2014-aarch64
-            build_csharp: 0
-            build_java: 1
-          - os: ubuntu-latest
-            dockerfile: Dockerfile-2014-x86_64
-            build_csharp: 1
-            build_java: 1
           - os: ubuntu-latest
             dockerfile: Dockerfile-2-28-x86_64
-            build_csharp: 0
-            build_java: 0
+            build_csharp: 1
+            build_java: 1
           - os: ubuntu-22.04-arm
             dockerfile: Dockerfile-2-28-aarch64
             build_csharp: 0
-            build_java: 0
+            build_java: 1
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Stop producing manylinux2014 wheels and consolidate on manylinux_2_28.

## Background

The `manylinux2014` tag (PEP 599) is based on CentOS 7, which reached **End of Life on June 30, 2024**. The underlying Docker build images (`quay.io/pypa/manylinux2014_*`) use an unmaintained OS and will no longer receive security updates or toolchain improvements.

The `manylinux_2_28` tag (PEP 600) is based on AlmaLinux 8, requiring glibc >= 2.28. Wheels tagged `manylinux_2_28` are compatible with:
- Debian 10+
- Ubuntu 18.10+
- Fedora 29+
- CentOS/RHEL 8+

This covers all actively supported Linux distributions.

## Changes

- Remove `Dockerfile-2014-x86_64` and `Dockerfile-2014-aarch64` matrix entries from the Package workflow.
- The `manylinux_2_28` x86_64 entry now also builds C# and Java packages (previously split across 2014 and 2_28 entries).
- The `manylinux_2_28` aarch64 entry now also builds Java packages.
