### PR TITLE
GHA: Add Python sdist job to Package workflow

### DIFF
--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -262,6 +262,25 @@ jobs:
             artifacts/SimpleITKDoxygenXML-*.tar.gz
             artifacts/SimpleITKDoxygen-*.tar.gz
 
+  sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+      - name: Build sdist
+        run: |
+          pip install build
+          python -m build --sdist
+      - name: Upload sdist
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: artifacts-sdist
+          path: dist/simpleitk-*.tar.gz
+
   publish-github:
     if: github.event_name != 'pull_request' && (github.ref_name == 'latest' || startsWith(github.ref_name, 'v'))
     environment:
@@ -272,6 +291,7 @@ jobs:
       - build
       - doxygen
       - package-docker
+      - sdist
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
@@ -328,7 +348,7 @@ jobs:
       - name: Check wheel metadata
         run: |
           pip install twine
-          twine check $( find ${{ steps.download.outputs.download-path }} -name "*.whl" )
+          twine check $( find ${{ steps.download.outputs.download-path }} -name "*.whl" -o -name "simpleitk-*.tar.gz" )
       - name: Create Release and Upload Artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -378,7 +398,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p dist
-          mv $( find  ${{ steps.download.outputs.download-path }} -type f -name "*.whl" ) dist/
+          mv $( find  ${{ steps.download.outputs.download-path }} -type f \( -name "*.whl" -o -name "simpleitk-*.tar.gz" \) ) dist/
       - name: PyPI Publish package
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,3 @@
-# This file is configured to install SimpleITK from the build directory.
-
 [build-system]
 requires = [
   "scikit-build-core==0.11.5",
@@ -45,7 +43,7 @@ provider = "scikit_build_core.metadata.setuptools_scm"
 [tool.setuptools_scm]
 version_scheme = "post-release"
 local_scheme = "no-local-version"
-write_to = "Wrapping/Python/SimpleITK/_version.py"
+version_file = "Wrapping/Python/SimpleITK/_version.py"
 tag_regex = "^v(?P<version>[^\\+]+)(?P<suffix>.*)?$"
 
 [tool.scikit-build]


### PR DESCRIPTION
Add a standalone `sdist` job that builds a Python source distribution using `python -m build --sdist` from the root `pyproject.toml` (scikit-build-core backend).

## Changes

### `.github/workflows/Package.yml`
- New `sdist` job: runs on all triggers (PR, tag, `workflow_dispatch`) on `ubuntu-latest`; uploads artifact as `artifacts-sdist/simpleitk-*.tar.gz`
- `publish-github` now depends on `sdist`; `twine check` validates both wheels and the sdist
- `publish-pypi` moves `*.tar.gz` alongside `*.whl` into `dist/` so the sdist is uploaded to PyPI with the wheels

### `pyproject.toml`
- Remove outdated comment referencing build directory install
- Replace deprecated `write_to` with `version_file` (setuptools-scm ≥8)