### PR TITLE
GHA: Pin R version to 4.5

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -133,7 +133,7 @@ jobs:
       if: contains(matrix.ctest-cache, 'WRAP_R')
       uses: r-lib/actions/setup-r@v2
       with:
-        r-version: 'latest'
+        r-version: '4.5'
     - name: Install Examples R package dependencies
       if: contains(matrix.ctest-cache, 'WRAP_R')
       run: |


### PR DESCRIPTION
Workaround for R 4.6.0 build failures with SWIG-generated R wrapping code.

Closes #2574