### PR TITLE
DOC+TEST: correct ProcessObject::Abort() documentation and add regression test

### DIFF
--- a/Code/Common/include/sitkProcessObject.h
+++ b/Code/Common/include/sitkProcessObject.h
@@ -308,16 +308,14 @@ public:
 
   /** Sets an abort flag on the active process.
    *
-   * Requests the current active process to abort. Additional,
-   * progress or iteration event may occur. If aborted then, an
-   * AbortEvent should occur. The Progress should be set to 1.0
-   * after aborting.
+   * Requests the current active process to abort. Additional
+   * progress or iteration events may occur. If aborted, an
+   * AbortEvent will occur and the Progress will be set to 1.0.
    *
-   * The expected behavior is that not exception should be throw
-   * out of this processes Execute method. Additionally, the
-   * results returned are valid but undefined content. The
-   * content may be only partially updated, uninitialized or the a
-   * of size zero.
+   * An itk::ProcessAborted exception may be thrown from the
+   * Execute method when the process is aborted. The results
+   * returned are valid but undefined in content: they may be
+   * only partially updated, uninitialized, or of size zero.
    *
    * If there is no active process the method has no effect.
    */

--- a/Testing/Unit/sitkCommonTests.cxx
+++ b/Testing/Unit/sitkCommonTests.cxx
@@ -21,6 +21,8 @@
 #include <sitkCommand.h>
 #include <sitkFunctionCommand.h>
 #include <sitkCastImageFilter.h>
+#include <sitkImageFileReader.h>
+#include <sitkSignedMaurerDistanceMapImageFilter.h>
 
 #include <sitkKernel.h>
 #include <sitkVersion.h>
@@ -610,6 +612,33 @@ TEST(ProcessObject, Threads)
   EXPECT_EQ("SINGLE", strupper(sitk::ProcessObject::GetGlobalDefaultThreader()));
   EXPECT_TRUE(sitk::ProcessObject::SetGlobalDefaultThreader("Single"));
   EXPECT_EQ("SINGLE", strupper(sitk::ProcessObject::GetGlobalDefaultThreader()));
+}
+
+// Issue #2625 S22: Verify that aborting a process throws itk::ProcessAborted
+// from Execute(). The underlying ITK pipeline throws itk::ProcessAborted after
+// aborting (via ProgressReporter and ProcessObject::UpdateOutputData).
+TEST(ProcessObject, Abort_ExceptionEscapesExecute)
+{
+  namespace sitk = itk::simple;
+
+  sitk::Image img = sitk::ReadImage(dataFinder.GetFile("Input/RA-Short.nrrd"));
+
+  // SignedMaurerDistanceMapImageFilter is a composite filter that reports
+  // detailed progress, making it suitable for triggering mid-execution abort.
+  sitk::SignedMaurerDistanceMapImageFilter filter;
+  filter.SetNumberOfThreads(16);
+
+  AbortAtCommand abortAtCommand(filter, 0.35f);
+  filter.AddCommand(sitk::sitkProgressEvent, abortAtCommand);
+
+  CountCommand abortEventCmd(filter);
+  filter.AddCommand(sitk::sitkAbortEvent, abortEventCmd);
+
+  // Aborting causes itk::ProcessAborted to be thrown from Execute().
+  EXPECT_ANY_THROW(filter.Execute(img));
+
+  // The AbortEvent is fired before the exception propagates.
+  EXPECT_EQ(1, abortEventCmd.m_Count);
 }
 
 TEST(Command, Test2)


### PR DESCRIPTION
Addresses finding S22 from issue #2625.

## Summary

The `Abort()` method incorrectly documented that no exception should escape `Execute()`. In practice, `itk::ProcessAborted` is thrown by `ProgressReporter` and rethrown by `ProcessObject::UpdateOutputData` after the `AbortEvent` fires, and no SimpleITK code catches it.

## Changes

- **`Code/Common/include/sitkProcessObject.h`**: Update the `Abort()` doc block to accurately state that `itk::ProcessAborted` may be thrown from `Execute()` when the process is aborted. Also fixes several typos/grammar issues in the original text.

- **`Testing/Unit/sitkCommonTests.cxx`**: Add `ProcessObject.Abort_ExceptionEscapesExecute` test using `SignedMaurerDistanceMapImageFilter` (a composite filter with detailed per-step progress reporting) to demonstrate and verify the abort exception behavior. Adds required includes for `sitkImageFileReader.h` and `sitkSignedMaurerDistanceMapImageFilter.h`.