### PR TITLE
ENH: Add R wrapping CI coverage to Build and BatchBuild workflows

### DIFF
--- a/.github/workflows/BatchBuild.yml
+++ b/.github/workflows/BatchBuild.yml
@@ -21,6 +21,7 @@ permissions:
 
 env:
   DEFAULT_PYTHON_VERSION: "3.11"
+  DEFAULT_R_VERSION: "4.5"
 
 jobs:
   build:
@@ -99,16 +100,19 @@ jobs:
             ctest-cache: |
               WRAP_PYTHON:BOOL=ON
               WRAP_JAVA:BOOL=ON
+              WRAP_R:BOOL=ON
               SimpleITK_USE_ELASTIX:BOOL=ON
 
           - os: ubuntu-24.04
             cmake-build-type: "Release"
             cmake-generator: "Ninja"
             apt-get-dependencies: "liblua5.3-dev lua5.3"
+            r-version: "4.0"
             use-superbuild: true
             ctest-cache: |
               WRAP_PYTHON:BOOL=ON
               WRAP_LUA:BOOL=ON
+              WRAP_R:BOOL=ON
               SimpleITK_USE_ELASTIX:BOOL=ON
 
           - os: ubuntu-24.04
@@ -143,6 +147,7 @@ jobs:
             use-superbuild: true
             ctest-cache: |
               WRAP_PYTHON:BOOL=ON
+              WRAP_R:BOOL=ON
 
           - os: macos-14
             cmake-build-type: "Release"
@@ -176,6 +181,11 @@ jobs:
         with:
           path: ${{ runner.temp }}/.ExternalData
           save: ${{ github.event_name != 'pull_request' }}
+      - name: Install R
+        if: contains(matrix.ctest-cache, 'WRAP_R')
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.r-version || env.DEFAULT_R_VERSION }}
       - name: Set up Python ${{ matrix.python-version || env.DEFAULT_PYTHON_VERSION }}
         uses: actions/setup-python@v6
         id: cpy
@@ -205,6 +215,10 @@ jobs:
           if [ ! -z "${{ matrix.apt-get-dependencies }}" ]; then
             sudo apt-get update
             sudo apt-get install -y ${{ matrix.apt-get-dependencies }}
+          fi
+
+          if [[ "${{ contains(matrix.ctest-cache, 'WRAP_R') }}" == "true" ]]; then
+            Rscript -e 'install.packages(c("argparser"))'
           fi
 
       - name: Build and Test

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -23,6 +23,10 @@ permissions:
   contents: read
   actions: read
 
+env:
+  DEFAULT_PYTHON_VERSION: "3.11"
+  DEFAULT_R_VERSION: "4.5"
+
 jobs:
 
   build:
@@ -104,10 +108,11 @@ jobs:
             cmake-build-type: "Release"
             cmake-generator: "Ninja"
             cmake_osx_architectures: "x86_64"
+            r_version: "4.4"
             use-ccache: true
             ctest-cache: |
+              WRAP_R:BOOL=ON
               WRAP_PYTHON:BOOL=ON
-              WRAP_JAVA:BOOL=ON
               WRAP_CSHARP:BOOL=OFF
               CMAKE_C_COMPILER_LAUNCHER:STRING=ccache
               CMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache
@@ -131,24 +136,20 @@ jobs:
       with:
         path: SimpleITK-dashboard
         ref: dashboard
-    - name: Install R
+    - name: Install R ${{ matrix.r-version || env.DEFAULT_R_VERSION }}
       if: contains(matrix.ctest-cache, 'WRAP_R')
       uses: r-lib/actions/setup-r@v2
       with:
-        r-version: '4.5'
-    - name: Install Examples R package dependencies
-      if: contains(matrix.ctest-cache, 'WRAP_R')
-      run: |
-        Rscript -e 'install.packages(c("argparser"))'
+        r-version: ${{ matrix.r-version || env.DEFAULT_R_VERSION }}
     - uses: ./.github/actions/external-data-cache
       with:
         path: ${{ runner.temp }}/.ExternalData
         save: ${{ github.event_name != 'pull_request' }}
-    - name: Set up Python 3.11
+    - name: Set up Python ${{ matrix.python-version || env.DEFAULT_PYTHON_VERSION }}
       uses: actions/setup-python@v6
       id: cpy
       with:
-        python-version: 3.11
+        python-version: ${{ matrix.python-version || env.DEFAULT_PYTHON_VERSION }}
     - name: Install build dependencies
       shell: bash
       run: |
@@ -160,6 +161,11 @@ jobs:
           elif [[ "${{ runner.os }}" == "macOS" ]]; then
             brew install ccache
           fi
+        fi
+
+        # Install R dependecies needed for exmaples
+        if [[ "${{ contains(matrix.ctest-cache, 'WRAP_R') }}" == "true" ]]; then
+          Rscript -e 'install.packages(c("argparser"))'
         fi
     - name: Restore ccache
       if: matrix.use-ccache

--- a/Code/Common/include/sitkLogger.h
+++ b/Code/Common/include/sitkLogger.h
@@ -49,7 +49,7 @@ class ITKLogger;
 class SITKCommon_EXPORT LoggerBase : public ObjectOwnedBase
 {
 public:
-  LoggerBase();
+  LoggerBase() = default;
 
   ~LoggerBase() override;
 

--- a/Code/Common/src/sitkLogger.cxx
+++ b/Code/Common/src/sitkLogger.cxx
@@ -120,8 +120,6 @@ protected:
 } // namespace
 
 
-LoggerBase::LoggerBase() = default;
-
 LoggerBase::~LoggerBase() = default;
 
 ITKLogger


### PR DESCRIPTION
- Addresses run-time link error on OSX related to the LoggerBase class.
- Add DEFAULT_R_VERSION and DEFAULT_PYTHON_VERSION top-level env defaults
- Add WRAP_R to to more builds
- Install argparser R package as part of build dependencies when WRAP_R