### PR TITLE
ENH: Fix free-threaded Python linking with CMake >= 3.30

### DIFF
--- a/.github/workflows/requirements-build.txt
+++ b/.github/workflows/requirements-build.txt
@@ -1,2 +1,2 @@
 ninja
-cmake~=3.29.0
+cmake~=3.31.0

--- a/Wrapping/Python/CMakeLists.txt
+++ b/Wrapping/Python/CMakeLists.txt
@@ -17,6 +17,20 @@ find_package(
     Development.SABIModule
 )
 
+# Free-threaded Python (PEP 703, e.g. Python 3.13t/3.14t) requires CMake >= 3.30 for
+# correct FindPython support. Earlier versions link against python3XX.lib instead of
+# python3XXt.lib, causing a crash (access violation) on module import.
+if(Python_SOABI MATCHES "t-" OR Python_SOABI MATCHES "t$")
+  if(CMAKE_VERSION VERSION_LESS "3.30")
+    message(
+      FATAL_ERROR
+      "Free-threaded Python (detected SOABI: '${Python_SOABI}') requires CMake >= 3.30. "
+      "CMake ${CMAKE_VERSION} will link against the wrong Python DLL, causing crashes. "
+      "Please upgrade CMake to 3.30 or later."
+    )
+  endif()
+endif()
+
 include_directories(
   ${SimpleITK_INCLUDE_DIRS}
   ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
CMake 3.30 added `FindPython` support for free-threaded Python (PEP 703). Earlier versions incorrectly resolve `Python::Module` to `python3XX.lib` instead of `python3XXt.lib`, causing an access violation on module import when loading the extension under the free-threaded interpreter.

## Changes
- Bump `cmake~=3.29.0` → `cmake~=3.31.0` in `requirements-build.txt` so CI uses a version that correctly handles free-threaded Python
- Add a `FATAL_ERROR` in `Wrapping/Python/CMakeLists.txt` when a free-threaded interpreter is detected (via `Python_SOABI` containing `'t'`) and CMake < 3.30, so users get a clear error instead of a silent crash

Related to backport PR #2580.