### PR TITLE
ENH: Add Python examples and documentation for Elastix

### DIFF
--- a/.github/workflows/additional_dictionary.txt
+++ b/.github/workflows/additional_dictionary.txt
@@ -2063,6 +2063,7 @@ tetrahedra
 textbf
 textrm
 tfm
+tfx
 th
 thisline
 thread_local

--- a/Examples/Elastix/CMakeLists.txt
+++ b/Examples/Elastix/CMakeLists.txt
@@ -39,3 +39,33 @@ set_tests_properties(
     DEPENDS
       "CXX.Example.Elastix"
 )
+
+# Python tests
+sitk_add_python_test(
+  Example.Elastix
+  "${CMAKE_CURRENT_SOURCE_DIR}/elx.py"
+  DATA{${SimpleITK_DATA_ROOT}/Input/BrainProtonDensitySliceBorder20.png}
+  DATA{${SimpleITK_DATA_ROOT}/Input/BrainProtonDensitySliceShifted13x17y.png}
+  ${CMAKE_CURRENT_SOURCE_DIR}/par0001.txt
+  ${SimpleITK_TEST_OUTPUT_DIR}/Python.Example.elx.nii
+  ${SimpleITK_TEST_OUTPUT_DIR}/Python.Example.elx.TransformParameters.txt
+)
+
+sitk_add_python_test(
+  Example.Transformix
+  "${CMAKE_CURRENT_SOURCE_DIR}/tfx.py"
+  DATA{${SimpleITK_DATA_ROOT}/Input/BrainProtonDensitySliceShifted13x17y.png}
+  ${SimpleITK_TEST_OUTPUT_DIR}/Python.Example.elx.TransformParameters.txt
+  ${SimpleITK_TEST_OUTPUT_DIR}/Python.Example.tfx.nii
+  IMAGE_COMPARE
+    ${SimpleITK_TEST_OUTPUT_DIR}/Python.Example.elx.nii
+    ${SimpleITK_TEST_OUTPUT_DIR}/Python.Example.tfx.nii
+    40
+)
+
+set_tests_properties(
+  Python.Example.Transformix
+  PROPERTIES
+    DEPENDS
+      "Python.Example.Elastix"
+)

--- a/Examples/Elastix/Documentation.rst
+++ b/Examples/Elastix/Documentation.rst
@@ -1,0 +1,74 @@
+SimpleElastix Registration
+==========================
+
+Overview
+--------
+
+This example demonstrates the usage of the SimpleElastix framework for image registration and transformation. SimpleElastix provides access to the powerful `elastix <https://elastix.lumc.nl/>`_ registration toolbox through SimpleITK's `ElastixImageFilter <https://simpleitk.org/doxygen/latest/html/classitk_1_1simple_1_1ElastixImageFilter.html>`_ and `TransformixImageFilter <https://simpleitk.org/doxygen/latest/html/classitk_1_1simple_1_1TransformixImageFilter.html>`_ classes.
+
+The elastix framework is widely used for medical image registration and offers:
+
+* A comprehensive collection of registration algorithms
+* Multi-resolution strategies
+* A variety of transformation models (rigid, affine, B-spline, etc.)
+* Multiple similarity metrics for different imaging modalities
+* A `parameter zoo <https://lkeb.ml/modelzoo/>`_ with pre-configured settings for common registration scenarios
+
+This example includes two programs:
+
+1. **elx** - Performs image registration using ElastixImageFilter
+2. **tfx** - Applies transformations using TransformixImageFilter
+
+The registration workflow typically consists of:
+
+1. Reading fixed and moving images
+2. Loading or creating a parameter map that defines the registration strategy
+3. Executing the registration to obtain a registered image and transform parameters
+4. Optionally applying the transform to other images using Transformix
+
+Parameter maps can be loaded from text files, created using default presets, or customized programmatically. The elastix parameter files use a simple text format that allows fine-grained control over the registration process.
+
+Code
+----
+
+Registration (elx)
+^^^^^^^^^^^^^^^^^^
+
+.. tabs::
+
+  .. tab:: C++
+
+    .. literalinclude:: ../../Examples/Elastix/elx.cxx
+       :language: c++
+       :lines: 1-
+
+  .. tab:: Python
+
+    .. literalinclude:: ../../Examples/Elastix/elx.py
+       :language: python
+       :lines: 1-
+
+Transformation (tfx)
+^^^^^^^^^^^^^^^^^^^^
+
+.. tabs::
+
+  .. tab:: C++
+
+    .. literalinclude:: ../../Examples/Elastix/tfx.cxx
+       :language: c++
+       :lines: 1-
+
+  .. tab:: Python
+
+    .. literalinclude:: ../../Examples/Elastix/tfx.py
+       :language: python
+       :lines: 1-
+
+See Also
+--------
+
+* `elastix documentation <https://elastix.lumc.nl/>`_
+* `elastix parameter zoo <https://lkeb.ml/modelzoo/>`_ - Pre-configured parameter files for various registration tasks
+* `SimpleITK ElastixImageFilter <https://simpleitk.org/doxygen/latest/html/classitk_1_1simple_1_1ElastixImageFilter.html>`_
+* `SimpleITK TransformixImageFilter <https://simpleitk.org/doxygen/latest/html/classitk_1_1simple_1_1TransformixImageFilter.html>`_

--- a/Examples/Elastix/elx.py
+++ b/Examples/Elastix/elx.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+# This example demonstrates the usage of the SimpleElastix framework
+# for image registration using the ElastixImageFilter.
+
+import SimpleITK as sitk
+import sys
+
+if len(sys.argv) < 6:
+    print(
+        f"Usage: {sys.argv[0]} <fixedImage> <movingImage> <parameterFile> <outputImage> <outputParameterFile>"
+    )
+    sys.exit(1)
+
+# Instantiate SimpleElastix
+elastix_image_filter = sitk.ElastixImageFilter()
+
+# Read input images
+fixed_image = sitk.ReadImage(sys.argv[1])
+moving_image = sitk.ReadImage(sys.argv[2])
+
+# Set images
+elastix_image_filter.SetFixedImage(fixed_image)
+elastix_image_filter.SetMovingImage(moving_image)
+
+# Read and set parameter map
+parameter_map = sitk.ReadParameterFile(sys.argv[3])
+elastix_image_filter.SetParameterMap(parameter_map)
+
+# Enable logging to console
+elastix_image_filter.LogToConsoleOn()
+
+# Run registration
+elastix_image_filter.Execute()
+
+# Write result image
+sitk.WriteImage(elastix_image_filter.GetResultImage(), sys.argv[4])
+
+# Write parameter file
+# This example only supports one parameter map and one transform parameter map
+sitk.WriteParameterFile(elastix_image_filter.GetTransformParameterMaps()[0], sys.argv[5])

--- a/Examples/Elastix/tfx.py
+++ b/Examples/Elastix/tfx.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+import SimpleITK as sitk
+import sys
+
+if len(sys.argv) < 4:
+    print(f"Usage: {sys.argv[0]} <inputImage> <parameterFile> <outputImage>")
+    sys.exit(1)
+
+# Instantiate transformix
+transformix_image_filter = sitk.TransformixImageFilter()
+
+# Enable logging to console
+transformix_image_filter.LogToConsoleOn()
+
+# Read input image
+moving_image = sitk.ReadImage(sys.argv[1])
+transformix_image_filter.SetMovingImage(moving_image)
+
+# Read and set transform parameter map
+transform_parameter_map = sitk.ReadParameterFile(sys.argv[2])
+transformix_image_filter.SetTransformParameterMap(transform_parameter_map)
+
+# Run warp
+transformix_image_filter.Execute()
+
+# Write result image
+sitk.WriteImage(transformix_image_filter.GetResultImage(), sys.argv[3])

--- a/Examples/index.rst
+++ b/Examples/index.rst
@@ -18,6 +18,7 @@ Examples
   link_DicomSeriesReadModifyWrite_docs
   link_DicomSeriesFromArray_docs
   link_DicomConvert_docs
+  link_Elastix_docs
   link_FastMarchingSegmentation_docs
   link_FilterProgressReporting_docs
   link_ImageGridManipulation_docs

--- a/docs/source/link_Elastix_docs.rst
+++ b/docs/source/link_Elastix_docs.rst
@@ -1,0 +1,1 @@
+.. include:: ../../Examples/Elastix/Documentation.rst


### PR DESCRIPTION
This PR adds Python versions of the Elastix registration and Transformix transformation examples, along with comprehensive documentation.

## Changes

- **Python Examples**: Created `elx.py` and `tfx.py` as Python equivalents to the existing C++ examples
- **Test Integration**: Added CMake test cases for both Python examples with proper dependencies
- **Documentation**: Added `Documentation.rst` with side-by-side C++/Python code tabs, highlighting the elastix parameter zoo for turnkey registration scenarios
- **Examples Index**: Updated to include link to Elastix documentation

The examples demonstrate:
- `ElastixImageFilter` for deformable image registration
- `TransformixImageFilter` for applying transformations
- Using parameter files from the elastix parameter zoo

## Testing

Added Python test cases in `Examples/Elastix/CMakeLists.txt`:
- `Python.Example.Elastix` - Tests registration with `elx.py`
- `Python.Example.Transformix` - Tests transformation with `tfx.py` (depends on Elastix output)

Both tests use the brain slice images and `par0001.txt` parameter file with 40-pixel tolerance.