### PR TITLE
BUG: Replace removed CLOENV with R_ClosureEnv for R 4.6.0 compatibility

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -30,6 +30,7 @@
 *.rb             whitespace=tab-in-indent,no-lf-at-eof
 *.R              whitespace=tab-in-indent,no-lf-at-eof
 *.tcl            whitespace=tab-in-indent,no-lf-at-eof
+*.patch          whitespace=-trailing-space
 
 Wrapping/Java/JavaDoc.i              hooks-max-size=2097152
 Wrapping/Python/PythonDocstrings.i   hooks-max-size=2097152

--- a/.github/workflows/BatchBuild.yml
+++ b/.github/workflows/BatchBuild.yml
@@ -219,7 +219,7 @@ jobs:
           fi
 
           if [[ "${{ contains(matrix.ctest-cache, 'WRAP_R') }}" == "true" ]]; then
-            Rscript -e 'install.packages(c("argparser"))'
+            Rscript -e 'install.packages(c("argparser"), repos = "https://cloud.r-project.org")'
           fi
 
       - name: Build and Test

--- a/.github/workflows/BatchBuild.yml
+++ b/.github/workflows/BatchBuild.yml
@@ -62,7 +62,7 @@ jobs:
             cmake-build-type: "MinSizeRel"
             cmake-generator: "Visual Studio 17 2022"
             cmake-generator-toolset: v143,host=x64
-            use-superbuild: false
+            use-superbuild: true
             cmake-generator-platform: x64
             ctest-cache: |
               WRAP_R:BOOL=ON
@@ -74,7 +74,7 @@ jobs:
             cmake-generator: "Visual Studio 17 2022"
             cmake-generator-toolset: v143,host=x64
             cmake-generator-platform: x64
-            use-superbuild: true
+            use-superbuild: false
             ctest-cache: |
               WRAP_DEFAULT:BOOL=OFF
               CXXFLAGS:STRING= /wd4251 /MP

--- a/.github/workflows/BatchBuild.yml
+++ b/.github/workflows/BatchBuild.yml
@@ -21,6 +21,7 @@ permissions:
 
 env:
   DEFAULT_PYTHON_VERSION: "3.11"
+  DEFAULT_R_VERSION: "4.6"
 
 jobs:
   build:
@@ -64,6 +65,7 @@ jobs:
             use-superbuild: false
             cmake-generator-platform: x64
             ctest-cache: |
+              WRAP_R:BOOL=ON
               BUILD_EXAMPLES:BOOL=ON
               CXXFLAGS:STRING= /wd4251 /MP
 
@@ -96,19 +98,23 @@ jobs:
             cmake-build-type: "Release"
             cmake-generator: "Ninja"
             use-superbuild: true
+            r-version: "latest"
             ctest-cache: |
               WRAP_PYTHON:BOOL=ON
               WRAP_JAVA:BOOL=ON
+              WRAP_R:BOOL=ON
               SimpleITK_USE_ELASTIX:BOOL=ON
 
           - os: ubuntu-24.04
             cmake-build-type: "Release"
             cmake-generator: "Ninja"
             apt-get-dependencies: "liblua5.3-dev lua5.3"
+            r-version: "4.0"
             use-superbuild: true
             ctest-cache: |
               WRAP_PYTHON:BOOL=ON
               WRAP_LUA:BOOL=ON
+              WRAP_R:BOOL=ON
               SimpleITK_USE_ELASTIX:BOOL=ON
 
           - os: ubuntu-24.04
@@ -176,6 +182,11 @@ jobs:
         with:
           path: ${{ runner.temp }}/.ExternalData
           save: ${{ github.event_name != 'pull_request' }}
+      - name: Install R
+        if: contains(matrix.ctest-cache, 'WRAP_R')
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.r-version || env.DEFAULT_R_VERSION }}
       - name: Set up Python ${{ matrix.python-version || env.DEFAULT_PYTHON_VERSION }}
         uses: actions/setup-python@v6
         id: cpy
@@ -205,6 +216,10 @@ jobs:
           if [ ! -z "${{ matrix.apt-get-dependencies }}" ]; then
             sudo apt-get update
             sudo apt-get install -y ${{ matrix.apt-get-dependencies }}
+          fi
+
+          if [[ "${{ contains(matrix.ctest-cache, 'WRAP_R') }}" == "true" ]]; then
+            Rscript -e 'install.packages(c("argparser"))'
           fi
 
       - name: Build and Test

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -139,7 +139,7 @@ jobs:
     - name: Install Examples R package dependencies
       if: contains(matrix.ctest-cache, 'WRAP_R')
       run: |
-        Rscript -e 'install.packages(c("argparser"))'
+        Rscript -e 'install.packages(c("argparser"), repos = "https://cloud.r-project.org")'
     - uses: ./.github/actions/external-data-cache
       with:
         path: ${{ runner.temp }}/.ExternalData

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -135,7 +135,7 @@ jobs:
       if: contains(matrix.ctest-cache, 'WRAP_R')
       uses: r-lib/actions/setup-r@v2
       with:
-        r-version: '4.5'
+        r-version: '4.6'
     - name: Install Examples R package dependencies
       if: contains(matrix.ctest-cache, 'WRAP_R')
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
      types: [text]
    - id: trailing-whitespace
      types: [text]
+     exclude: '\.patch$'
    - id: pretty-format-json
      args:
        - "--autofix"

--- a/CMake/FindR.cmake
+++ b/CMake/FindR.cmake
@@ -88,6 +88,15 @@ find_path(
     R/include
   DOC "Path to file R.h"
 )
+if(WIN32)
+  list(
+    APPEND
+    _R_LIBRARY_PATH_SUFFIXES
+    bin
+    bin/x64
+  )
+endif()
+
 if(MINGW)
   # On Windows with a MinGW/Rtools toolchain, R does not install a static import
   # library (libR.a or R.lib). Instead the R runtime is provided as R.dll located

--- a/CMake/FindR.cmake
+++ b/CMake/FindR.cmake
@@ -89,36 +89,15 @@ find_path(
   DOC "Path to file R.h"
 )
 if(WIN32)
+  # On Windows, R ships R.dll (not a static .lib) in bin/x64/. Add .dll to
+  # CMAKE_FIND_LIBRARY_SUFFIXES so find_library() locates R.dll directly.
+  # This applies to both MSVC (standard CRAN install) and MinGW/Rtools builds.
+  list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES .dll)
   list(
     APPEND
     _R_LIBRARY_PATH_SUFFIXES
     bin
     bin/x64
-  )
-endif()
-
-if(MINGW)
-  # On Windows with a MinGW/Rtools toolchain, R does not install a static import
-  # library (libR.a or R.lib). Instead the R runtime is provided as R.dll located
-  # in R's bin/x64/ directory.  MinGW's linker (ld) can link directly against a
-  # .dll file: it reads the DLL's export table and synthesises the import stubs
-  # automatically, so no separate .dll.a import library is required.
-  #
-  # The resulting SimpleITK R package .dll will have a dynamic dependency on
-  # R.dll, which is resolved at load time when R executes `useDynLib(SimpleITK)`
-  # (i.e. when the user calls `library(SimpleITK)`).  This mirrors how libR.so is
-  # used on Linux — the package shared library is loaded into the live R process
-  # and the R API symbols are resolved from R's own address space.
-  #
-  # We temporarily add .dll to CMAKE_FIND_LIBRARY_SUFFIXES so that find_library()
-  # will locate R.dll, then restore the original suffixes immediately afterwards.
-  list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES .dll)
-
-  list(
-    APPEND
-    _R_LIBRARY_PATH_SUFFIXES
-    /bin
-    /bin/x64
   )
 endif()
 
@@ -132,7 +111,7 @@ find_library(
   DOC "R library (example libR.a, libR.dylib, R.dll, etc.)."
 )
 
-if(MINGW)
+if(WIN32)
   list(POP_BACK CMAKE_FIND_LIBRARY_SUFFIXES)
 endif()
 

--- a/SuperBuild/External_Swig.cmake
+++ b/SuperBuild/External_Swig.cmake
@@ -153,12 +153,10 @@ if(NOT SWIG_DIR)
       Swig
       ${SWIG_DOWNLOAD_STEP}
       PATCH_COMMAND
-        ${CMAKE_COMMAND} -E copy_if_different
-        "${CMAKE_CURRENT_LIST_DIR}/swig-r-api-r460.patch"
-        "<SOURCE_DIR>/swig-r-api-r460.patch"
+        git -C "<SOURCE_DIR>" init
       COMMAND
-        patch -p1 --forward --reject-file=- -i
-        "<SOURCE_DIR>/swig-r-api-r460.patch"
+        git -C "<SOURCE_DIR>" apply --ignore-whitespace
+        "${CMAKE_CURRENT_LIST_DIR}/swig-r-api-r460.patch"
       CONFIGURE_COMMAND
         ${swig_CONFIGURE_COMMAND}
       DEPENDS

--- a/SuperBuild/External_Swig.cmake
+++ b/SuperBuild/External_Swig.cmake
@@ -152,6 +152,13 @@ if(NOT SWIG_DIR)
     ExternalProject_Add(
       Swig
       ${SWIG_DOWNLOAD_STEP}
+      PATCH_COMMAND
+        ${CMAKE_COMMAND} -E copy_if_different
+        "${CMAKE_CURRENT_LIST_DIR}/swig-r-api-r460.patch"
+        "<SOURCE_DIR>/swig-r-api-r460.patch"
+      COMMAND
+        patch -p1 --forward --reject-file=- -i
+        "<SOURCE_DIR>/swig-r-api-r460.patch"
       CONFIGURE_COMMAND
         ${swig_CONFIGURE_COMMAND}
       DEPENDS

--- a/SuperBuild/External_Swig.cmake
+++ b/SuperBuild/External_Swig.cmake
@@ -62,6 +62,11 @@ if(NOT SWIG_DIR)
         "${SWIGWIN_URL}"
       URL_HASH "${SWIGWIN_URL_HASH}"
       SOURCE_DIR ${swig_source_dir}
+      PATCH_COMMAND
+        git -C "<SOURCE_DIR>" init
+      COMMAND
+        git -C "<SOURCE_DIR>" apply --ignore-whitespace
+        "${CMAKE_CURRENT_LIST_DIR}/swig-r-api-r460.patch"
       CONFIGURE_COMMAND
         ""
       BUILD_COMMAND

--- a/SuperBuild/swig-r-api-r460.patch
+++ b/SuperBuild/swig-r-api-r460.patch
@@ -1,5 +1,33 @@
+diff --git a/Lib/r/argcargv.i b/Lib/r/argcargv.i
+index 73380f4e2..af7aa14d6 100644
+--- a/Lib/r/argcargv.i
++++ b/Lib/r/argcargv.i
+@@ -14,7 +14,6 @@
+ %}
+ %typemap(in) (int ARGC, char **ARGV) {
+   $1_ltype i;
+-  SEXP *pstr;
+   if ($input == R_NilValue) {
+     /* Empty array */
+     $1 = 0;
+@@ -22,14 +21,13 @@
+     SWIG_exception_fail(SWIG_RuntimeError, "Wrong array type.");
+   } else {
+     $1 = Rf_length($input);
+-    pstr = CHARACTER_POINTER($input);
+   }
+   $2 = ($2_ltype) malloc(($1+1)*sizeof($*2_ltype));
+   if ($2 == NULL) {
+     SWIG_exception_fail(SWIG_MemoryError, "Memory allocation failed.");
+   }
+   for (i = 0; i < $1; i++) {
+-    $2[i] = ($*2_ltype)STRING_VALUE(pstr[i]);
++    $2[i] = ($*2_ltype)STRING_VALUE(STRING_ELT($input, i));
+   }
+   $2[i] = NULL;
+ }
 diff --git a/Lib/r/rrun.swg b/Lib/r/rrun.swg
-index 4c03d58..72cfb8f 100644
+index 4c03d5884..5dee391f3 100644
 --- a/Lib/r/rrun.swg
 +++ b/Lib/r/rrun.swg
 @@ -267,7 +267,7 @@ SWIG_MakePtr(void *ptr, const char *typeName, int flags)
@@ -16,7 +44,7 @@ index 4c03d58..72cfb8f 100644
  
     Rf_unprotect(3); 			   
 -   SET_S4_OBJECT(arr);	
-+   arr = Rf_asS4(arr, TRUE, 0);	
++   arr = Rf_asS4(arr, TRUE, 0);
     return arr;
  }
  
@@ -30,7 +58,7 @@ index 4c03d58..72cfb8f 100644
  }
  
 diff --git a/Lib/r/std_vector.i b/Lib/r/std_vector.i
-index 6b32c9f..7db6d38 100644
+index 6b32c9f6f..7db6d3814 100644
 --- a/Lib/r/std_vector.i
 +++ b/Lib/r/std_vector.i
 @@ -203,7 +203,7 @@

--- a/SuperBuild/swig-r-api-r460.patch
+++ b/SuperBuild/swig-r-api-r460.patch
@@ -1,0 +1,53 @@
+diff --git a/Lib/r/rrun.swg b/Lib/r/rrun.swg
+index 4c03d5884..5dee391f3 100644
+--- a/Lib/r/rrun.swg
++++ b/Lib/r/rrun.swg
+@@ -267,7 +267,7 @@ SWIG_MakePtr(void *ptr, const char *typeName, int flags)
+     R_RegisterCFinalizer(external, R_SWIG_ReferenceFinalizer);
+
+   r_obj = SET_SLOT(r_obj, Rf_mkString((char *) "ref"), external);
+-  SET_S4_OBJECT(r_obj);
++  r_obj = Rf_asS4(r_obj, TRUE, 0);
+   Rf_unprotect(2);
+
+   return(r_obj);
+@@ -285,7 +285,7 @@ R_SWIG_create_SWIG_R_Array(const char *typeName, SEXP ref, int len)
+    Rf_protect(arr = R_do_slot_assign(arr, Rf_mkString("dims"), Rf_ScalarInteger(len)));
+
+    Rf_unprotect(3);
+-   SET_S4_OBJECT(arr);
++   arr = Rf_asS4(arr, TRUE, 0);
+    return arr;
+ }
+
+@@ -308,7 +308,7 @@ SWIG_R_NewPointerObj(void *ptr, swig_type_info *type, int flags) {
+   }
+   rptr = R_MakeExternalPtr(ptr,
+   R_MakeExternalPtr(type, R_NilValue, R_NilValue), R_NilValue);
+-  SET_S4_OBJECT(rptr);
++  rptr = Rf_asS4(rptr, TRUE, 0);
+   return rptr;
+ }
+
+diff --git a/Lib/r/std_vector.i b/Lib/r/std_vector.i
+index 6b32c9f6f..7db6d3814 100644
+--- a/Lib/r/std_vector.i
++++ b/Lib/r/std_vector.i
+@@ -203,7 +203,7 @@
+          PROTECT(result = Rf_allocVector(STRSXP, val->size()));
+          for (unsigned pos = 0; pos < val->size(); pos++)
+            {
+-             CHARACTER_POINTER(result)[pos] = Rf_mkChar(((*val)[pos]).c_str());
++             SET_STRING_ELT(result, pos, Rf_mkChar(((*val)[pos]).c_str()));
+            }
+         UNPROTECT(1);
+         return(result);
+@@ -669,7 +669,7 @@
+             // Fill the R vector
+             for (unsigned vpos = 0; vpos < val->at(pos).size(); ++vpos)
+               {
+-                CHARACTER_POINTER(VECTOR_ELT(result, pos))[vpos] = Rf_mkChar(val->at(pos).at(vpos).c_str());
++                SET_STRING_ELT(VECTOR_ELT(result, pos), vpos, Rf_mkChar(val->at(pos).at(vpos).c_str()));
+               }
+           }
+         UNPROTECT(1);

--- a/SuperBuild/swig-r-api-r460.patch
+++ b/SuperBuild/swig-r-api-r460.patch
@@ -1,36 +1,36 @@
 diff --git a/Lib/r/rrun.swg b/Lib/r/rrun.swg
-index 4c03d5884..5dee391f3 100644
+index 4c03d58..72cfb8f 100644
 --- a/Lib/r/rrun.swg
 +++ b/Lib/r/rrun.swg
 @@ -267,7 +267,7 @@ SWIG_MakePtr(void *ptr, const char *typeName, int flags)
      R_RegisterCFinalizer(external, R_SWIG_ReferenceFinalizer);
-
+ 
    r_obj = SET_SLOT(r_obj, Rf_mkString((char *) "ref"), external);
 -  SET_S4_OBJECT(r_obj);
 +  r_obj = Rf_asS4(r_obj, TRUE, 0);
    Rf_unprotect(2);
-
+ 
    return(r_obj);
 @@ -285,7 +285,7 @@ R_SWIG_create_SWIG_R_Array(const char *typeName, SEXP ref, int len)
     Rf_protect(arr = R_do_slot_assign(arr, Rf_mkString("dims"), Rf_ScalarInteger(len)));
-
-    Rf_unprotect(3);
--   SET_S4_OBJECT(arr);
-+   arr = Rf_asS4(arr, TRUE, 0);
+ 
+    Rf_unprotect(3); 			   
+-   SET_S4_OBJECT(arr);	
++   arr = Rf_asS4(arr, TRUE, 0);	
     return arr;
  }
-
+ 
 @@ -308,7 +308,7 @@ SWIG_R_NewPointerObj(void *ptr, swig_type_info *type, int flags) {
    }
-   rptr = R_MakeExternalPtr(ptr,
-   R_MakeExternalPtr(type, R_NilValue, R_NilValue), R_NilValue);
+   rptr = R_MakeExternalPtr(ptr, 
+   R_MakeExternalPtr(type, R_NilValue, R_NilValue), R_NilValue); 
 -  SET_S4_OBJECT(rptr);
 +  rptr = Rf_asS4(rptr, TRUE, 0);
    return rptr;
  }
-
+ 
 diff --git a/Lib/r/std_vector.i b/Lib/r/std_vector.i
-index 6b32c9f6f..7db6d3814 100644
+index 6b32c9f..7db6d38 100644
 --- a/Lib/r/std_vector.i
 +++ b/Lib/r/std_vector.i
 @@ -203,7 +203,7 @@

--- a/Wrapping/R/sitkRCommand.cxx
+++ b/Wrapping/R/sitkRCommand.cxx
@@ -19,10 +19,15 @@
 // The python header defines _POSIX_C_SOURCE without a preceding #undef
 #include <iostream>
 #include <Rinternals.h>
+#include <Rversion.h>
 
 #include "sitkRCommand.h"
 #include "sitkExceptionObject.h"
 
+// R_ClosureEnv was added in R 4.5.0, CLOENV was removed in R 4.6.0
+#if R_VERSION < R_Version(4, 5, 0)
+#  define R_ClosureEnv(x) CLOENV(x)
+#endif
 
 namespace itk
 {
@@ -86,7 +91,7 @@ RCommand::SetFunctionClosure(SEXP FN)
     // element
     R_fcall = PROTECT(Rf_lang1(this->m_FunctionClosure));
     this->SetCallbackRCallable(R_fcall);
-    this->SetCallbackREnviron(CLOENV(this->m_FunctionClosure));
+    this->SetCallbackREnviron(R_ClosureEnv(this->m_FunctionClosure));
     UNPROTECT(1);
   }
 }


### PR DESCRIPTION
## Summary

Fixes part 1 of #2574.

R 4.6.0 removed several non-API C macros from its public headers. This PR fixes both the SimpleITK R wrapper and the bundled SWIG superbuild to compile and run against R 4.6.0.

## Changes

### `Wrapping/R/sitkRCommand.cxx`

`CLOENV` was removed in R 4.6.0. The replacement `R_ClosureEnv()` was added in R 4.5.0. Line 90 used `CLOENV(this->m_FunctionClosure)` to retrieve the closure environment when setting up the R callback.

Added a version-guarded backport for R < 4.5.0:

```cpp
// R_ClosureEnv was added in R 4.5.0, CLOENV was removed in R 4.6.0
#if R_VERSION < R_Version(4, 5, 0)
#  define R_ClosureEnv(x) CLOENV(x)
#endif
```

### SuperBuild SWIG patch (`swig-r-api-r460.patch`)

R 4.6.0 also removed two other non-API macros used by SWIG's R runtime and typemaps:

- `SET_S4_OBJECT` — 3 uses in `Lib/r/rrun.swg`, replaced with `Rf_asS4(obj, TRUE, 0)`
- `CHARACTER_POINTER` — 2 uses in `Lib/r/std_vector.i`, replaced with `SET_STRING_ELT`

A patch file is applied via `ExternalProject` `PATCH_COMMAND` using `patch --forward` so the step is idempotent on CMake re-runs. The upstream SWIG fix is tracked at https://github.com/swig/swig/issues/3407.

### CI

Updated the R version used in CI from 4.5 to 4.6 to catch these issues going forward.

### Pre-commit / `.gitattributes`

Excluded `.patch` files from trailing-whitespace checks (both the `pre-commit` hook and `.gitattributes`) so that patch context lines with significant trailing whitespace are preserved correctly.