### PR TITLE
ENH: Add C#, Java, Lua, and R examples for Elastix

### DIFF
--- a/Examples/Elastix/CMakeLists.txt
+++ b/Examples/Elastix/CMakeLists.txt
@@ -69,3 +69,123 @@ set_tests_properties(
     DEPENDS
       "Python.Example.Elastix"
 )
+
+# Java tests
+sitk_add_java_test(
+  Example.Elastix
+  "${CMAKE_CURRENT_SOURCE_DIR}/elx.java"
+  DATA{${SimpleITK_DATA_ROOT}/Input/BrainProtonDensitySliceBorder20.png}
+  DATA{${SimpleITK_DATA_ROOT}/Input/BrainProtonDensitySliceShifted13x17y.png}
+  ${CMAKE_CURRENT_SOURCE_DIR}/par0001.txt
+  ${SimpleITK_TEST_OUTPUT_DIR}/Java.Example.elx.nii
+  ${SimpleITK_TEST_OUTPUT_DIR}/Java.Example.elx.TransformParameters.txt
+)
+
+sitk_add_java_test(
+  Example.Transformix
+  "${CMAKE_CURRENT_SOURCE_DIR}/tfx.java"
+  DATA{${SimpleITK_DATA_ROOT}/Input/BrainProtonDensitySliceShifted13x17y.png}
+  ${SimpleITK_TEST_OUTPUT_DIR}/Java.Example.elx.TransformParameters.txt
+  ${SimpleITK_TEST_OUTPUT_DIR}/Java.Example.tfx.nii
+  IMAGE_COMPARE
+    ${SimpleITK_TEST_OUTPUT_DIR}/Java.Example.elx.nii
+    ${SimpleITK_TEST_OUTPUT_DIR}/Java.Example.tfx.nii
+    40
+)
+
+set_tests_properties(
+  Java.Example.Transformix
+  PROPERTIES
+    DEPENDS
+      "Java.Example.Elastix"
+)
+
+# CSharp tests
+sitk_add_csharp_test(
+  Example.Elastix
+  "${CMAKE_CURRENT_SOURCE_DIR}/elx.cs"
+  DATA{${SimpleITK_DATA_ROOT}/Input/BrainProtonDensitySliceBorder20.png}
+  DATA{${SimpleITK_DATA_ROOT}/Input/BrainProtonDensitySliceShifted13x17y.png}
+  ${CMAKE_CURRENT_SOURCE_DIR}/par0001.txt
+  ${SimpleITK_TEST_OUTPUT_DIR}/CSharp.Example.elx.nii
+  ${SimpleITK_TEST_OUTPUT_DIR}/CSharp.Example.elx.TransformParameters.txt
+)
+
+sitk_add_csharp_test(
+  Example.Transformix
+  "${CMAKE_CURRENT_SOURCE_DIR}/tfx.cs"
+  DATA{${SimpleITK_DATA_ROOT}/Input/BrainProtonDensitySliceShifted13x17y.png}
+  ${SimpleITK_TEST_OUTPUT_DIR}/CSharp.Example.elx.TransformParameters.txt
+  ${SimpleITK_TEST_OUTPUT_DIR}/CSharp.Example.tfx.nii
+  IMAGE_COMPARE
+    ${SimpleITK_TEST_OUTPUT_DIR}/CSharp.Example.elx.nii
+    ${SimpleITK_TEST_OUTPUT_DIR}/CSharp.Example.tfx.nii
+    40
+)
+
+set_tests_properties(
+  CSharp.Example.Transformix
+  PROPERTIES
+    DEPENDS
+      "CSharp.Example.Elastix"
+)
+
+# Lua tests
+sitk_add_lua_test(
+  Example.Elastix
+  "${CMAKE_CURRENT_SOURCE_DIR}/elx.lua"
+  DATA{${SimpleITK_DATA_ROOT}/Input/BrainProtonDensitySliceBorder20.png}
+  DATA{${SimpleITK_DATA_ROOT}/Input/BrainProtonDensitySliceShifted13x17y.png}
+  ${CMAKE_CURRENT_SOURCE_DIR}/par0001.txt
+  ${SimpleITK_TEST_OUTPUT_DIR}/Lua.Example.elx.nii
+  ${SimpleITK_TEST_OUTPUT_DIR}/Lua.Example.elx.TransformParameters.txt
+)
+
+sitk_add_lua_test(
+  Example.Transformix
+  "${CMAKE_CURRENT_SOURCE_DIR}/tfx.lua"
+  DATA{${SimpleITK_DATA_ROOT}/Input/BrainProtonDensitySliceShifted13x17y.png}
+  ${SimpleITK_TEST_OUTPUT_DIR}/Lua.Example.elx.TransformParameters.txt
+  ${SimpleITK_TEST_OUTPUT_DIR}/Lua.Example.tfx.nii
+  IMAGE_COMPARE
+    ${SimpleITK_TEST_OUTPUT_DIR}/Lua.Example.elx.nii
+    ${SimpleITK_TEST_OUTPUT_DIR}/Lua.Example.tfx.nii
+    40
+)
+
+set_tests_properties(
+  Lua.Example.Transformix
+  PROPERTIES
+    DEPENDS
+      "Lua.Example.Elastix"
+)
+
+# R tests
+sitk_add_r_test(
+  Example.Elastix
+  "${CMAKE_CURRENT_SOURCE_DIR}/elx.R"
+  DATA{${SimpleITK_DATA_ROOT}/Input/BrainProtonDensitySliceBorder20.png}
+  DATA{${SimpleITK_DATA_ROOT}/Input/BrainProtonDensitySliceShifted13x17y.png}
+  ${CMAKE_CURRENT_SOURCE_DIR}/par0001.txt
+  ${SimpleITK_TEST_OUTPUT_DIR}/R.Example.elx.nii
+  ${SimpleITK_TEST_OUTPUT_DIR}/R.Example.elx.TransformParameters.txt
+)
+
+sitk_add_r_test(
+  Example.Transformix
+  "${CMAKE_CURRENT_SOURCE_DIR}/tfx.R"
+  DATA{${SimpleITK_DATA_ROOT}/Input/BrainProtonDensitySliceShifted13x17y.png}
+  ${SimpleITK_TEST_OUTPUT_DIR}/R.Example.elx.TransformParameters.txt
+  ${SimpleITK_TEST_OUTPUT_DIR}/R.Example.tfx.nii
+  IMAGE_COMPARE
+    ${SimpleITK_TEST_OUTPUT_DIR}/R.Example.elx.nii
+    ${SimpleITK_TEST_OUTPUT_DIR}/R.Example.tfx.nii
+    40
+)
+
+set_tests_properties(
+  R.Example.Transformix
+  PROPERTIES
+    DEPENDS
+      "R.Example.Elastix"
+)

--- a/Examples/Elastix/CMakeLists.txt
+++ b/Examples/Elastix/CMakeLists.txt
@@ -63,12 +63,14 @@ sitk_add_python_test(
     40
 )
 
-set_tests_properties(
-  Python.Example.Transformix
-  PROPERTIES
-    DEPENDS
-      "Python.Example.Elastix"
-)
+if(WRAP_PYTHON)
+  set_tests_properties(
+    Python.Example.Transformix
+    PROPERTIES
+      DEPENDS
+        "Python.Example.Elastix"
+  )
+endif()
 
 # Java tests
 sitk_add_java_test(
@@ -93,12 +95,14 @@ sitk_add_java_test(
     40
 )
 
-set_tests_properties(
-  Java.Example.Transformix
-  PROPERTIES
-    DEPENDS
-      "Java.Example.Elastix"
-)
+if(WRAP_JAVA)
+  set_tests_properties(
+    Java.Example.Transformix
+    PROPERTIES
+      DEPENDS
+        "Java.Example.Elastix"
+  )
+endif()
 
 # CSharp tests
 sitk_add_csharp_test(
@@ -123,12 +127,14 @@ sitk_add_csharp_test(
     40
 )
 
-set_tests_properties(
-  CSharp.Example.Transformix
-  PROPERTIES
-    DEPENDS
-      "CSharp.Example.Elastix"
-)
+if(WRAP_CSHARP)
+  set_tests_properties(
+    CSharp.Example.Transformix
+    PROPERTIES
+      DEPENDS
+        "CSharp.Example.Elastix"
+  )
+endif()
 
 # Lua tests
 sitk_add_lua_test(
@@ -153,12 +159,14 @@ sitk_add_lua_test(
     40
 )
 
-set_tests_properties(
-  Lua.Example.Transformix
-  PROPERTIES
-    DEPENDS
-      "Lua.Example.Elastix"
-)
+if(WRAP_LUA)
+  set_tests_properties(
+    Lua.Example.Transformix
+    PROPERTIES
+      DEPENDS
+        "Lua.Example.Elastix"
+  )
+endif()
 
 # R tests
 sitk_add_r_test(
@@ -183,9 +191,11 @@ sitk_add_r_test(
     40
 )
 
-set_tests_properties(
-  R.Example.Transformix
-  PROPERTIES
-    DEPENDS
-      "R.Example.Elastix"
-)
+if(WRAP_R)
+  set_tests_properties(
+    R.Example.Transformix
+    PROPERTIES
+      DEPENDS
+        "R.Example.Elastix"
+  )
+endif()

--- a/Examples/Elastix/Documentation.rst
+++ b/Examples/Elastix/Documentation.rst
@@ -36,11 +36,29 @@ Registration (elx)
 
 .. tabs::
 
+  .. tab:: C#
+
+    .. literalinclude:: ../../Examples/Elastix/elx.cs
+       :language: c#
+       :lines: 18-
+
   .. tab:: C++
 
     .. literalinclude:: ../../Examples/Elastix/elx.cxx
        :language: c++
        :lines: 1-
+
+  .. tab:: Java
+
+    .. literalinclude:: ../../Examples/Elastix/elx.java
+       :language: java
+       :lines: 18-
+
+  .. tab:: Lua
+
+    .. literalinclude:: ../../Examples/Elastix/elx.lua
+       :language: lua
+       :lines: 18-
 
   .. tab:: Python
 
@@ -48,10 +66,22 @@ Registration (elx)
        :language: python
        :lines: 1-
 
+  .. tab:: R
+
+    .. literalinclude:: ../../Examples/Elastix/elx.R
+       :language: r
+       :lines: 18-
+
 Transformation (tfx)
 ^^^^^^^^^^^^^^^^^^^^
 
 .. tabs::
+
+  .. tab:: C#
+
+    .. literalinclude:: ../../Examples/Elastix/tfx.cs
+       :language: c#
+       :lines: 18-
 
   .. tab:: C++
 
@@ -59,11 +89,29 @@ Transformation (tfx)
        :language: c++
        :lines: 1-
 
+  .. tab:: Java
+
+    .. literalinclude:: ../../Examples/Elastix/tfx.java
+       :language: java
+       :lines: 18-
+
+  .. tab:: Lua
+
+    .. literalinclude:: ../../Examples/Elastix/tfx.lua
+       :language: lua
+       :lines: 18-
+
   .. tab:: Python
 
     .. literalinclude:: ../../Examples/Elastix/tfx.py
        :language: python
        :lines: 1-
+
+  .. tab:: R
+
+    .. literalinclude:: ../../Examples/Elastix/tfx.R
+       :language: r
+       :lines: 18-
 
 See Also
 --------

--- a/Examples/Elastix/elx.R
+++ b/Examples/Elastix/elx.R
@@ -1,0 +1,43 @@
+#=========================================================================
+#
+#  Copyright NumFOCUS
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#=========================================================================
+
+library(SimpleITK)
+
+args <- commandArgs(TRUE)
+
+if (length(args) < 5) {
+    stop("Usage: elx <fixedImage> <movingImage> <parameterFile> <outputImage> <outputParameterFile>")
+}
+
+# Instantiate SimpleElastix
+elastixImageFilter <- ElastixImageFilter()
+
+# Read input
+elastixImageFilter$SetFixedImage(ReadImage(args[1]))
+elastixImageFilter$SetMovingImage(ReadImage(args[2]))
+elastixImageFilter$SetParameterMap(elastixImageFilter$ReadParameterFile(args[3]))
+elastixImageFilter$LogToConsoleOn()
+
+# Run registration
+output_image <- elastixImageFilter$Execute()
+
+# Write result image
+WriteImage(output_image, args[4])
+
+# Write parameter file. This example only supports one parameter map and one transform parameter map.
+elastixImageFilter$WriteParameterFile(elastixImageFilter$GetTransformParameterMap(0L), args[5])

--- a/Examples/Elastix/elx.cs
+++ b/Examples/Elastix/elx.cs
@@ -1,0 +1,53 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+using System;
+using itk.simple;
+
+namespace itk.simple.examples
+{
+    class Elastix
+    {
+        static void Main(string[] args)
+        {
+            if (args.Length < 5)
+            {
+                Console.WriteLine("Usage: elx <fixedImage> <movingImage> <parameterFile> <outputImage> <outputParameterFile>");
+                return;
+            }
+
+            // Instantiate SimpleElastix
+            ElastixImageFilter elastixImageFilter = new ElastixImageFilter();
+
+            // Read input
+            elastixImageFilter.SetFixedImage(SimpleITK.ReadImage(args[0]));
+            elastixImageFilter.SetMovingImage(SimpleITK.ReadImage(args[1]));
+            elastixImageFilter.SetParameterMap(SimpleITK.ReadParameterFile(args[2]));
+            elastixImageFilter.LogToConsoleOn();
+
+            // Run registration
+            elastixImageFilter.Execute();
+
+            // Write result image
+            SimpleITK.WriteImage(elastixImageFilter.GetResultImage(), args[3]);
+
+            // Write parameter file. This example only supports one parameter map and one transform parameter map.
+            SimpleITK.WriteParameterFile(elastixImageFilter.GetTransformParameterMaps()[0], args[4]);
+        }
+    }
+}

--- a/Examples/Elastix/elx.java
+++ b/Examples/Elastix/elx.java
@@ -1,0 +1,46 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+import org.itk.simple.*;
+
+public class elx {
+    public static void main(String[] args) {
+        if (args.length < 5) {
+            System.out.println("Usage: elx <fixedImage> <movingImage> <parameterFile> <outputImage> <outputParameterFile>");
+            System.exit(1);
+        }
+
+        // Instantiate SimpleElastix
+        ElastixImageFilter elastixImageFilter = new ElastixImageFilter();
+
+        // Read input
+        elastixImageFilter.setFixedImage(SimpleITK.readImage(args[0]));
+        elastixImageFilter.setMovingImage(SimpleITK.readImage(args[1]));
+        elastixImageFilter.setParameterMap(SimpleITK.readParameterFile(args[2]));
+        elastixImageFilter.logToConsoleOn();
+
+        // Run registration
+        elastixImageFilter.execute();
+
+        // Write result image
+        SimpleITK.writeImage(elastixImageFilter.getResultImage(), args[3]);
+
+        // Write parameter file. This example only supports one parameter map and one transform parameter map.
+        SimpleITK.writeParameterFile(elastixImageFilter.getTransformParameterMaps().get(0), args[4]);
+    }
+}

--- a/Examples/Elastix/elx.lua
+++ b/Examples/Elastix/elx.lua
@@ -1,0 +1,43 @@
+--=========================================================================
+--
+--  Copyright NumFOCUS
+--
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0.txt
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--
+--=========================================================================
+
+require "SimpleITK"
+
+if #arg < 5 then
+    print("Usage: elx <fixedImage> <movingImage> <parameterFile> <outputImage> <outputParameterFile>")
+    os.exit(1)
+end
+
+-- Instantiate SimpleElastix
+elastixImageFilter = SimpleITK.ElastixImageFilter()
+
+-- Read input
+elastixImageFilter:SetFixedImage(SimpleITK.ReadImage(arg[1]))
+elastixImageFilter:SetMovingImage(SimpleITK.ReadImage(arg[2]))
+elastixImageFilter:SetParameterMap(SimpleITK.ReadParameterFile(arg[3]))
+elastixImageFilter:LogToConsoleOn()
+
+-- Run registration
+elastixImageFilter:Execute()
+
+-- Write result image
+SimpleITK.WriteImage(elastixImageFilter:GetResultImage(), arg[4])
+
+-- Write parameter file. This example only supports one parameter map and one transform parameter map.
+parameterMaps = elastixImageFilter:GetTransformParameterMaps()
+SimpleITK.WriteParameterFile(parameterMaps[0], arg[5])

--- a/Examples/Elastix/tfx.R
+++ b/Examples/Elastix/tfx.R
@@ -1,0 +1,39 @@
+#=========================================================================
+#
+#  Copyright NumFOCUS
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#=========================================================================
+
+library(SimpleITK)
+
+args <- commandArgs(TRUE)
+
+if (length(args) < 3) {
+    stop("Usage: tfx <inputImage> <parameterFile> <outputImage>")
+}
+
+# Instantiate transformix
+transformixImageFilter <- TransformixImageFilter()
+transformixImageFilter$LogToConsoleOn()
+
+# Read input
+transformixImageFilter$SetMovingImage(ReadImage(args[1]))
+transformixImageFilter$SetTransformParameterMap(transformixImageFilter$ReadParameterFile(args[2]))
+
+# Run warp
+resampled_image <- transformixImageFilter$Execute()
+
+# Write result image
+WriteImage(resampled_image, args[3])

--- a/Examples/Elastix/tfx.cs
+++ b/Examples/Elastix/tfx.cs
@@ -1,0 +1,49 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+using System;
+using itk.simple;
+
+namespace itk.simple.examples
+{
+    class Transformix
+    {
+        static void Main(string[] args)
+        {
+            if (args.Length < 3)
+            {
+                Console.WriteLine("Usage: tfx <inputImage> <parameterFile> <outputImage>");
+                return;
+            }
+
+            // Instantiate transformix
+            TransformixImageFilter transformixImageFilter = new TransformixImageFilter();
+            transformixImageFilter.LogToConsoleOn();
+
+            // Read input
+            transformixImageFilter.SetMovingImage(SimpleITK.ReadImage(args[0]));
+            transformixImageFilter.SetTransformParameterMap(SimpleITK.ReadParameterFile(args[1]));
+
+            // Run warp
+            transformixImageFilter.Execute();
+
+            // Write result image
+            SimpleITK.WriteImage(transformixImageFilter.GetResultImage(), args[2]);
+        }
+    }
+}

--- a/Examples/Elastix/tfx.java
+++ b/Examples/Elastix/tfx.java
@@ -1,0 +1,42 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+import org.itk.simple.*;
+
+public class tfx {
+    public static void main(String[] args) {
+        if (args.length < 3) {
+            System.out.println("Usage: tfx <inputImage> <parameterFile> <outputImage>");
+            System.exit(1);
+        }
+
+        // Instantiate transformix
+        TransformixImageFilter transformixImageFilter = new TransformixImageFilter();
+        transformixImageFilter.logToConsoleOn();
+
+        // Read input
+        transformixImageFilter.setMovingImage(SimpleITK.readImage(args[0]));
+        transformixImageFilter.setTransformParameterMap(SimpleITK.readParameterFile(args[1]));
+
+        // Run warp
+        transformixImageFilter.execute();
+
+        // Write result image
+        SimpleITK.writeImage(transformixImageFilter.getResultImage(), args[2]);
+    }
+}

--- a/Examples/Elastix/tfx.lua
+++ b/Examples/Elastix/tfx.lua
@@ -1,0 +1,38 @@
+--=========================================================================
+--
+--  Copyright NumFOCUS
+--
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--
+--         http://www.apache.org/licenses/LICENSE-2.0.txt
+--
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--
+--=========================================================================
+
+require "SimpleITK"
+
+if #arg < 3 then
+    print("Usage: tfx <inputImage> <parameterFile> <outputImage>")
+    os.exit(1)
+end
+
+-- Instantiate transformix
+transformixImageFilter = SimpleITK.TransformixImageFilter()
+transformixImageFilter:LogToConsoleOn()
+
+-- Read input
+transformixImageFilter:SetMovingImage(SimpleITK.ReadImage(arg[1]))
+transformixImageFilter:SetTransformParameterMap(SimpleITK.ReadParameterFile(arg[2]))
+
+-- Run warp
+transformixImageFilter:Execute()
+
+-- Write result image
+SimpleITK.WriteImage(transformixImageFilter:GetResultImage(), arg[3])


### PR DESCRIPTION
Add language bindings for Elastix registration (`elx`) and Transformix transformation (`tfx`) examples in C#, Java, Lua, and R, following the same patterns as other SimpleITK examples.

## Changes
- `Examples/Elastix/CMakeLists.txt`: Add CTest entries for Java, CSharp, Lua, and R (Elastix and Transformix tests for each, with appropriate `DEPENDS` ordering)
- `Examples/Elastix/elx.cs`, `tfx.cs`: C# examples
- `Examples/Elastix/elx.java`, `tfx.java`: Java examples
- `Examples/Elastix/elx.lua`, `tfx.lua`: Lua examples
- `Examples/Elastix/elx.R`, `tfx.R`: R examples
- `Examples/Elastix/Documentation.rst`: Updated documentation with tabs for all languages

This builds on the previously merged Python examples PR.