### PR TITLE
BUG: Use the enum type name CoherenceEnhancingDiffusionImageFilter declares

### DIFF
--- a/Code/BasicFilters/yaml/CoherenceEnhancingDiffusionImageFilter.yaml
+++ b/Code/BasicFilters/yaml/CoherenceEnhancingDiffusionImageFilter.yaml
@@ -25,7 +25,7 @@ members:
   - cEED
   - Isotropic
   default: itk::simple::CoherenceEnhancingDiffusionImageFilter::CED
-  itk_type: typename FilterType::EnhancementEnum
+  itk_type: typename FilterType::EnhancementType
   briefdescriptionSet: Switch between CED, EED, and variants.
   detaileddescriptionSet: ""
   briefdescriptionGet: ''


### PR DESCRIPTION
`itk::CoherenceEnhancingDiffusionImageFilter` declares `EnhancementType`, not `EnhancementEnum` — the generated wrapper fails to compile against an ITK that enables the AnisotropicDiffusionLBR module (in-tree since the remote-module ingest, though still `EXCLUDE_FROM_DEFAULT`; enabled via `Module_AnisotropicDiffusionLBR=ON` or `ITK_BUILD_ALL_MODULES=ON`).

<details>
<summary>Root cause and history</summary>

- SimpleITK commit `c575a688` (2019-12, "Change ITK enums type") renamed `itk_type` across many filters to the `*Enum` convention while tracking ITK's toolkit-wide enum modernization.
- The AnisotropicDiffusionLBR remote module never performed that modernization: `enum EnhancementType` is declared at the last remote-module pin (`753f2498`) and in the copy ingested into ITK main (`Modules/Filtering/AnisotropicDiffusionLBR/include/itkCoherenceEnhancingDiffusionImageFilter.h:98`).
- The mismatch surfaces when SimpleITK is built against an ITK with the module enabled:

```
sitkCoherenceEnhancingDiffusionImageFilter.cxx:165:48: error: no type named 'EnhancementEnum'
  in 'itk::CoherenceEnhancingDiffusionImageFilter<itk::Image<float, 3>>'
```

</details>

<details>
<summary>Validation</summary>

With this one-line yaml fix, the wrapper regenerates and `SimpleITK_AnisotropicDiffusionLBR` compiles and links cleanly (macOS arm64, clang 19, SimpleITK main `0eb2afc6` against ITK main `577fd288` with `ITK_BUILD_ALL_MODULES=ON`).

If ITK later modernizes the filter to `EnhancementEnum`, this line can follow suit — but matching the API as it exists today unbreaks the build in all current combinations.

</details>

<!--
provenance: claude-code session 2026-07-02
validated: forest testbed build_forest-svdc, target SimpleITK_AnisotropicDiffusionLBR rc=0
itk_header: Modules/Filtering/AnisotropicDiffusionLBR/include/itkCoherenceEnhancingDiffusionImageFilter.h:98 (enum EnhancementType)
itk_module_default: EXCLUDE_FROM_DEFAULT (itk-module.cmake:22); forest had ITK_BUILD_ALL_MODULES=ON
sitk_regression_origin: c575a688 (2019-12-09)
ci_failures_head_52ed66d3: mac-arm64 java lane (known, see #2620), macos-x86_64 homebrew tap trust (runner env)
-->
