### PR TITLE
ENH: Update CMake version to 3.31.0

### DIFF
--- a/CMake/sitkCMakeInit.cmake
+++ b/CMake/sitkCMakeInit.cmake
@@ -1,5 +1,5 @@
 set(SITK_CMAKE_MINIMUM_REQUIRED_VERSION "3.23.0")
-set(SITK_CMAKE_POLICY_VERSION "3.23")
+set(SITK_CMAKE_POLICY_VERSION "3.31.0")
 
 # cache_list_append( <cache list name> [<element> ...])
 #

--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -1,14 +1,5 @@
-cmake_minimum_required(VERSION 3.16.3...3.20)
+cmake_minimum_required(VERSION 3.23.0...3.31.0)
 project(SimpleITKExamples)
-
-foreach(
-  p
-  CMP0156 # De-duplicate libraries on link lines based on linker capabilities.
-)
-  if(POLICY ${p})
-    cmake_policy(SET ${p} NEW)
-  endif()
-endforeach()
 
 if(NOT CMAKE_PROJECT_NAME STREQUAL "SimpleITK")
   find_package(SimpleITK REQUIRED)

--- a/Examples/CppCMake/Source/CMakeLists.txt
+++ b/Examples/CppCMake/Source/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16.3)
+cmake_minimum_required(VERSION 3.23.0...3.31.0)
 
 project(sitk_example)
 

--- a/SuperBuild/swig_configure_step.cmake.in
+++ b/SuperBuild/swig_configure_step.cmake.in
@@ -4,7 +4,7 @@
 # environment. If there is a problem with them in the future they can
 # be addressed in CMake with the same structure.
 
-cmake_minimum_required(VERSION 3.16.3...3.26.0)
+cmake_minimum_required(VERSION 3.23.0...3.31.0)
 
 set(ENV{CC} "@CMAKE_C_COMPILER_LAUNCHER@ @CMAKE_C_COMPILER@")
 set(ENV{CFLAGS} "@REQUIRED_C_FLAGS@ @CMAKE_C_FLAGS@ @CMAKE_C_FLAGS_RELEASE@")

--- a/Wrapping/Python/scikit-build-Packaging.cmake
+++ b/Wrapping/Python/scikit-build-Packaging.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.26)
+cmake_minimum_required(VERSION 3.26...3.31.0)
 
 project(SimpleITKInternalPythonPackage NONE)
 

--- a/docs/images/CMakeLists.txt
+++ b/docs/images/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16.3..3.30.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.16.3..3.31.0 FATAL_ERROR)
 
 project(SimpleITKSphinx-Data LANGUAGES NONE)
 


### PR DESCRIPTION
Update `cmake_minimum_required` version ranges and policy version to 3.31.0 across the project.

**Changes:**
- Update `SITK_CMAKE_POLICY_VERSION` from 3.23 to 3.31.0
- Update Examples `cmake_minimum_required` to 3.23.0...3.31.0 and remove manual CMP0156 policy setting (now handled by version range)
- Update Python packaging `cmake_minimum_required` to 3.26...3.31.0
- Update CppCMake example to 3.23.0...3.31.0
- Update docs/images to 3.16.3...3.31.0