### PR TITLE
ENH: fix ImageFileReader extract implicit-zero path ignoring index

### DIFF
--- a/Code/IO/src/sitkImageFileReader.cxx
+++ b/Code/IO/src/sitkImageFileReader.cxx
@@ -359,7 +359,15 @@ ImageFileReader::ExecuteInternal(itk::ImageIOBase * imageio)
   assert(imageio != nullptr);
 
 
-  if (m_ExtractSize.empty() || m_ExtractSize.size() == ImageType::ImageDimension)
+  // Use the same-dimension reader only when:
+  // 1. No extraction is requested, or
+  // 2. Every axis in ExtractSize is non-zero (no dimension collapse) AND
+  //    the file has exactly that many dimensions (no implicit zero-collapse).
+  // When the file has more dimensions than m_ExtractSize (implicit trailing zeros),
+  // fall through to the full-rank InternalReader so that ExecuteExtract can honor
+  // all ExtractIndex entries and collapse direction to a proper sub-matrix.
+  if (m_ExtractSize.empty() || (m_ExtractSize.size() == ImageType::ImageDimension &&
+                                imageio->GetNumberOfDimensions() == ImageType::ImageDimension))
   {
 
     typename Reader::Pointer reader = Reader::New();

--- a/Testing/Unit/sitkImageIOTests.cxx
+++ b/Testing/Unit/sitkImageIOTests.cxx
@@ -1102,6 +1102,48 @@ TEST(IO, ImageFileReader_Extract2)
 }
 
 
+// Regression test for issue S17: ImageFileReader implicit-zero extract spellings
+// must agree.  "size=[w,h]" for a 3-D file is documented as equivalent to
+// "size=[w,h,0]" (missing entries are zero), so both must honor the same
+// ExtractIndex (including the collapsed z-axis slice) and must produce identical
+// output images.
+TEST(IO, ImageFileReader_ExtractImplicitZero)
+{
+  sitk::Image generatedImage(50, 60, 70, sitk::sitkInt16);
+  generatedImage.SetOrigin(v3(1.0, 2.0, 3.0));
+  generatedImage.SetSpacing(v3(0.5, 0.6, 0.7));
+
+  generatedImage = sitk::AdditiveGaussianNoise(generatedImage, 128.0, 0.0, 42u);
+
+  const ::testing::TestInfo * info = ::testing::UnitTest::GetInstance()->current_test_info();
+  std::string                 filename = std::string(info->test_case_name()) + "." + info->name() + ".mha";
+  filename = dataFinder.GetOutputFile(filename);
+  sitk::WriteImage(generatedImage, filename);
+
+  sitk::ImageFileReader reader;
+  reader.SetFileName(filename);
+
+  // Explicit zero: [20, 30, 0] collapses the z-axis at index 5.
+  reader.SetExtractSize({ 20u, 30u, 0u });
+  reader.SetExtractIndex({ 3, 4, 5 });
+  sitk::Image explicitResult = reader.Execute();
+
+  // Implicit zero: [20, 30] — the missing z entry is documented as zero.
+  // After the fix both spellings must produce the same image.
+  reader.SetExtractSize({ 20u, 30u });
+  reader.SetExtractIndex({ 3, 4, 5 });
+  sitk::Image implicitResult = reader.Execute();
+
+  EXPECT_EQ(2u, explicitResult.GetDimension());
+  EXPECT_EQ(2u, implicitResult.GetDimension());
+
+  EXPECT_EQ(sitk::Hash(explicitResult), sitk::Hash(implicitResult));
+  EXPECT_VECTOR_DOUBLE_NEAR(explicitResult.GetOrigin(), implicitResult.GetOrigin(), 1e-10);
+  EXPECT_VECTOR_DOUBLE_NEAR(explicitResult.GetSpacing(), implicitResult.GetSpacing(), 1e-10);
+  EXPECT_VECTOR_DOUBLE_NEAR(explicitResult.GetDirection(), implicitResult.GetDirection(), 1e-10);
+}
+
+
 TEST(IO, ImageFileReader_5DExtract)
 {
   const std::string file = dataFinder.GetDirectory() + "/Input/points_5d.mha";


### PR DESCRIPTION
## Summary

Fixes issue #2625 (finding S17).

### Problem

`ImageFileReader::SetExtractSize` documents that missing dimension entries
are implicitly zero:

> If the size's length is less than the image's dimension then the missing
> values are assumed to be zero.

This means for a 3-D file the following two spellings should be equivalent:

```python
reader.SetExtractSize([w, h])        # implicit zero → collapse z
reader.SetExtractSize([w, h, 0])     # explicit zero → collapse z
```

They were **not** equivalent. `ExecuteInternal` chose its read path with:

```cpp
if (m_ExtractSize.empty() || m_ExtractSize.size() == ImageType::ImageDimension)
```

`ImageType::ImageDimension` is the *output* dimension (count of non-zero
entries in `m_ExtractSize`). For `{w, h}` applied to a 3-D file,
`m_ExtractSize.size() == 2 == ImageType::ImageDimension`, so the code
created an `itk::ImageFileReader<Image2D>` for a 3-D file. That path:

- **Silently dropped** any `ExtractIndex` entries beyond the output
  dimension (the z-slice index was never applied; always read slice 0).
- Did **not** collapse the direction cosine matrix to a sub-matrix; the
  output carried identity direction instead.

The explicit-zero form `{w, h, 0}` already fell through to the full-rank
`InternalReader` path whose `ExecuteExtract` correctly handles implicit
zeros via `else if (i >= ImageType::ImageDimension) { region.SetSize(i, 0u); }`
and calls `SetDirectionCollapseToSubmatrix`.

### Fix

Add `imageio->GetNumberOfDimensions() == ImageType::ImageDimension` to the
condition so the same-rank reader is only used when the file's actual
dimension equals the output dimension (no implicit collapsing needed):

```cpp
if (m_ExtractSize.empty() ||
    (m_ExtractSize.size() == ImageType::ImageDimension &&
     imageio->GetNumberOfDimensions() == ImageType::ImageDimension))
```

### Tests

Added `IO.ImageFileReader_ExtractImplicitZero`: writes a 3-D image, then
reads a 2-D slice using both the implicit-zero spelling and the explicit-zero
spelling and asserts that the hash, origin, spacing, and direction are
identical.