### PR TITLE
BUG: Fix license-expression metadata breaking twine check

### DIFF
--- a/Wrapping/Python/Packaging/pyproject.toml.in
+++ b/Wrapping/Python/Packaging/pyproject.toml.in
@@ -14,7 +14,7 @@ authors = [
     {name = "Insight Software Consortium", email = "insight-users@itk.org"}
 ]
 description = "SimpleITK is a simplified interface to the Insight Toolkit (ITK) for image registration and segmentation"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 keywords = ["SimpleITK", "ITK", "InsightToolkit", "segmentation", "registration", "medical imaging", "image processing", "computer vision", "DICOM"]
 classifiers = [
     "Programming Language :: Python",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ authors = [
     {name = "Insight Software Consortium", email = "insight-users@itk.org"}
 ]
 description = "SimpleITK is a simplified interface to the Insight Toolkit (ITK) for image registration and segmentation"
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 keywords = ["SimpleITK", "ITK", "InsightToolkit", "segmentation", "registration", "medical imaging", "image processing", "computer vision", "DICOM"]
 classifiers = [
     "Programming Language :: Python",


### PR DESCRIPTION
## Summary

Fix `InvalidDistribution: unrecognized or malformed field 'license-expression'` error from `twine check` breaking the nightly packaging GHA workflow.

## Problem

The bare SPDX string form `license = "Apache-2.0"` is PEP 639 syntax, which causes `scikit-build-core` to emit a `License-Expression:` field in core metadata 2.4. Older versions of `twine` do not recognize `license-expression` as a valid metadata field and reject the distribution.

## Fix

Changed `license = "Apache-2.0"` to `license = {text = "Apache-2.0"}` in both:
- `pyproject.toml`
- `Wrapping/Python/Packaging/pyproject.toml.in`

The table form emits the traditional `License:` field (core metadata 2.1), which is compatible with all `twine` versions.