### PR TITLE
Simplify wrapping logic by setting WRAP_<LANGUAGE> in each wrapper

### DIFF
--- a/CMake/sitkAddTest.cmake
+++ b/CMake/sitkAddTest.cmake
@@ -96,7 +96,7 @@ endfunction()
 # This is a function which set up the environment for executing python examples and tests
 #
 function(sitk_add_python_test name)
-  if(NOT WRAP_PYTHON AND NOT CMAKE_PROJECT_NAME STREQUAL "SimpleITK_Python")
+  if(NOT WRAP_PYTHON)
     return()
   endif()
 
@@ -141,7 +141,7 @@ endfunction()
 # This is a function which set up the environment for executing python examples and tests
 #
 function(sitk_add_pytest_test name)
-  if(NOT WRAP_PYTHON AND NOT CMAKE_PROJECT_NAME STREQUAL "SimpleITK_Python")
+  if(NOT WRAP_PYTHON)
     return()
   endif()
 
@@ -192,7 +192,7 @@ endfunction()
 # This is a function which set up the enviroment for executing lua examples and tests
 #
 function(sitk_add_lua_test name)
-  if(NOT WRAP_LUA AND NOT CMAKE_PROJECT_NAME STREQUAL "SimpleITK_Lua")
+  if(NOT WRAP_LUA)
     return()
   endif()
 
@@ -235,7 +235,7 @@ endfunction()
 # This is a function which set up the enviroment for executing ruby examples and tests
 #
 function(sitk_add_ruby_test name)
-  if(NOT WRAP_RUBY AND NOT CMAKE_PROJECT_NAME STREQUAL "SimpleITK_Ruby")
+  if(NOT WRAP_RUBY)
     return()
   endif()
 
@@ -278,7 +278,7 @@ endfunction()
 # This is a function which set up the enviroment for executing TCL examples and tests
 #
 function(sitk_add_tcl_test name)
-  if(NOT WRAP_TCL AND NOT CMAKE_PROJECT_NAME STREQUAL "SimpleITK_Tcl")
+  if(NOT WRAP_TCL)
     return()
   endif()
 
@@ -313,7 +313,7 @@ endfunction()
 # This is a function which set up the enviroment for executing JAVA examples and tests
 #
 function(sitk_add_java_test name java_file)
-  if(NOT WRAP_JAVA AND NOT CMAKE_PROJECT_NAME STREQUAL "SimpleITK_Java")
+  if(NOT WRAP_JAVA)
     return()
   endif()
 
@@ -383,7 +383,7 @@ endfunction()
 # This is a function which set up the enviroment for executing R examples and tests
 #
 function(sitk_add_r_test name)
-  if(NOT WRAP_R AND NOT CMAKE_PROJECT_NAME STREQUAL "SimpleITK_R")
+  if(NOT WRAP_R)
     return()
   endif()
 
@@ -438,7 +438,7 @@ endfunction()
 # enviroment for executing CSharp examples and tests.
 #
 function(sitk_add_csharp_test name csharp_file)
-  if(NOT WRAP_CSHARP AND NOT CMAKE_PROJECT_NAME STREQUAL "SimpleITK_CSharp")
+  if(NOT WRAP_CSHARP)
     return()
   endif()
 

--- a/Wrapping/CSharp/CMakeLists.txt
+++ b/Wrapping/CSharp/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(
 )
 
 project(SimpleITK_CSharp)
+set(WRAP_CSHARP ON)
 
 include(../../CMake/sitkProjectLanguageCommon.cmake NO_POLICY_SCOPE)
 

--- a/Wrapping/Java/CMakeLists.txt
+++ b/Wrapping/Java/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(
 )
 
 project(SimpleITK_Java)
+set(WRAP_JAVA ON)
 
 include(../../CMake/sitkProjectLanguageCommon.cmake NO_POLICY_SCOPE)
 

--- a/Wrapping/Lua/CMakeLists.txt
+++ b/Wrapping/Lua/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(
 )
 
 project(SimpleITK_Lua)
+set(WRAP_LUA ON)
 
 include(../../CMake/sitkProjectLanguageCommon.cmake NO_POLICY_SCOPE)
 

--- a/Wrapping/Python/CMakeLists.txt
+++ b/Wrapping/Python/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(
 )
 
 project(SimpleITK_Python)
+set(WRAP_PYTHON ON)
 
 include(../../CMake/sitkProjectLanguageCommon.cmake NO_POLICY_SCOPE)
 

--- a/Wrapping/R/CMakeLists.txt
+++ b/Wrapping/R/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(
 )
 
 project(SimpleITK_R)
+set(WRAP_R ON)
 
 include(../../CMake/sitkProjectLanguageCommon.cmake NO_POLICY_SCOPE)
 

--- a/Wrapping/Ruby/CMakeLists.txt
+++ b/Wrapping/Ruby/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(
 )
 
 project(SimpleITK_Ruby)
+set(WRAP_RUBY ON)
 
 include(../../CMake/sitkProjectLanguageCommon.cmake NO_POLICY_SCOPE)
 

--- a/Wrapping/Tcl/CMakeLists.txt
+++ b/Wrapping/Tcl/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(
 )
 
 project(SimpleITK_TCL)
+set(WRAP_TCL ON)
 
 include(../../CMake/sitkProjectLanguageCommon.cmake NO_POLICY_SCOPE)
 


### PR DESCRIPTION
Add `set(WRAP_<LANGUAGE> ON)` to all language wrapper `CMakeLists.txt` files and simplify the conditional checks in `sitk_add_<language>_test` functions to only check `WRAP_<LANGUAGE>` instead of both `WRAP_<LANGUAGE>` and `CMAKE_PROJECT_NAME`.

This fixes test failures on the dashboard when a wrapping directory is built as a standalone project.

### Changes

- Add `set(WRAP_<LANGUAGE> ON)` to:
  - `Wrapping/CSharp/CMakeLists.txt`
  - `Wrapping/Java/CMakeLists.txt`
  - `Wrapping/Lua/CMakeLists.txt`
  - `Wrapping/R/CMakeLists.txt`
  - `Wrapping/Ruby/CMakeLists.txt`
  - `Wrapping/Tcl/CMakeLists.txt`
  - (`Wrapping/Python/CMakeLists.txt` already had this)

- Simplify `CMake/sitkAddTest.cmake`: remove redundant `CMAKE_PROJECT_NAME` checks from `sitk_add_python_test`, `sitk_add_pytest_test`, `sitk_add_lua_test`, `sitk_add_ruby_test`, `sitk_add_tcl_test`, `sitk_add_java_test`, `sitk_add_r_test`, and `sitk_add_csharp_test`.
