### PR TITLE
DOC: Add release notes for v2.5.5

### DIFF
--- a/docs/source/release_notes/index.rst
+++ b/docs/source/release_notes/index.rst
@@ -10,6 +10,7 @@ Release Notes
    notes-v3.0.0a3
    notes-v3.0.0a2
    notes-v3.0.0a1
+   notes-v2.5.5
    notes-v2.5.4
    notes-v2.5.3
    notes-v2.5.2

--- a/docs/source/release_notes/notes-v2.5.5.md
+++ b/docs/source/release_notes/notes-v2.5.5.md
@@ -1,0 +1,16 @@
+# SimpleITK Release v2.5.5
+
+
+To upgrade to this Python binary package run:
+```pip install --upgrade --pre simpleitk --find-links https://github.com/SimpleITK/SimpleITK/releases/tag/v2.5.5```
+
+
+
+**What's Changed**
+* ENH: Add free-threaded Python (3.14t) packaging support - for release by @blowekamp in https://github.com/SimpleITK/SimpleITK/pull/2580
+* ENH: Update macOS CI runner from macos-13 to macos-14 by @blowekamp in https://github.com/SimpleITK/SimpleITK/pull/2584
+* Fix R CLOENV - for release and master by @blowekamp in https://github.com/SimpleITK/SimpleITK/pull/2585
+* BUG: Patch SWIG superbuild for R 4.6.0 API removals by @blowekamp in https://github.com/SimpleITK/SimpleITK/pull/2587
+
+
+**Full Changelog**: https://github.com/SimpleITK/SimpleITK/compare/v2.5.4...v2.5.5


### PR DESCRIPTION
Add release notes for the v2.5.5 release, fetched from the GitHub release page, following the existing conventions.