### PR TITLE
ENH: Simplify ccache key in Build.yml GHA workflow

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -174,10 +174,11 @@ jobs:
       uses: actions/cache@v5
       with:
         path: ${{ runner.temp }}/.ccache
-        key: ccache-v1-${{ matrix.name }}-${{ github.head_ref && format('{0}-{1}', github.base_ref, github.head_ref) || github.ref_name }}-${{ github.sha }}
+        # GHA scoping rules make branch names in the key redundant:
+        # restore-keys are searched on the current branch first, then the
+        # default branch, so PRs naturally fall back to the latest main cache.
+        key: ccache-v1-${{ matrix.name }}-${{ github.sha }}
         restore-keys: |
-          ccache-v1-${{ matrix.name }}-${{ github.head_ref && format('{0}-{1}', github.base_ref, github.head_ref) || github.ref_name }}-
-          ccache-v1-${{ matrix.name }}-${{ github.head_ref && github.base_ref || github.ref_name }}-
           ccache-v1-${{ matrix.name }}-
     - name: Configure ccache
       if: matrix.use-ccache


### PR DESCRIPTION
## Summary

The ccache `key` and `restore-keys` were encoding branch names (`github.head_ref`, `github.base_ref`, `github.ref_name`) to try to create a branch-preference fallback order. This is unnecessary.

GHA cache scoping [already handles this natively](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#cache-key-matching): restore-keys are searched on the **current branch first**, then the **default branch** (`main`), and for PRs also the **base branch**. A PR therefore naturally falls back to the latest `main` ccache via the simple prefix `ccache-v1-{name}-`, with no branch names needed in the key.

## Change

```yaml
# Before
key: ccache-v1-${{ matrix.name }}-${{ github.head_ref && format('{0}-{1}', github.base_ref, github.head_ref) || github.ref_name }}-${{ github.sha }}
restore-keys: |
  ccache-v1-${{ matrix.name }}-${{ github.head_ref && format('{0}-{1}', github.base_ref, github.head_ref) || github.ref_name }}-
  ccache-v1-${{ matrix.name }}-${{ github.head_ref && github.base_ref || github.ref_name }}-
  ccache-v1-${{ matrix.name }}-

# After
key: ccache-v1-${{ matrix.name }}-${{ github.sha }}
restore-keys: |
  ccache-v1-${{ matrix.name }}-
```