### PR TITLE
BUG: Fix LabelMapMaskImageFilter BackgroundValue cast through label type

### DIFF
--- a/Code/BasicFilters/yaml/LabelMapMaskImageFilter.yaml
+++ b/Code/BasicFilters/yaml/LabelMapMaskImageFilter.yaml
@@ -6,6 +6,7 @@ doc: ''
 pixel_types: LabelPixelIDTypeList
 pixel_types2: typelist2::append<BasicPixelIDTypeList, ComplexPixelIDTypeList>::type
 filter_type: itk::LabelMapMaskImageFilter<InputImageType, InputImageType2>
+output_image_type: InputImageType2
 inputs:
 - name: LabelMapImage
   type: Image

--- a/Testing/Unit/sitkBasicFiltersTests.cxx
+++ b/Testing/Unit/sitkBasicFiltersTests.cxx
@@ -42,6 +42,7 @@
 #include <sitkPatchBasedDenoisingImageFilter.h>
 #include <sitkConnectedThresholdImageFilter.h>
 #include <sitkMergeLabelMapFilter.h>
+#include <sitkLabelMapMaskImageFilter.h>
 #include <sitkDiffeomorphicDemonsRegistrationFilter.h>
 #include <sitkFastSymmetricForcesDemonsRegistrationFilter.h>
 #include <sitkThresholdImageFilter.h>
@@ -113,6 +114,29 @@ TEST(BasicFilter, DiffeomorphicDemonsRegistrationFilter_ENUMCHECK)
   EXPECT_EQ((int)ITKType::Fixed, (int)itk::simple::DiffeomorphicDemonsRegistrationFilter::Fixed);
   EXPECT_EQ((int)ITKType::WarpedMoving, (int)itk::simple::DiffeomorphicDemonsRegistrationFilter::WarpedMoving);
   EXPECT_EQ((int)ITKType::MappedMoving, (int)itk::simple::DiffeomorphicDemonsRegistrationFilter::MappedMoving);
+}
+
+TEST(BasicFilters, LabelMapMaskImageFilter_BackgroundValuePreserved)
+{
+  // Regression test for 2625 (S16): BackgroundValue was cast through the
+  // unsigned label type (destroying negatives) instead of the feature image
+  // type. Verify a negative background value survives the round-trip.
+  namespace sitk = itk::simple;
+
+  sitk::Image labelMap = sitk::ReadImage(dataFinder.GetFile("Input/2th_cthead1.mha"));
+  labelMap = sitk::Cast(labelMap, sitk::sitkLabelUInt8);
+  sitk::Image featureImage = sitk::ReadImage(dataFinder.GetFile("Input/cthead1-Float.mha"));
+
+  sitk::LabelMapMaskImageFilter filter;
+  filter.SetLabel(1);
+  filter.SetBackgroundValue(-1000.0);
+  sitk::Image output = filter.Execute(labelMap, featureImage);
+
+  EXPECT_EQ(sitk::sitkFloat32, output.GetPixelID());
+
+  sitk::StatisticsImageFilter stats;
+  stats.Execute(output);
+  EXPECT_DOUBLE_EQ(-1000.0, stats.GetMinimum());
 }
 
 TEST(BasicFilters, MergeLabelMap_ENUMCHECK)


### PR DESCRIPTION
## Summary

Fixes issue #2625 (S16): `BackgroundValue` in `LabelMapMaskImageFilter` was silently losing negative values due to a wrong cast.

## Root Cause

`BackgroundValue` was declared `pixeltype: Output`, but no `output_image_type` was set in the YAML. The dual template's fallback assigns `OutputImageType = InputImageType` — the **LabelMap** type (unsigned integer). This caused the `double` background value to be `static_cast` to the unsigned label pixel type before being forwarded to ITK, destroying any negative or non-integer value.

## Fix

Add `output_image_type: InputImageType2` to `LabelMapMaskImageFilter.yaml`, making `OutputImageType` alias the feature image type as ITK's filter intends.

## Test

Added `BasicFilters.LabelMapMaskImageFilter_BackgroundValuePreserved` in `sitkBasicFiltersTests.cxx`: runs the filter with a float feature image and `BackgroundValue = -1000.0`, asserts the output minimum is `-1000.0`.