### PR TITLE
ENH: Add free-threaded Python (3.14t) packaging support - for release

### DIFF
--- a/.github/actions/package_python/action.yml
+++ b/.github/actions/package_python/action.yml
@@ -21,12 +21,12 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       id: cpy
       with:
         python-version: ${{ inputs.python-version }}
     - name: Build Python ${{ steps.cpy.outputs.python-version }}
-      continue-on-error: ${{ inputs.continue-on-error }}
+      continue-on-error: ${{ inputs.continue-on-error == 'true' }}
       shell: bash
       if: runner.os == 'macOS'
       env:
@@ -34,7 +34,7 @@ runs:
       run: |
         ${{ github.action_path }}/scripts/mac_build_python.sh
     - name: Build Python ${{ steps.cpy.outputs.python-version }}
-      continue-on-error: ${{ inputs.continue-on-error }}
+      continue-on-error: ${{ inputs.continue-on-error == 'true' }}
       shell: cmd
       if: runner.os == 'Windows'
       env:

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build ${{ matrix.dockerfile }}
         shell: bash
         env:
-          PYTHON_VERSIONS: "cp39-cp39 cp310-cp310"
+          PYTHON_VERSIONS: "cp39-cp39 cp310-cp310 cp314-cp314t"
           BUILD_CSHARP: ${{ contains(matrix.os, 'arm') && '0' || '1' }}
           BUILD_JAVA: 1
           BUILD_PYTHON_LIMITED_API: 1
@@ -155,7 +155,7 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
-          python -m pip install ninja cmake~=3.29.0
+          python -m pip install ninja cmake~=3.31.0
 
           if [  ! -z "${{ matrix.xcode-version }}" ]; then
             sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer/
@@ -224,6 +224,11 @@ jobs:
         uses: ./.github/actions/package_python
         with:
           python-version: 3.9
+      - name: Package Python 3.14t
+        uses: ./.github/actions/package_python
+        with:
+          python-version: "3.14t"
+          continue-on-error: true
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/Utilities/Distribution/manylinux/imagefiles/cmd.sh
+++ b/Utilities/Distribution/manylinux/imagefiles/cmd.sh
@@ -130,7 +130,7 @@ if [[ ! -z ${BUILD_PYTHON_LIMITED_API:+x} && "${BUILD_PYTHON_LIMITED_API}" -ne 0
     USE_LIMITED_API=ON
     PYTHON=cp311-cp311
     PYTHON_EXECUTABLE=/opt/python/${PYTHON}/bin/python
-    PLATFORM=$(${PYTHON_EXECUTABLE} -c "import distutils.util; print(distutils.util.get_platform())")
+    PLATFORM=$(${PYTHON_EXECUTABLE} -c "import sysconfig; print(sysconfig.get_platform())")
     build_simpleitk_python &&
        ( auditwheel repair $(find ${BLD_DIR}-${PYTHON}${USE_LIMITED_API:+-abi3}/ -name *.whl) -w ${OUT_DIR}/wheelhouse/;
          ctest -j ${NPROC} -LE UNSTABLE | tee ${OUT_DIR}/ctest_${PLATFORM}_${PYTHON}${USE_LIMITED_API:+-abi3}.log &&
@@ -142,7 +142,7 @@ fi
 
 for PYTHON in ${PYTHON_VERSIONS}; do
     PYTHON_EXECUTABLE=/opt/python/${PYTHON}/bin/python
-    PLATFORM=$(${PYTHON_EXECUTABLE} -c "import distutils.util; print(distutils.util.get_platform())")
+    PLATFORM=$(${PYTHON_EXECUTABLE} -c "import sysconfig; print(sysconfig.get_platform())")
     build_simpleitk_python &&
         ( auditwheel repair $(find ${BLD_DIR}-${PYTHON}/ -name *.whl) -w ${OUT_DIR}/wheelhouse/;
           ctest -j ${NPROC} -LE UNSTABLE | tee ${OUT_DIR}/ctest_${PLATFORM}_${PYTHON}.log &&

--- a/Wrapping/Python/CMakeLists.txt
+++ b/Wrapping/Python/CMakeLists.txt
@@ -7,6 +7,18 @@ include(../../CMake/sitkProjectLanguageCommon.cmake NO_POLICY_SCOPE)
 
 find_package( Python REQUIRED COMPONENTS Interpreter Development.Module OPTIONAL_COMPONENTS Development.SABIModule)
 
+# Free-threaded Python (PEP 703, e.g. Python 3.13t/3.14t) requires CMake >= 3.30 for
+# correct FindPython support. Earlier versions link against python3XX.lib instead of
+# python3XXt.lib, causing a crash (access violation) on module import.
+if (Python_SOABI MATCHES "t-" OR Python_SOABI MATCHES "t$")
+  if (CMAKE_VERSION VERSION_LESS "3.30")
+    message(FATAL_ERROR
+      "Free-threaded Python (detected SOABI: '${Python_SOABI}') requires CMake >= 3.30. "
+      "CMake ${CMAKE_VERSION} will link against the wrong Python DLL, causing crashes. "
+      "Please upgrade CMake to 3.30 or later.")
+  endif()
+endif()
+
 include_directories ( ${SimpleITK_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR} )
 
 #

--- a/Wrapping/Python/Python.i
+++ b/Wrapping/Python/Python.i
@@ -29,6 +29,13 @@
 #include "sitkPyCommand.h"
 %}
 
+%init %{
+#ifdef Py_GIL_DISABLED
+    // Declare this module as safe to use without the GIL (PEP 703 / free-threaded).
+    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
+#endif
+%}
+
 %include "PythonDocstrings.i"
 %include "sitkPathType.i"
  //%feature("autodoc", "1");


### PR DESCRIPTION
- Python.i: declare module GIL-safe for free-threaded builds via PyUnstable_Module_SetGIL under Py_GIL_DISABLED guard
- Package.yml: add cp314-cp314t to manylinux PYTHON_VERSIONS and a continue-on-error 'Package Python 3.14t' step for macOS/Windows
- package_python/action.yml: bump setup-python from v5 to v6
- cmd.sh: replace deprecated distutils.util.get_platform() with sysconfig.get_platform()