### PR TITLE
Add sitk-upload-binary-data skill

### DIFF
--- a/.github/skills/sitk-upload-binary-data/SKILL.md
+++ b/.github/skills/sitk-upload-binary-data/SKILL.md
@@ -106,21 +106,27 @@ If this fails, **stop** and tell the user:
 > gh repo clone SimpleITK/SimpleITKExternalData .ExternalData
 > ```
 
-Otherwise, list its remotes to find one to push to:
+Otherwise, list its remotes to identify both the upstream and the remote
+to push to:
 
 ```bash
 git -C .ExternalData remote -v
 ```
 
-- Ignore any remote pointing at `SimpleITK/SimpleITKExternalData` itself
-  (typically `origin`/`upstream`) — that's the upstream, not a fork.
-- If exactly one other remote remains, use its name as `<push-remote>`.
-- Otherwise (zero or multiple candidates), ask the user which remote
-  name to use as `<push-remote>`, listing whatever remote names were
-  found. If none exist, tell the user they need to add one first (e.g.
-  by running `gh repo fork --remote --remote-name <name>` themselves).
+- The remote pointing at `SimpleITK/SimpleITKExternalData` itself
+  (typically `origin`/`upstream`) is `<upstream-remote>` — used in Step 4
+  to fetch and base the branch on `main`. Do not assume it is named
+  `origin`; read the actual name from the `remote -v` output.
+- Do **not** run `gh repo fork` — never create a fork automatically.
+  Among the *other* remotes (not `<upstream-remote>`):
+  - If exactly one remains, use its name as `<push-remote>`.
+  - Otherwise (zero or multiple candidates), ask the user which remote
+    name to use as `<push-remote>`, listing whatever remote names were
+    found. If none exist, tell the user they need to add one first
+    (e.g. by running `gh repo fork --remote --remote-name <name>`
+    themselves).
 
-Use as `<push-remote>` in Step 4.
+Use `<upstream-remote>` and `<push-remote>` in Step 4.
 
 ### Step 3 — Hash, copy, create content links, remove originals
 
@@ -146,8 +152,8 @@ All commands use `git -C .ExternalData` to stay in the source root.
 Run from the **SimpleITK source root**:
 
 ```bash
-git -C .ExternalData fetch origin
-git -C .ExternalData checkout -B <branch-name> origin/main
+git -C .ExternalData fetch <upstream-remote>
+git -C .ExternalData checkout -B <branch-name> <upstream-remote>/main
 git -C .ExternalData add SHA512/<hash>
 git -C .ExternalData commit -m "Add <original-filename>"
 git -C .ExternalData push --force-with-lease <push-remote> HEAD:<branch-name>

--- a/.github/skills/sitk-upload-binary-data/SKILL.md
+++ b/.github/skills/sitk-upload-binary-data/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: sitk-upload-binary-data
+description: 'Upload binary testing data to SimpleITK ExternalData repository. Use when: adding test data, uploading binary file, creating content link, new test input, ExternalData upload, sha512 content link.'
+argument-hint: 'Relative path to binary file, e.g. Testing/Data/Baseline/MyFilter_output.nrrd'
+---
+
+# Upload Binary Data to SimpleITK ExternalData
+
+Upload binary files (test inputs, baseline images, etc.) to the
+`SimpleITK/SimpleITKExternalData` GitHub repository by computing their
+SHA-512 hash, placing them in the `.ExternalData` object store, creating
+content link files, and opening a draft PR.
+
+## When to Use
+
+- Adding new test input images or baseline outputs
+- Uploading any binary file that should not be committed to the SimpleITK Git repo
+- Replaces input file with a `.sha512` CMake ExternalData content link
+
+## Required Tools
+
+Verify these are available before proceeding:
+
+| Tool | Purpose | Check command |
+|------|---------|---------------|
+| `git` | Repository operations | `git --version` |
+| `gh` | GitHub CLI for forking/PRs | `gh auth status` |
+| `sha512sum` or `shasum` | Compute file hashes | `sha512sum --version` (Linux) or `shasum --version` (macOS) |
+
+## Background
+
+Binary test data in SimpleITK uses
+[CMake ExternalData](https://cmake.org/cmake/help/latest/module/ExternalData.html).
+Content link files (e.g. `Testing/Data/Input/image.nrrd.sha512`) contain
+only a 128-character lowercase hex **SHA-512** hash followed by a newline.
+The `.ExternalData` directory at the SimpleITK source root is a clone of
+`SimpleITK/SimpleITKExternalData` and also a local CMake ExternalData
+object store (listed in `.gitignore`), so builds work immediately once a
+file is placed there.
+
+Always create `.sha512` content links and `SHA512/<hash>` objects. See
+[resources/external-data-background.md](resources/external-data-background.md)
+for full history, legacy considerations, and object store/URL resolution
+details.
+
+## Bundled Script
+
+### `scripts/hash_and_stage.sh`
+
+A bash script that handles hashing, copying, content-link creation, and
+cleanup for one or more binary files. Run from the SimpleITK source root.
+
+**Usage:**
+```
+bash .github/skills/sitk-upload-binary-data/scripts/hash_and_stage.sh <file1> [<file2> ...]
+```
+
+**What it does:**
+1. Validates prerequisites (`sha512sum`, git repo, `.ExternalData` clone).
+2. For each file:
+   - Computes the SHA-512 hash via `sha512sum`.
+   - Copies the binary to `.ExternalData/SHA512/<hash>` (skips if the
+     hash already exists).
+   - Writes `<file>.sha512` containing the 128-char hex hash + newline.
+   - Removes the original binary file.
+   - Notes any existing `.md5` content link for removal.
+3. Prints suggested `git add` / `git rm` commands.
+
+**Output labels:**
+- `COPY` — binary copied to object store
+- `SKIP` — hash already present, no copy needed
+- `LINK` — `.sha512` content link created
+- `DEL`  — original binary removed
+
+**Does NOT:** create branches, commit, push, or open PRs — those steps
+are performed separately (see Step 4 below).
+
+**Exit codes:** non-zero on any error (missing file, bad `.ExternalData`
+directory, missing `sha512sum`). The error message explains the problem.
+
+## Procedure
+
+Given one or more binary file paths relative to the SimpleITK source root.
+Example: `Testing/Data/Baseline/BasicFilters_NormalizedCorrelationImageFilter_NoMask.nrrd`
+
+### Step 1 — Verify the file exists
+
+Confirm each binary file is present at the given path. If not, stop and
+tell the user.
+
+### Step 2 — Verify the `.ExternalData` clone and select a push remote
+
+All commands run from the **SimpleITK source root**. First confirm
+`.ExternalData` is a real git clone:
+
+```bash
+test -d .ExternalData/.git
+```
+
+If this fails, **stop** and tell the user:
+
+> The `.ExternalData` directory must be a clone of
+> `SimpleITK/SimpleITKExternalData`. To set it up, run:
+>
+> ```
+> gh repo clone SimpleITK/SimpleITKExternalData .ExternalData
+> ```
+
+Otherwise, list its remotes to find one to push to:
+
+```bash
+git -C .ExternalData remote -v
+```
+
+- Ignore any remote pointing at `SimpleITK/SimpleITKExternalData` itself
+  (typically `origin`/`upstream`) — that's the upstream, not a fork.
+- If exactly one other remote remains, use its name as `<push-remote>`.
+- Otherwise (zero or multiple candidates), ask the user which remote
+  name to use as `<push-remote>`, listing whatever remote names were
+  found. If none exist, tell the user they need to add one first (e.g.
+  by running `gh repo fork --remote --remote-name <name>` themselves).
+
+Use as `<push-remote>` in Step 4.
+
+### Step 3 — Hash, copy, create content links, remove originals
+
+Run the [bundled script](#bundled-script) from the SimpleITK source root:
+
+```bash
+bash .github/skills/sitk-upload-binary-data/scripts/hash_and_stage.sh \
+  path/to/file1 [path/to/file2 ...]
+```
+
+Capture the hash from the script output (the `COPY` or `SKIP` line) or
+read it from the generated `.sha512` file:
+
+```bash
+HASH=$(cat path/to/file.sha512)
+```
+
+If the script fails, read its error output and report to the user.
+
+### Step 4 — Create branch, commit, and PR in ExternalData repo
+
+All commands use `git -C .ExternalData` to stay in the source root.
+Run from the **SimpleITK source root**:
+
+```bash
+git -C .ExternalData fetch origin
+git -C .ExternalData checkout -B <branch-name> origin/main
+git -C .ExternalData add SHA512/<hash>
+git -C .ExternalData commit -m "Add <original-filename>"
+git -C .ExternalData push --force-with-lease <push-remote> HEAD:<branch-name>
+```
+
+The `gh` CLI does not support `-C`, so use a subshell for PR creation.
+The subshell does **not** change the parent shell's working directory:
+
+```bash
+(cd .ExternalData && gh pr create --repo SimpleITK/SimpleITKExternalData \
+  --title "Add <original-filename>" \
+  --body "Binary testing data for SimpleITK." \
+  --draft)
+```
+
+**Branch naming**: Use the sanitized original filename (replace dots and
+special chars with hyphens, no prefix). For multiple files use
+`upload-N-files`.
+
+**Commit message**: `Add filename1, filename2, ...` — include original
+filenames so reviewers know what the data is.
+
+### Step 5 — Stage the content link in SimpleITK
+
+Back in the SimpleITK source root:
+
+```bash
+git add -- path/to/file.sha512
+```
+
+
+### Step 6 — Report to user
+
+Summarize:
+- Content link created at `<path>.sha512`
+- Data placed in `.ExternalData/SHA512/<hash>` (builds work locally now)
+- Draft PR opened on `SimpleITK/SimpleITKExternalData` (include URL)
+- Remind: data won't be available via S3/CMake download until the
+  ExternalData PR is merged
+
+
+# Troubleshooting Resources
+- Additional background information is available in [resources/external-data-background.md](resources/external-data-background.md).

--- a/.github/skills/sitk-upload-binary-data/resources/external-data-background.md
+++ b/.github/skills/sitk-upload-binary-data/resources/external-data-background.md
@@ -1,0 +1,86 @@
+# Background: CMake ExternalData in SimpleITK
+
+This is auxiliary reference material for the `sitk-upload-binary-data`
+skill. It is not needed for routine uploads — see `SKILL.md` for the
+procedure.
+
+## What is CMake ExternalData?
+
+SimpleITK stores large/binary test data outside the Git repository using
+the [CMake ExternalData](https://cmake.org/cmake/help/latest/module/ExternalData.html)
+module
+([background](https://blog.kitware.com/cmake-externaldata-using-large-files-with-distributed-version-control/)).
+Instead of committing a binary, the repo commits a small **content link**
+file containing only a hash of the binary's contents. At configure/build
+time, CMake resolves each content link to the real file, fetching it from
+a local object store or a remote URL if not already present.
+
+## Content link format
+
+- File name: `<original-name>.<algo-extension>`, e.g. `image.nrrd.sha512`.
+- File content: a single lowercase hex hash string (128 chars for
+  SHA-512) followed by a newline. No other metadata.
+- `<algo-extension>` for SHA-512 is `.sha512`. The legacy MD5 extension
+  was `.md5` (32 hex chars) — see [Legacy MD5](#legacy-md5-do-not-use-for-new-data) below.
+
+## Object stores and URL resolution
+
+Configured in [`CMake/sitkExternalData.cmake`](../../../../CMake/sitkExternalData.cmake).
+CMake looks for objects, in order:
+
+1. Local object stores in `ExternalData_OBJECT_STORES` (defaults to
+   `${CMAKE_BINARY_DIR}/ExternalData/Objects`).
+2. `${SimpleITK_SOURCE_DIR}/.ExternalData`, if present — a clone of
+   `SimpleITK/SimpleITKExternalData` used as a local object store (this is
+   why the upload skill copies binaries here: builds succeed immediately
+   without needing a network download).
+3. Remote URL templates (`%(algo)/%(hash)`), tried in order:
+   - `https://simpleitk.s3.amazonaws.com/public/%(algo)/%(hash)` — S3
+     mirror, synced from the `SimpleITKExternalData` repo by a GitHub
+     Actions workflow on merge to `main`.
+   - `https://simpleitk.org/SimpleITKExternalData/%(algo)/%(hash)` —
+     GitHub Pages mirror.
+   - `https://data.kitware.com:443/api/v1/file/hashsum/%(algo)/%(hash)/download` —
+     Girder instance (legacy/shared ITK ecosystem source).
+   - `https://insightsoftwareconsortium.github.io/ITKTestingData/%(algo)/%(hash)`
+     and `https://itk.org/files/ExternalData/%(algo)/%(hash)` — ITK's own
+     testing data mirrors (shared ecosystem fallback, rarely hit for
+     SimpleITK-specific data).
+
+## The `SimpleITK/SimpleITKExternalData` repository
+
+Stores binaries in a flat layout: `SHA512/<hash>` (and, historically,
+`MD5/<hash>`). The file name IS the hash; the file content IS the raw
+binary. There is no other indexing — a hash is only discoverable by
+already knowing it from a content link.
+
+## Legacy MD5: do not use for new data
+
+MD5 was the original ExternalData hash algorithm used by SimpleITK.
+The project fully migrated to SHA-512 for all content links, completed by
+a 2019 commit titled "Use only sha512 data file remove md5", which
+removed every remaining `.md5` content link file from the source tree.
+
+- **All `.md5` content links have been removed from the SimpleITK repo.**
+  No `.md5` content link should ever be added or reintroduced.
+- The `MD5/` directory still exists in the `SimpleITKExternalData` object
+  store (and on S3) purely as a historical remnant — old binaries that
+  were only ever referenced by now-deleted `.md5` links. These objects
+  are inert: nothing in the current source tree points to them.
+- **Never add, modify, or reference MD5 objects.** Always hash and stage
+  new binaries as SHA-512 (`.sha512` content links, `SHA512/<hash>`
+  object paths), per the main skill procedure.
+- If you encounter a `.md5` content link anywhere in the tree, treat it
+  as a bug — it should be re-hashed to SHA-512 and the `.md5` file
+  removed.
+
+## Unrelated: `IMAGE_MD5_COMPARE` CMake test macro
+
+`CMake/sitkAddTest.cmake` has a per-test option named `IMAGE_MD5_COMPARE`
+that compares a generated test output image against an expected MD5
+hash string given directly in the test definition (via the
+`sitkTestDriver --compare-MD5` flag). This is a lightweight image
+regression check unrelated to the ExternalData content-link mechanism
+described above — it does not read or write `.md5`/`.sha512` files or
+the `.ExternalData` object store. Do not confuse the two when searching
+the codebase for "md5".

--- a/.github/skills/sitk-upload-binary-data/scripts/hash_and_stage.sh
+++ b/.github/skills/sitk-upload-binary-data/scripts/hash_and_stage.sh
@@ -34,9 +34,9 @@ die() { echo "ERROR: $*" >&2; exit 1; }
 [[ $# -ge 1 ]] || die "Usage: $0 <file1> [<file2> ...]"
 
 if command -v sha512sum >/dev/null 2>&1; then
-    SHA512CMD="sha512sum"
+    SHA512CMD=(sha512sum)
 elif command -v shasum >/dev/null 2>&1; then
-    SHA512CMD="shasum -a 512"
+    SHA512CMD=(shasum -a 512)
 else
     die "Neither sha512sum (Linux) nor shasum (macOS) found."
 fi
@@ -61,14 +61,16 @@ MD5_CONFLICTS=()
 for FILE in "$@"; do
     [[ -f "${FILE}" ]] || die "File not found: ${FILE}"
 
-    BASENAME="$(basename "${FILE}")"
-    HASH="$($SHA512CMD "${FILE}" | awk '{print $1}')"
+    BASENAME="$(basename -- "${FILE}")"
+    HASH="$("${SHA512CMD[@]}" -- "${FILE}" | awk '{print $1}')"
+    [[ "${HASH}" =~ ^[0-9a-f]{128}$ ]] \
+        || die "Unexpected hash output for ${FILE}: '${HASH}'"
 
     DEST="${ED_DIR}/SHA512/${HASH}"
     if [[ -f "${DEST}" ]]; then
         echo "SKIP  ${BASENAME}: hash already in .ExternalData"
     else
-        cp "${FILE}" "${DEST}"
+        cp -- "${FILE}" "${DEST}"
         echo "COPY  ${BASENAME} -> .ExternalData/SHA512/${HASH:0:12}..."
     fi
 
@@ -77,7 +79,7 @@ for FILE in "$@"; do
     echo "LINK  ${FILE}.sha512"
 
     # remove original
-    rm "${FILE}"
+    rm -- "${FILE}"
     echo "DEL   ${FILE}"
 
     # note old .md5 content links

--- a/.github/skills/sitk-upload-binary-data/scripts/hash_and_stage.sh
+++ b/.github/skills/sitk-upload-binary-data/scripts/hash_and_stage.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#==========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#==========================================================================
+#
+# Hash binary files, copy into .ExternalData/SHA512/, create .sha512
+# content links, and remove the originals.  Does NOT create a PR or
+# touch any git branches — that is handled separately.
+#
+# Usage:  hash_and_stage.sh <file1> [<file2> ...]
+#
+# Must be run from the SimpleITK source root.
+#
+set -euo pipefail
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+# --- preflight -----------------------------------------------------------
+
+[[ $# -ge 1 ]] || die "Usage: $0 <file1> [<file2> ...]"
+
+if command -v sha512sum >/dev/null 2>&1; then
+    SHA512CMD="sha512sum"
+elif command -v shasum >/dev/null 2>&1; then
+    SHA512CMD="shasum -a 512"
+else
+    die "Neither sha512sum (Linux) nor shasum (macOS) found."
+fi
+
+SOURCE_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" \
+    || die "Not inside a git repository."
+
+ED_DIR="${SOURCE_ROOT}/.ExternalData"
+
+[[ -d "${ED_DIR}/.git" ]] \
+    || die ".ExternalData is not a git clone. Run:\n  gh repo clone SimpleITK/SimpleITKExternalData ${ED_DIR}"
+
+git -C "${ED_DIR}" remote -v 2>/dev/null | grep -q SimpleITKExternalData \
+    || die ".ExternalData is not a clone of SimpleITK/SimpleITKExternalData."
+
+mkdir -p "${ED_DIR}/SHA512"
+
+# --- process files --------------------------------------------------------
+
+MD5_CONFLICTS=()
+
+for FILE in "$@"; do
+    [[ -f "${FILE}" ]] || die "File not found: ${FILE}"
+
+    BASENAME="$(basename "${FILE}")"
+    HASH="$($SHA512CMD "${FILE}" | awk '{print $1}')"
+
+    DEST="${ED_DIR}/SHA512/${HASH}"
+    if [[ -f "${DEST}" ]]; then
+        echo "SKIP  ${BASENAME}: hash already in .ExternalData"
+    else
+        cp "${FILE}" "${DEST}"
+        echo "COPY  ${BASENAME} -> .ExternalData/SHA512/${HASH:0:12}..."
+    fi
+
+    # content link (128 hex chars + newline)
+    echo "${HASH}" > "${FILE}.sha512"
+    echo "LINK  ${FILE}.sha512"
+
+    # remove original
+    rm "${FILE}"
+    echo "DEL   ${FILE}"
+
+    # note old .md5 content links
+    if [[ -f "${FILE}.md5" ]]; then
+        MD5_CONFLICTS+=("${FILE}.md5")
+    fi
+done
+
+# --- summary --------------------------------------------------------------
+
+echo ""
+echo "Content links created.  Next steps:"
+echo ""
+echo "  git add -- $(printf '%s.sha512 ' "$@")"
+
+if [[ ${#MD5_CONFLICTS[@]} -gt 0 ]]; then
+    echo ""
+    echo "Remove obsolete MD5 content links:"
+    echo ""
+    echo "  git rm -- ${MD5_CONFLICTS[*]}"
+fi

--- a/.github/workflows/additional_dictionary.txt
+++ b/.github/workflows/additional_dictionary.txt
@@ -859,6 +859,7 @@ affine
 affines
 al
 alen
+algo
 algol
 aliasa
 alignas
@@ -906,6 +907,7 @@ atoi
 atol
 attractor
 aug
+auth
 auto
 autocorrelation
 autocorrelations
@@ -1019,6 +1021,7 @@ closedness
 cmake
 cmd
 cmds
+codebase
 codebook
 codebooks
 codeofconduct
@@ -1338,6 +1341,7 @@ gimble
 gipl
 gitforwindows
 github
+gitignore
 gitlab
 globals
 gmail
@@ -1898,6 +1902,7 @@ rhs
 rindex
 rint
 rjwagner
+rm
 rms
 roberto
 rockspec
@@ -1942,6 +1947,7 @@ setstate
 sexualized
 sgi
 sha
+shasum
 shi
 short
 showbase
@@ -2033,6 +2039,7 @@ subregion
 subregions
 subsample
 subsampling
+subshell
 subtree
 subtypes
 subvoxel


### PR DESCRIPTION
## Summary

Adds an agent skill (`.github/skills/sitk-upload-binary-data/`) for uploading binary testing data to the `SimpleITK/SimpleITKExternalData` repository:

- Hashes files with SHA-512, stages them in the local `.ExternalData` object store, and creates CMake ExternalData content links.
- Opens a draft PR against the ExternalData repo instead of assuming a fork exists (never auto-forks; prompts for the push remote to use).
- Background on CMake ExternalData, the object store/URL resolution, and the legacy MD5 → SHA-512 migration is documented in an auxiliary resource file (`resources/external-data-background.md`) to keep the main skill concise.

Also adds a few technical terms (`algo`, `auth`, `codebase`, `gitignore`, `rm`, `shasum`, `subshell`) to `.github/workflows/additional_dictionary.txt` so the new skill files pass the comment spell-check pre-commit hook.