### PR TITLE
FIX: Correct build names to match enabled languages

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -59,7 +59,7 @@ jobs:
               SimpleITK_EXPLICIT_INSTANTIATION:BOOL=ON
               SimpleITK_USE_SYSTEM_SWIG:BOOL=OFF
           - os: mac-arm64
-            name: mac-arm64-python-elastix-python
+            name: mac-arm64-elastix-python
             cmake-build-type: "Release"
             cmake-generator: "Ninja"
             use-superbuild: false
@@ -67,7 +67,7 @@ jobs:
               WRAP_PYTHON:BOOL=ON
               SimpleITK_USE_ELASTIX:BOOL=ON
           - os: ubuntu-24.04
-            name: linux-x64-superbuild-elastix-python
+            name: linux-x64-superbuild-elastix-python-r
             cmake-build-type: "Release"
             cmake-generator: "Ninja"
             cmake_build_parallel_level: 6
@@ -104,7 +104,7 @@ jobs:
               CMAKE_C_COMPILER_LAUNCHER:STRING=ccache
               CMAKE_CXX_COMPILER_LAUNCHER:STRING=ccache
           - os: macos-15
-            name: macos-x86_64-python-java
+            name: macos-x86_64-python-r
             cmake-build-type: "Release"
             cmake-generator: "Ninja"
             cmake_osx_architectures: "x86_64"


### PR DESCRIPTION
Fixes mismatches between CI build names and their enabled language wrappers.

**Changes:**
- `mac-arm64-python-elastix-python` → `mac-arm64-elastix-python` (removed duplicate)
- `linux-x64-superbuild-elastix-python` → `linux-x64-superbuild-elastix-python-r` (added missing R)
- `macos-x86_64-python-java` → `macos-x86_64-python-r` (corrected java to r)

**Language Coverage:**

| Build Configuration | Python | Java | R | C# | Tcl | Ruby | Elastix |
|---------------------|:------:|:----:|:--:|:--:|:---:|:----:|:-------:|
| mac-arm64-superbuild-python-java-tcl-ruby | ✓ | ✓ | | | ✓ | ✓ | |
| mac-arm64-elastix-python | ✓ | | | | | | ✓ |
| linux-x64-superbuild-elastix-python-r | ✓ | | ✓ | | | | ✓ |
| linux-arm-gold-linker-python-java | ✓ | ✓ | | | | | |
| linux-arm-itk-build-python-java | ✓ | ✓ | | | | | |
| macos-x86_64-python-r | ✓ | | ✓ | | | | |
| windows-v142-x64-python-java-csharp | ✓ | ✓ | | ✓ | | | |