### PR TITLE
Fix C# string interpolation in ParameterMaps.cs for older C# version compatibility

### DIFF
--- a/Examples/Elastix/ParameterMaps/ParameterMaps.cs
+++ b/Examples/Elastix/ParameterMaps/ParameterMaps.cs
@@ -79,10 +79,10 @@ namespace itk.simple.examples
                 string outputPrefix = args[2];
                 for (int i = 0; i < transformParameterMaps.Count; i++)
                 {
-                    string filename = $"{outputPrefix}_TransformParameters_{i}.txt";
+                    string filename = string.Format("{0}_TransformParameters_{1}.txt", outputPrefix, i);
                     SimpleITK.WriteParameterFile(transformParameterMaps[i], filename);
                 }
-                SimpleITK.WriteImage(resultImage, $"{outputPrefix}.nii");
+                SimpleITK.WriteImage(resultImage, string.Format("{0}.nii", outputPrefix));
             }
         }
     }


### PR DESCRIPTION
## Description
Fixes C# compilation error CS1056 (Unexpected character '$') in the ParameterMaps.cs example.

## Changes
- Replaced C# string interpolation (`$"..."` syntax) with `string.Format()` calls
- This ensures compatibility with older C# versions that don't support the interpolation feature

## Fixes
- Resolves compilation error: `error CS1056: Unexpected character '$'`

## Files Modified
- `Examples/Elastix/ParameterMaps/ParameterMaps.cs`

## Testing
The code now compiles without the CS1056 error when targeting older C# versions.