### PR TITLE
ENH: Add support for ITK SingleMultiThreader

### DIFF
--- a/Code/Common/include/sitkProcessObject.h
+++ b/Code/Common/include/sitkProcessObject.h
@@ -162,6 +162,7 @@ public:
    *  - "POOL" itk::PoolMultiThreader
    *  - "TBB" itk::TBBThreader (optional)
    *  - "PLATFORM" itk::PlatformMultiThreader
+   *  - "SINGLE" itk::SingleMultiThreader
    *
    * The default and the available multi-threaders are
    * dependent upon ITK's configuration. See the ITK
@@ -176,7 +177,7 @@ public:
    * threader argument is not case sensitive.
    *
    * \sa itk::MultiThreaderBase itk::PoolMultiThreader
-   * itk::TBBThreader itk::PlatformMultiThreader
+   * itk::TBBThreader itk::PlatformMultiThreader itk::SingleMultiThreader
    * @{
    */
   static bool

--- a/Code/Common/src/sitkProcessObject.cxx
+++ b/Code/Common/src/sitkProcessObject.cxx
@@ -325,7 +325,7 @@ ProcessObject::SetGlobalDefaultThreader(const std::string & threader)
   auto threaderEnum = itk::MultiThreaderBase::ThreaderTypeFromString(threader);
   if (threaderEnum == itk::MultiThreaderBase::ThreaderEnum::Unknown
 #if !defined(ITK_USE_TBB)
-      || threaderEnum == itk::MultiThreaderBase::ThreaderEnum::Unknown
+      || threaderEnum == itk::MultiThreaderBase::ThreaderEnum::TBB
 #endif
   )
   {

--- a/Testing/Unit/CMakeLists.txt
+++ b/Testing/Unit/CMakeLists.txt
@@ -113,6 +113,27 @@ target_compile_options(
     ${SimpleITK_PRIVATE_COMPILE_OPTIONS}
 )
 
+include(CheckIncludeFileCXX)
+set(_sitk_saved_cmake_required_includes "${CMAKE_REQUIRED_INCLUDES}")
+if(DEFINED ITK_INCLUDE_DIRS)
+  list(APPEND CMAKE_REQUIRED_INCLUDES ${ITK_INCLUDE_DIRS})
+endif()
+check_include_file_cxx(
+  "itkSingleMultiThreader.h"
+  SITK_ITK_HAS_SINGLE_THREADER
+)
+set(CMAKE_REQUIRED_INCLUDES "${_sitk_saved_cmake_required_includes}")
+unset(_sitk_saved_cmake_required_includes)
+
+if(SITK_ITK_HAS_SINGLE_THREADER)
+  set_source_files_properties(
+    sitkCommonTests.cxx
+    PROPERTIES
+      COMPILE_DEFINITIONS
+        SITK_ITK_HAS_SINGLE_THREADER
+  )
+endif()
+
 #
 # Glob for necessary template files up front, before the foreach loop over
 # the filters:

--- a/Testing/Unit/sitkCommonTests.cxx
+++ b/Testing/Unit/sitkCommonTests.cxx
@@ -605,6 +605,15 @@ TEST(ProcessObject, Threads)
 
   EXPECT_TRUE(sitk::ProcessObject::SetGlobalDefaultThreader("POOL"));
   EXPECT_EQ("POOL", strupper(sitk::ProcessObject::GetGlobalDefaultThreader()));
+
+#if defined(SITK_ITK_HAS_SINGLE_THREADER)
+  EXPECT_TRUE(sitk::ProcessObject::SetGlobalDefaultThreader("SINGLE"));
+  EXPECT_EQ("SINGLE", strupper(sitk::ProcessObject::GetGlobalDefaultThreader()));
+  EXPECT_TRUE(sitk::ProcessObject::SetGlobalDefaultThreader("Single"));
+  EXPECT_EQ("SINGLE", strupper(sitk::ProcessObject::GetGlobalDefaultThreader()));
+#else
+  EXPECT_FALSE(sitk::ProcessObject::SetGlobalDefaultThreader("SINGLE"));
+#endif
 }
 
 TEST(Command, Test2)

--- a/Wrapping/Python/tests/sitkFlatStaticMethod.py
+++ b/Wrapping/Python/tests/sitkFlatStaticMethod.py
@@ -52,6 +52,11 @@ def test_ProcessObject():
     sitk.ProcessObject_SetGlobalDefaultNumberOfThreads(2)
     assert sitk.ProcessObject_GetGlobalDefaultNumberOfThreads() == 2
 
+    # "SINGLE" threader is available when ITK has itk::SingleMultiThreader
+    result = sitk.ProcessObject_SetGlobalDefaultThreader("SINGLE")
+    if result:
+        assert sitk.ProcessObject_GetGlobalDefaultThreader().upper() == "SINGLE"
+
 def test_IO(test_data):
     sitk.ImageSeriesReader_GetGDCMSeriesIDs(str(test_data["test_dir"]))
     sitk.ImageReaderBase_GetImageIOFromFileName(str(test_data["test_dcm_file"]))


### PR DESCRIPTION
Add support for the new `itk::SingleMultiThreader` introduced in ITK PR [#6222](https://github.com/InsightSoftwareConsortium/ITK/pull/6222).

### Changes

- **`sitkProcessObject.h`** — Updated `SetGlobalDefaultThreader` documentation to list `"SINGLE"` as an available threader option.
- **`sitkProcessObject.cxx`** — Fixed pre-existing bug in `SetGlobalDefaultThreader` where the `#if !defined(ITK_USE_TBB)` guard was checking `ThreaderEnum::Unknown` instead of `ThreaderEnum::TBB`. No additional guard is needed for `"SINGLE"` since `ThreaderTypeFromString` on older ITK returns `Unknown` for unrecognized strings.
- **`Testing/Unit/CMakeLists.txt`** — Added `check_include_file_cxx` detection for `itkSingleMultiThreader.h` and passes `SITK_ITK_HAS_SINGLE_THREADER` as a compile definition to `sitkCommonTests.cxx`.
- **`Testing/Unit/sitkCommonTests.cxx`** — Added conditional test verifying `SetGlobalDefaultThreader("SINGLE")` works when available, or returns `false` when not.
- **`Wrapping/Python/tests/sitkFlatStaticMethod.py`** — Added runtime test for `"SINGLE"` threader via `SetGlobalDefaultThreader`.

### Notes

When built against an ITK with `SingleMultiThreader`, users can select it via:
```python
sitk.ProcessObject.SetGlobalDefaultThreader("SINGLE")
```
or the environment variable `ITK_GLOBAL_DEFAULT_THREADER=Single`.