### PR TITLE
DOC: Note ANTs transform order when porting to CompositeTransform

### DIFF
--- a/docs/source/fundamentalConcepts.rst
+++ b/docs/source/fundamentalConcepts.rst
@@ -255,20 +255,6 @@ In the context of registration, if you use a composite transform as the transfor
 that is optimized, only the parameters of the last transformation :math:`T_n` will
 be optimized over.
 
-.. note::
-
-   When porting from the `Advanced Normalization Tools (ANTs) ecosystem
-   <https://github.com/ANTsX>`_, the repeated ``-t`` transforms given to
-   ``antsApplyTransforms`` must be added in **reverse** of their command line
-   order. ANTs prepends each repeated flag to its internal option list, so it
-   builds its composite from the last command line argument to the first::
-
-    antsApplyTransforms -t warp.nii.gz -t affine.mat
-
-   is reproduced by ``CompositeTransform([affine, warp])``. The reversal applies
-   to the ``-t`` flags themselves; if a single ``-t`` names a composite transform
-   file, its sub-transforms are added in their stored order.
-
 Additional Resources
 =====================
 

--- a/docs/source/fundamentalConcepts.rst
+++ b/docs/source/fundamentalConcepts.rst
@@ -233,6 +233,27 @@ In the context of registration, if you use a composite transform as the transfor
 that is optimized, only the parameters of the last transformation :math:`T_n` will
 be optimized over.
 
+.. note::
+
+   When porting from the `Advanced Normalization Tools (ANTs) ecosystem
+   <https://github.com/ANTsX>`_, the repeated ``-t`` transforms given to
+   ``antsApplyTransforms`` must be added in **reverse** of their command line
+   order. ANTs stores repeated flags in reverse and builds its composite from
+   that reversed list, so::
+
+    antsApplyTransforms -t warp.nii.gz -t affine.mat
+
+   is reproduced by::
+
+    composite = CompositeTransform(3)
+    composite.AddTransform(affine)  # listed last on the command line, so added first
+    composite.AddTransform(warp)    # listed first on the command line, so added last
+
+   Running ``antsApplyTransforms --verbose`` prints the transforms in the order
+   ANTs adds them, which is the order to pass to ``AddTransform``. The reversal
+   applies to the ``-t`` flags themselves; if a single ``-t`` names a composite
+   transform file, its sub-transforms are added in their stored order.
+
 Additional Resources
 =====================
 

--- a/docs/source/fundamentalConcepts.rst
+++ b/docs/source/fundamentalConcepts.rst
@@ -229,6 +229,28 @@ stack based, that is, first in last applied:
  composite_transform = CompositeTransform([T0, T1])
  composite_transform.AddTransform(T2)
 
+The order in which transformations are added is therefore the reverse of the order
+in which they are applied. Given three transformations :math:`A`, :math:`B` and
+:math:`C` added in that order:
+
+.. code-block:: python
+
+ composite = CompositeTransform(3)
+ composite.AddTransform(A)
+ composite.AddTransform(B)
+ composite.AddTransform(C)
+
+the composite maps a point :math:`\mathbf{x}` as:
+
+.. math::
+
+  \mathrm{composite}(\mathbf{x}) = A(B(C(\mathbf{x})))
+
+That is, :math:`C`, the last transformation added, is the first one applied to the
+point, and :math:`A`, the first one added, is applied last. Passing the
+transformations to the constructor as ``CompositeTransform([A, B, C])`` is
+equivalent to adding them in the same order.
+
 In the context of registration, if you use a composite transform as the transformation
 that is optimized, only the parameters of the last transformation :math:`T_n` will
 be optimized over.
@@ -243,16 +265,9 @@ be optimized over.
 
     antsApplyTransforms -t warp.nii.gz -t affine.mat
 
-   is reproduced by::
-
-    composite = CompositeTransform(3)
-    composite.AddTransform(affine)  # listed last on the command line, so added first
-    composite.AddTransform(warp)    # listed first on the command line, so added last
-
-   Running ``antsApplyTransforms --verbose`` prints the transforms in the order
-   ANTs adds them, which is the order to pass to ``AddTransform``. The reversal
-   applies to the ``-t`` flags themselves; if a single ``-t`` names a composite
-   transform file, its sub-transforms are added in their stored order.
+   is reproduced by ``CompositeTransform([affine, warp])``. The reversal applies
+   to the ``-t`` flags themselves; if a single ``-t`` names a composite transform
+   file, its sub-transforms are added in their stored order.
 
 Additional Resources
 =====================

--- a/docs/source/fundamentalConcepts.rst
+++ b/docs/source/fundamentalConcepts.rst
@@ -238,8 +238,8 @@ be optimized over.
    When porting from the `Advanced Normalization Tools (ANTs) ecosystem
    <https://github.com/ANTsX>`_, the repeated ``-t`` transforms given to
    ``antsApplyTransforms`` must be added in **reverse** of their command line
-   order. ANTs stores repeated flags in reverse and builds its composite from
-   that reversed list, so::
+   order. ANTs prepends each repeated flag to its internal option list, so it
+   builds its composite from the last command line argument to the first::
 
     antsApplyTransforms -t warp.nii.gz -t affine.mat
 


### PR DESCRIPTION
Adds a note to the composite transform documentation, as requested in #2505.

`CompositeTransform` behaves as documented; the catch is that the `-t` order on the `antsApplyTransforms` command line is not the `AddTransform()` order. ANTs stores repeated command line flags in reverse, so a `-t` list ported straight into `AddTransform()` calls composes in the opposite order. 

The note also records that the reversal applies to the `-t` flags themselves, not to the sub-transforms within a single composite transform file.