### PR TITLE
COMP: Link ITKRegistrationCommonModule for elastix pyramid headers

### DIFF
--- a/Code/ElastixTransformixWrappers/CMakeLists.txt
+++ b/Code/ElastixTransformixWrappers/CMakeLists.txt
@@ -36,6 +36,7 @@ target_link_libraries(
     SimpleITK_ITKCommon
     transformix_lib
     elastix_lib
+    ITK::ITKRegistrationCommonModule
 )
 target_compile_options(
   SimpleElastix


### PR DESCRIPTION
## Problem

When building SimpleITK with Elastix in Superbuild mode on Windows (using `ITK_USE_BUILD_DIR=ON`), the build fails with:

```
elxFixedImagePyramidBase.h(26,10): fatal error C1083: Cannot open include file:
'itkMultiResolutionPyramidImageFilter.h': No such file or directory
```

See the failing dashboard build: https://open.cdash.org/builds/11201211/build

## Root Cause

The issue originates from a recent change in the `origin/main` branch of the elastix repository (commit `af47e22` — "ENH: Use target based includes in CMakeLists"). That commit replaced global `include_directories(${elxINCLUDE_DIRECTORIES})` with proper target-based `target_include_directories()`. This is a good change, but it exposed a missing dependency.

The header chain is:

```
sitkElastixImageFilterImpl.h
  → itkElastixRegistrationMethod.h
    → elxElastixTemplate.h
      → elxFixedImagePyramidBase.h  (public header of elxCore)
        → itkMultiResolutionPyramidImageFilter.h  ← from ITKRegistrationCommon
```

`itkMultiResolutionPyramidImageFilter.h` lives in the `ITKRegistrationCommon` ITK module (`Modules/Registration/Common/include/`). This is a **header-only module** — its target `ITK::ITKRegistrationCommonModule` is an `INTERFACE` library, and it is **not** included in the `${ITK_LIBRARIES}` variable that elastix uses.

**With installed ITK:** all headers are merged into a single install include directory, so any ITK-linked target can find all ITK headers regardless of which module they belong to. The build works.

**With `ITK_USE_BUILD_DIR=ON` (build tree ITK):** each ITK module has its own separate include directory. Without an explicit dependency on `ITK::ITKRegistrationCommonModule`, its include path is never added to the compile command, and the header cannot be found. This is the configuration used in the Windows Superbuild CI.

## Fix

Add `ITK::ITKRegistrationCommonModule` as a PRIVATE link dependency of `SimpleElastix`. This propagates the include directory for `itkMultiResolutionPyramidImageFilter.h` when building against an ITK build tree.

## Note to the Elastix Team

The underlying deficiency is in elastix itself: `elxCore`'s public headers (`elxFixedImagePyramidBase.h`, `elxMovingImagePyramidBase.h`) `#include "itkMultiResolutionPyramidImageFilter.h"`, but `elxCore`'s `target_link_libraries()` does not declare a PUBLIC dependency on `ITK::ITKRegistrationCommonModule`. As a result, consumers of `elxCore` (and transitively `elastix_lib`) do not automatically get the `ITKRegistrationCommon` include path when using a non-installed ITK.

The proper fix in elastix would be to add to `Core/CMakeLists.txt`:

```cmake
target_link_libraries(elxCore PUBLIC
  ITKRegistrationCommon  # or ITK::ITKRegistrationCommonModule
)
```

This SimpleITK workaround links it directly in `SimpleElastix` to unblock the Windows CI build in the interim.
