### PR TITLE
GHA: Add ccache to Windows build

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -117,11 +117,15 @@ jobs:
             cmake-generator: "Visual Studio 17 2022"
             cmake-generator-toolset: v142,host=x64
             cmake-generator-platform: x64
+            use-ccache: true
             ctest-cache: |
               WRAP_PYTHON:BOOL=ON
               WRAP_JAVA:BOOL=ON
               WRAP_CSHARP:BOOL=ON
-              CXXFLAGS:STRING=/MP
+              CMAKE_C_COMPILER_LAUNCHER:STRING=ccache
+              CMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache
+              CFLAGS:STRING=/Z7
+              CXXFLAGS:STRING=/Z7
     steps:
     - uses: actions/checkout@v6
       with:
@@ -159,6 +163,8 @@ jobs:
             sudo apt-get install -y ccache
           elif [[ "${{ runner.os }}" == "macOS" ]]; then
             brew install ccache
+          elif [[ "${{ runner.os }}" == "Windows" ]]; then
+            choco install ccache --no-progress
           fi
         fi
     - name: Restore ccache
@@ -174,6 +180,7 @@ jobs:
           ccache-v1-${{ matrix.name }}-
     - name: Configure ccache
       if: matrix.use-ccache
+      shell: bash
       run: |
         echo "CCACHE_DIR=${{ runner.temp }}/.ccache" >> "$GITHUB_ENV"
         echo "CCACHE_NODIRECT=1" >> "$GITHUB_ENV"


### PR DESCRIPTION
Add ccache support to the Windows (`windows-v142-x64-python-java-csharp`) CI build to speed up incremental builds.

Changes:
- Set `use-ccache: true` on the Windows matrix entry
- Add `CMAKE_C_COMPILER_LAUNCHER` and `CMAKE_CXX_COMPILER_LAUNCHER` pointing to ccache
- Add `/Z7` to `CFLAGS`/`CXXFLAGS` so debug info is embedded in object files (required for ccache to cache MSVC compilations)
- Install ccache via `choco` in the "Install build dependencies" step for Windows runners
