### PR TITLE
BUG: Fix Elastix SuperBuild dep when using system ITK

### DIFF
--- a/SuperBuild/External_Elastix.cmake
+++ b/SuperBuild/External_Elastix.cmake
@@ -1,7 +1,10 @@
 set(proj Elastix)
 
 # Set dependency list
-set(${proj}_DEPENDENCIES "ITK")
+set(${proj}_DEPENDENCIES "")
+if(NOT SimpleITK_USE_SYSTEM_ITK)
+  list(APPEND ${proj}_DEPENDENCIES "ITK")
+endif()
 
 file(
   WRITE


### PR DESCRIPTION
When `SimpleITK_USE_SYSTEM_ITK` is ON, the `ITK` ExternalProject target is never created. Unconditionally listing `ITK` as a dependency of the Elastix ExternalProject causes a CMake configuration error:

```
CMake Error at .../ExternalProject.cmake:3671 (get_property):
  get_property could not find TARGET ITK.
```

Fix by only adding `ITK` to the Elastix dependency list when not using the system ITK.