### PR TITLE
ci: harden Package workflow against supply-chain and injection risks

### DIFF
--- a/.github/actions/external-data-cache/action.yml
+++ b/.github/actions/external-data-cache/action.yml
@@ -13,7 +13,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/cache/restore@v5
+    - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       if: inputs.save != 'true'
       with:
         path: ${{ inputs.path }}
@@ -21,7 +21,7 @@ runs:
         enableCrossOsArchive: true
         restore-keys: |
           external-data-v2-
-    - uses: actions/cache@v5
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       if: inputs.save == 'true'
       with:
         path: ${{ inputs.path }}

--- a/.github/actions/package_csharp/action.yml
+++ b/.github/actions/package_csharp/action.yml
@@ -28,8 +28,9 @@ runs:
       continue-on-error: ${{ inputs.continue-on-error == 'true' }}
       shell: cmd
       if: runner.os == 'Windows'
-      run: |
-        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"  ${{ inputs.VCVAR_OPTIONS }}
-        bash ${{ github.action_path }}/scripts/win_build_csharp.sh
       env:
+        VCVAR_OPTIONS: ${{ inputs.VCVAR_OPTIONS }}
         CSHARP_PLATFORM: x64
+      run: |
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"  %VCVAR_OPTIONS%
+        bash ${{ github.action_path }}/scripts/win_build_csharp.sh

--- a/.github/actions/package_java/action.yml
+++ b/.github/actions/package_java/action.yml
@@ -28,6 +28,8 @@ runs:
       continue-on-error: ${{ inputs.continue-on-error == 'true' }}
       shell: cmd
       if: runner.os == 'Windows'
+      env:
+        VCVAR_OPTIONS: ${{ inputs.VCVAR_OPTIONS }}
       run: |
-        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"  ${{ inputs.VCVAR_OPTIONS }}
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"  %VCVAR_OPTIONS%
         bash ${{ github.action_path }}/scripts/win_build_java.sh

--- a/.github/actions/package_python/action.yml
+++ b/.github/actions/package_python/action.yml
@@ -25,7 +25,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       id: cpy
       with:
         python-version: ${{ inputs.python-version }}

--- a/.github/actions/package_python/action.yml
+++ b/.github/actions/package_python/action.yml
@@ -44,6 +44,7 @@ runs:
       if: runner.os == 'Windows'
       env:
         USE_LIMITED_API: ${{ inputs.use_limited_api }}
+        VCVAR_OPTIONS: ${{ inputs.VCVAR_OPTIONS }}
       run: |
-        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"  ${{ inputs.VCVAR_OPTIONS }}
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"  %VCVAR_OPTIONS%
         bash ${{ github.action_path }}/scripts/win_build_python.sh

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -38,7 +38,7 @@ jobs:
             build_csharp: 0
             build_java: 1
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - name: Docker Build Image
@@ -74,7 +74,7 @@ jobs:
         run: |
           ls -lhR .
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: artifacts-${{ matrix.os }}-${{matrix.dockerfile}}
           path: |
@@ -133,10 +133,10 @@ jobs:
               SimpleITK_BUILD_DISTRIBUTE:BOOL=ON
               CXXFLAGS:STRING= /MP
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           path: SimpleITK-dashboard
           ref: dashboard
@@ -145,7 +145,7 @@ jobs:
           path: ${{ env.ExternalData_OBJECT_STORES }}
           save: ${{ github.event_name != 'pull_request' }}
       - name: Set up Python 3.11
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         id: cpy
         with:
           python-version: 3.11
@@ -227,7 +227,7 @@ jobs:
           continue-on-error: true
           cmake_osx_architectures: ${{ matrix.cmake_osx_architectures || '' }}
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: artifacts-${{ matrix.os }}
           path: |
@@ -237,7 +237,7 @@ jobs:
   doxygen:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - name: Build Docker Image for Doxygen
@@ -255,7 +255,7 @@ jobs:
           docker cp sitk-dox:/SimpleITKDoxygen.tar.gz artifacts/SimpleITKDoxygen-${TAG}.tar.gz
           docker cp sitk-dox:/SimpleITKDoxygenXML.tar.gz artifacts/SimpleITKDoxygenXML-${TAG}.tar.gz
       - name: Archive Doxygen Artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: doxygen-xml
           path: |
@@ -275,10 +275,10 @@ jobs:
       - package-docker
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         id: download
         with:
           path: ${{ github.workspace }}/artifacts

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -292,29 +292,35 @@ jobs:
           cat checksums.txt
       - name: Set tag name
         id: tag
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          echo "TAG NAME: ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
-          echo "name=${{github.ref_name}}" >> $GITHUB_OUTPUT
+          echo "TAG NAME: ${REF_NAME}" >> $GITHUB_STEP_SUMMARY
+          echo "name=${REF_NAME}" >> $GITHUB_OUTPUT
       - name: Create Release Notes
         shell: bash
+        env:
+          TAG_NAME: ${{ steps.tag.outputs.name }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          DOWNLOAD_PATH: ${{ steps.download.outputs.download-path }}
         run: |
-          echo "Tag Name: ${{ steps.tag.outputs.name }}"
-          if [ "${{ steps.tag.outputs.name }}" == "latest" ]; then
-            echo "This is an automatic packaging of SimpleITK based on the ${{github.event.repository.default_branch}} branch. It contains the latest features and experimental developments." > notes.txt
+          echo "Tag Name: ${TAG_NAME}"
+          if [ "${TAG_NAME}" == "latest" ]; then
+            echo "This is an automatic packaging of SimpleITK based on the ${DEFAULT_BRANCH} branch. It contains the latest features and experimental developments." > notes.txt
           else
-            echo "This is an automatic packaging of SimpleITK based on the ${{ steps.tag.outputs.name }} tag." > notes.txt
+            echo "This is an automatic packaging of SimpleITK based on the ${TAG_NAME} tag." > notes.txt
           fi
           echo "
 
           To upgrade to this Python binary package run:
-          \`\`\`pip install --upgrade --pre simpleitk --find-links https://github.com/SimpleITK/SimpleITK/releases/tag/${{ steps.tag.outputs.name }}\`\`\`
+          \`\`\`pip install --upgrade --pre simpleitk --find-links https://github.com/SimpleITK/SimpleITK/releases/tag/${TAG_NAME}\`\`\`
           " >>notes.txt
 
           ${{ github.workspace }}/Utilities/Maintenance/GeneratePythonDownloadsPage.py \
             --hash md5 \
             --format gh \
-            --tag "${{ steps.tag.outputs.name }}" \
-            $( find ${{ steps.download.outputs.download-path }} -type f  -name \*.whl ) \
+            --tag "${TAG_NAME}" \
+            $( find "${DOWNLOAD_PATH}" -type f  -name \*.whl ) \
           >> notes.txt
 
           echo "== notes.txt =="
@@ -323,28 +329,32 @@ jobs:
       - name: Create Release and Upload Artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ steps.tag.outputs.name }}
+          REF_NAME: ${{ github.ref_name }}
+          GIT_SHA: ${{ github.sha }}
+          DOWNLOAD_PATH: ${{ steps.download.outputs.download-path }}
         run: |
-          if [ "${{ steps.tag.outputs.name }}" == "latest" ]; then
-            gh release delete ${{ steps.tag.outputs.name }} --yes || true
+          if [ "${TAG_NAME}" == "latest" ]; then
+            gh release delete "${TAG_NAME}" --yes || true
           fi
 
-          if [[  "${{ steps.tag.outputs.name }}" == "latest" ||
-              "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)?((-.)?[a-zA-Z]+[0-9]*)$ ]]; then
+          if [[  "${TAG_NAME}" == "latest" ||
+              "${REF_NAME}" =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)?((-.)?[a-zA-Z]+[0-9]*)$ ]]; then
             create_args="--prerelease"
           fi
 
-          gh release create ${{ steps.tag.outputs.name }} \
-            --target ${{ github.sha }} \
+          gh release create "${TAG_NAME}" \
+            --target "${GIT_SHA}" \
             --verify-tag \
             --draft \
             --generate-notes \
             $create_args \
             --notes-file notes.txt \
-            --title "Release ${{ github.ref_name }}"
-          gh release upload ${{ steps.tag.outputs.name }} $( find  ${{ steps.download.outputs.download-path }} -type f \( -name "*.whl" -o -name "*.zip" -o -name "*.gz" \) )
+            --title "Release ${REF_NAME}"
+          gh release upload "${TAG_NAME}" $( find  "${DOWNLOAD_PATH}" -type f \( -name "*.whl" -o -name "*.zip" -o -name "*.gz" \) )
 
-          if [ "${{ steps.tag.outputs.name }}" == "latest" ]; then
-            gh release edit ${{ steps.tag.outputs.name }} --draft=false
+          if [ "${TAG_NAME}" == "latest" ]; then
+            gh release edit "${TAG_NAME}" --draft=false
           fi
       - name: Prepare for PyPI upload
         shell: bash


### PR DESCRIPTION
Addresses three security issues identified in the Package workflow and associated composite actions.

## Changes

**Prevent shell injection via context expressions** (`publish` job)
Context values (`github.ref_name`, `steps.tag.outputs.name`, etc.) were interpolated directly into bash scripts. They are now passed through intermediate `env:` variables, following [GitHub's recommended practice](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#good-practices-for-mitigating-script-injection-attacks).

**Pin third-party actions to full commit SHAs**
All `actions/checkout`, `actions/setup-python`, `actions/upload-artifact`, `actions/download-artifact`, and `actions/cache` references now use immutable commit SHAs instead of mutable version tags. Covers `Package.yml` and the three composite actions.

**Fix `VCVAR_OPTIONS` interpolation in `cmd` shell** (`package_csharp`, `package_java`, `package_python`)
`${{ inputs.VCVAR_OPTIONS }}` was written directly into `cmd` shell scripts. It is now passed via `env:` and referenced as `%VCVAR_OPTIONS%`.