### PR TITLE
BUG: Remove duplicate Python packaging steps in Package workflow

### DIFF
--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -197,17 +197,6 @@ jobs:
           rm -rf ${COREBINARYDIRECTORY}/ITK ${COREBINARYDIRECTORY}/ITK-build
           rm -rf ${COREBINARYDIRECTORY}/SimpleITK-build
 
-      - name: Package Python 3.11
-        uses: ./.github/actions/package_python
-        with:
-          python-version: 3.11
-          use_limited_api: true
-          cmake_osx_architectures: ${{ matrix.cmake_osx_architectures || '' }}
-      - name: Package Python 3.10
-        uses: ./.github/actions/package_python
-        with:
-          python-version: "3.10"
-          cmake_osx_architectures: ${{ matrix.cmake_osx_architectures || '' }}
       - name: Package CSharp
         if: runner.os != 'macOS'
         uses: ./.github/actions/package_csharp


### PR DESCRIPTION
Commit 4559d6d5c ("Enable Elastix of GHA Packaging") accidentally inserted duplicate `Package Python 3.11` and `Package Python 3.10` steps immediately after the `Cleanup build` step. Those steps already existed after `Package Java`. This removes the two duplicate steps.