### PR TITLE
GHA: emit error annotation on Python packaging failure

### DIFF
--- a/.github/actions/package_python/scripts/mac_build_python.sh
+++ b/.github/actions/package_python/scripts/mac_build_python.sh
@@ -2,6 +2,12 @@
 
 set -ex
 
+warn_on_failure() {
+  local rc=$?
+  [ $rc -ne 0 ] && echo "::error title=Build Failed::Python ${PYTHON_ABI_TAG:-unknown} macOS build failed with exit code $rc"
+}
+trap warn_on_failure EXIT
+
 export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=2
 
 echo "COREBINARYDIRECTORY: ${COREBINARYDIRECTORY}"

--- a/.github/actions/package_python/scripts/win_build_python.sh
+++ b/.github/actions/package_python/scripts/win_build_python.sh
@@ -2,6 +2,12 @@
 
 set -ex
 
+warn_on_failure() {
+  local rc=$?
+  [ $rc -ne 0 ] && echo "::error title=Build Failed::Python ${PYTHON_ABI_TAG:-unknown} Windows build failed with exit code $rc"
+}
+trap warn_on_failure EXIT
+
 export PATH=/usr/bin:${PATH}
 
 export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=2

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -364,7 +364,7 @@ jobs:
           mv $( find  ${{ steps.download.outputs.download-path }} -type f -name "*.whl" ) dist/
       - name: PyPI Publish package
         if: startsWith(github.ref_name, 'v')
-        # hash for release/v1.12.4
+        # hash for release/v1.14.0
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:
           repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Two small improvements to the Python packaging GitHub Actions setup.

## Changes

### Fix outdated version comment in `Package.yml`

The comment for the `pypa/gh-action-pypi-publish` SHA pin incorrectly
referenced `v1.12.4`. The SHA already corresponds to `v1.14.0` (updated
by Dependabot in #2560).

### Emit GHA error annotation on build failure

The `package_python` composite action uses `continue-on-error: true` for
optional Python version builds. When a build fails silently under this
setting, it can be hard to notice without inspecting individual step logs.

Add a `warn_on_failure` EXIT trap to both `mac_build_python.sh` and
`win_build_python.sh` that emits a `::error::` workflow annotation when
the script exits non-zero. This surfaces the failure visibly as a red
annotation in the GHA UI without changing job pass/fail behaviour.