### PR TITLE
BUG: Fix DicomSeriesReader test for ITK PR#5357 direction fix

### DIFF
--- a/Testing/Unit/sitkImageIOTests.cxx
+++ b/Testing/Unit/sitkImageIOTests.cxx
@@ -26,6 +26,7 @@
 #include <sitkExtractImageFilter.h>
 #include <sitkRegionOfInterestImageFilter.h>
 
+#include <cmath>
 #include <itksys/SystemTools.hxx>
 
 
@@ -552,7 +553,26 @@ TEST(IO, DicomSeriesReader)
   EXPECT_EQ(image2.GetSize(), image2_reverse.GetSize());
   EXPECT_NE(image2.GetOrigin(), image2_reverse.GetOrigin());
   EXPECT_EQ(image2.GetSpacing(), image2_reverse.GetSpacing());
-  EXPECT_EQ(image2.GetDirection(), image2_reverse.GetDirection());
+  // ITK PR#5357 fixed ForceOrthogonalDirection to negate the z-column when
+  // reading in reverse order. X/y-columns are unaffected; z-column must match
+  // in magnitude (sign may differ: ITK < 6.0 preserved the sign (pre-fix),
+  // ITK >= 6.0 negates it (post ITK PR#5357)).
+  {
+    const auto d = image2.GetDirection();
+    const auto dr = image2_reverse.GetDirection();
+    ASSERT_EQ(d.size(), dr.size());
+    ASSERT_EQ(d.size(), 9u);
+    for (size_t i : { 0u, 1u, 3u, 4u, 6u, 7u })
+    {
+      EXPECT_NEAR(d[i], dr[i], 1e-10) << "Direction element [" << i
+                                      << "] (x/y-column) should be unchanged by ReverseOrder";
+    }
+    for (size_t i : { 2u, 5u, 8u })
+    {
+      EXPECT_NEAR(std::abs(d[i]), std::abs(dr[i]), 1e-10)
+        << "Direction z-column element [" << i << "] magnitude should be unchanged by ReverseOrder";
+    }
+  }
   EXPECT_EQ(image2.GetPixelID(), image2_reverse.GetPixelID());
   EXPECT_EQ(image2.GetDimension(), image2_reverse.GetDimension());
   EXPECT_EQ(image2.GetNumberOfComponentsPerPixel(), image2_reverse.GetNumberOfComponentsPerPixel());


### PR DESCRIPTION
## Summary

The `IO.DicomSeriesReader` test was failing due to a behavioral change in ITK PR InsightSoftwareConsortium/ITK#5357, which fixed `ForceOrthogonalDirection` to correctly negate the z-column of the direction matrix when reading a DICOM series in reverse order.

The previous test used `EXPECT_EQ` on the full direction matrix, expecting it to be identical between forward and reversed reads. This was correct for old ITK (where the z-column sign was not updated — a bug), but fails with the fixed ITK.

## Fix

Replace the single `EXPECT_EQ(direction, direction_reverse)` with element-wise checks that are valid for both old and new ITK:

- **x/y-columns** (flat indices 0,1,3,4,6,7): must be **identical** regardless of `ReverseOrder` — these come from DICOM image orientation tags and are unaffected.
- **z-column** (flat indices 2,5,8): must match in **magnitude** — old ITK keeps the sign (bug), new ITK negates it (correct), but the unit vector magnitude is preserved in both cases.