### PR TITLE
ENH: Detect pre-release tag to set pip install command and GitHub release flag

### DIFF
--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -295,6 +295,15 @@ jobs:
         run: |
           echo "TAG NAME: ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
           echo "name=${{github.ref_name}}" >> $GITHUB_OUTPUT
+      - name: Detect pre-release
+        id: prerelease
+        run: |
+          if [[ "${{ steps.tag.outputs.name }}" == "latest" ||
+              "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)?((-.)?[a-zA-Z]+[0-9]*)$ ]]; then
+            echo "is_prerelease=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_prerelease=false" >> $GITHUB_OUTPUT
+          fi
       - name: Create Release Notes
         shell: bash
         run: |
@@ -304,10 +313,15 @@ jobs:
           else
             echo "This is an automatic packaging of SimpleITK based on the ${{ steps.tag.outputs.name }} tag." > notes.txt
           fi
+          if [ "${{ steps.prerelease.outputs.is_prerelease }}" == "true" ]; then
+            pip_cmd="pip install --upgrade --pre simpleitk"
+          else
+            pip_cmd="pip install --upgrade simpleitk"
+          fi
           echo "
 
           To upgrade to this Python binary package run:
-          \`\`\`pip install --upgrade --pre simpleitk --find-links https://github.com/SimpleITK/SimpleITK/releases/tag/${{ steps.tag.outputs.name }}\`\`\`
+          \`\`\`${pip_cmd} --find-links https://github.com/SimpleITK/SimpleITK/releases/tag/${{ steps.tag.outputs.name }}\`\`\`
           " >>notes.txt
 
           ${{ github.workspace }}/Utilities/Maintenance/GeneratePythonDownloadsPage.py \
@@ -328,8 +342,7 @@ jobs:
             gh release delete ${{ steps.tag.outputs.name }} --yes || true
           fi
 
-          if [[  "${{ steps.tag.outputs.name }}" == "latest" ||
-              "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)?((-.)?[a-zA-Z]+[0-9]*)$ ]]; then
+          if [ "${{ steps.prerelease.outputs.is_prerelease }}" == "true" ]; then
             create_args="--prerelease"
           fi
 


### PR DESCRIPTION
Extracts the pre-release detection logic into a dedicated `Detect pre-release` step (id: `prerelease`) that exports `is_prerelease=true/false` to `$GITHUB_OUTPUT`.\r\n\r\nThis output is then used in two places:\r\n- **`Create Release Notes`**: selects `pip install --upgrade simpleitk` for formal releases and `pip install --upgrade --pre simpleitk` for pre-releases.\r\n- **`Create Release and Upload Artifacts`**: replaces the duplicated `[[ ... ]]` regex check with a simple reference to `steps.prerelease.outputs.is_prerelease`."