### PR TITLE
ENH: Update macOS CI runner from macos-13 to macos-14

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -57,13 +57,12 @@ jobs:
               WRAP_PYTHON:BOOL=ON
               WRAP_JAVA:BOOL=ON
               ITK_USE_BUILD_DIR:BOOL=ON
-          - os: macos-13
+          - os: macos-15-intel
             cmake-build-type: "Release"
             cmake-generator: "Ninja"
             ctest-cache: |
               WRAP_PYTHON:BOOL=ON
               WRAP_JAVA:BOOL=ON
-              WRAP_CSHARP:BOOL=ON
           - os: windows-2022
             cmake-build-type: "Release"
             cmake-generator: "Visual Studio 17 2022"


### PR DESCRIPTION
Replace the deprecated `macos-13` runner with `macos-14` in the `Build.yml` CI workflow matrix.