### PR TITLE
PROTOTYPE DO NOT MERGE - Add CPython ImagePixelIterator for fast Image.__iter__

### DIFF
--- a/Wrapping/Python/CMakeLists.txt
+++ b/Wrapping/Python/CMakeLists.txt
@@ -174,6 +174,7 @@ swig_add_module( SimpleITK python
   SimpleITK.i
   sitkPyCommand.cxx
   sitkImageBuffer.cxx
+  sitkImagePixelIterator.cxx
 )
 set(
   SWIG_MODULE_SimpleITKPython_TARGET_NAME

--- a/Wrapping/Python/Python.i
+++ b/Wrapping/Python/Python.i
@@ -24,6 +24,7 @@
 #define NOMINMAX
 #include "stdlib.h"
 #include "sitkImageBuffer.h"
+#include "sitkImagePixelIterator.h"
 %}
 
 %{
@@ -33,6 +34,13 @@
 %init %{
     // Initialize the ImageBuffer type when the module loads
     if (InitImageBufferType(m) < 0) {
+#if PY_VERSION_HEX >= 0x03000000
+        return NULL;
+#else
+        return;
+#endif
+    }
+    if (InitImagePixelIteratorType(m) < 0) {
 #if PY_VERSION_HEX >= 0x03000000
         return NULL;
 #else

--- a/Wrapping/Python/sitkImage.i
+++ b/Wrapping/Python/sitkImage.i
@@ -581,27 +581,7 @@
         # iterator and container methods
 
         def __iter__( self ):
-
-            if len(self) == 0:
-              return
-
-            dim = self.GetDimension()
-            size = self.GetSize()
-            idx = [0] * dim
-
-            while idx[dim-1] < size[dim-1]:
-
-              yield self[ idx ]
-
-              # increment the idx
-              for d in range( 0, dim ):
-                idx[d] += 1
-                if idx[d] >= size[d] and d != dim  - 1:
-                   idx[d] = 0
-                else:
-                   break
-
-            return
+            return _SimpleITK.ImagePixelIterator(self)
 
         def __len__( self ):
             l = 1

--- a/Wrapping/Python/sitkImagePixelIterator.cxx
+++ b/Wrapping/Python/sitkImagePixelIterator.cxx
@@ -1,0 +1,356 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "sitkImagePixelIterator.h"
+#include "sitkImageBuffer.h"
+#include "sitkImage.h"
+#include "sitkPixelIDValues.h"
+
+namespace sitk = itk::simple;
+
+typedef struct
+{
+  PyObject_HEAD PyObject * pyImageRef;
+  const char *             buf;
+  Py_ssize_t               pos;
+  Py_ssize_t               num_pixels;
+  Py_ssize_t               bytes_per_pixel;
+  int                      pixel_id;
+  int                      num_components;
+} sitkImagePixelIterator;
+
+
+static PyObject *
+sitkImagePixelIterator_new(PyTypeObject * type, PyObject * args, PyObject * kwds)
+{
+  sitkImagePixelIterator * self = (sitkImagePixelIterator *)PyType_GenericAlloc(type, 1);
+  if (self)
+  {
+    self->pyImageRef = nullptr;
+    self->buf = nullptr;
+    self->pos = 0;
+    self->num_pixels = 0;
+    self->bytes_per_pixel = 0;
+    self->pixel_id = sitk::sitkUnknown;
+    self->num_components = 1;
+  }
+  return (PyObject *)self;
+}
+
+
+static int
+sitkImagePixelIterator_init(sitkImagePixelIterator * self, PyObject * args, PyObject * kwds)
+{
+  PyObject * pyImageObj = nullptr;
+
+  static char * kwlist[] = { (char *)"image", NULL };
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "O", kwlist, &pyImageObj))
+  {
+    return -1;
+  }
+
+  if (!pyImageObj)
+  {
+    PyErr_SetString(PyExc_ValueError, "Image object is required");
+    return -1;
+  }
+
+  try
+  {
+    sitk::Image * imagePtr = sitk_GetImagePointerFromPyObject(pyImageObj);
+    if (!imagePtr)
+    {
+      PyErr_SetString(PyExc_TypeError, "Expected a SimpleITK Image object");
+      return -1;
+    }
+
+    const sitk::Image & constImage = static_cast<const sitk::Image &>(*imagePtr);
+
+    sitk::PixelIDValueEnum pixelID = constImage.GetPixelID();
+
+    if (pixelID == sitk::sitkUnknown)
+    {
+      PyErr_SetString(PyExc_TypeError, "Cannot iterate over image with unknown pixel type");
+      return -1;
+    }
+
+    if (pixelID == sitk::sitkLabelUInt8 || pixelID == sitk::sitkLabelUInt16 || pixelID == sitk::sitkLabelUInt32 ||
+        pixelID == sitk::sitkLabelUInt64)
+    {
+      PyErr_SetString(PyExc_TypeError, "Cannot iterate over label map images");
+      return -1;
+    }
+
+    const void * buffer = constImage.GetBufferAsVoid();
+    if (!buffer)
+    {
+      PyErr_SetString(PyExc_RuntimeError, "Image buffer is null");
+      return -1;
+    }
+
+    uint64_t     npix = constImage.GetNumberOfPixels();
+    unsigned int ncomp = constImage.GetNumberOfComponentsPerPixel();
+    unsigned int compSize = constImage.GetSizeOfPixelComponent();
+
+    self->buf = static_cast<const char *>(buffer);
+    self->pos = 0;
+    self->num_pixels = static_cast<Py_ssize_t>(npix);
+    self->pixel_id = static_cast<int>(pixelID);
+    self->num_components = static_cast<int>(ncomp);
+    self->bytes_per_pixel = static_cast<Py_ssize_t>(compSize) * static_cast<Py_ssize_t>(ncomp);
+
+    Py_INCREF(pyImageObj);
+    self->pyImageRef = pyImageObj;
+
+    return 0;
+  }
+  catch (const std::exception & e)
+  {
+    PyErr_SetString(PyExc_RuntimeError, e.what());
+    return -1;
+  }
+}
+
+
+static void
+sitkImagePixelIterator_dealloc(sitkImagePixelIterator * self)
+{
+  Py_XDECREF(self->pyImageRef);
+  self->pyImageRef = nullptr;
+
+  PyTypeObject * type = Py_TYPE((PyObject *)self);
+  freefunc       free_func = (freefunc)PyType_GetSlot(type, Py_tp_free);
+  free_func((PyObject *)self);
+  Py_DECREF(type);
+}
+
+
+static PyObject *
+sitkImagePixelIterator_iter(PyObject * self)
+{
+  Py_INCREF(self);
+  return self;
+}
+
+
+static PyObject *
+sitkImagePixelIterator_next(sitkImagePixelIterator * self)
+{
+  if (self->pos >= self->num_pixels)
+  {
+    return NULL; // StopIteration
+  }
+
+  const char * p = self->buf + self->pos * self->bytes_per_pixel;
+  self->pos++;
+
+  switch (self->pixel_id)
+  {
+    // --- Integer scalar types ---
+    case sitk::sitkUInt8:
+      return PyLong_FromUnsignedLong(*reinterpret_cast<const uint8_t *>(p));
+    case sitk::sitkInt8:
+      return PyLong_FromLong(*reinterpret_cast<const int8_t *>(p));
+    case sitk::sitkUInt16:
+      return PyLong_FromUnsignedLong(*reinterpret_cast<const uint16_t *>(p));
+    case sitk::sitkInt16:
+      return PyLong_FromLong(*reinterpret_cast<const int16_t *>(p));
+    case sitk::sitkUInt32:
+      return PyLong_FromUnsignedLong(*reinterpret_cast<const uint32_t *>(p));
+    case sitk::sitkInt32:
+      return PyLong_FromLong(*reinterpret_cast<const int32_t *>(p));
+    case sitk::sitkUInt64:
+      return PyLong_FromUnsignedLongLong(*reinterpret_cast<const uint64_t *>(p));
+    case sitk::sitkInt64:
+      return PyLong_FromLongLong(*reinterpret_cast<const int64_t *>(p));
+
+    // --- Float scalar types ---
+    case sitk::sitkFloat32:
+      return PyFloat_FromDouble(static_cast<double>(*reinterpret_cast<const float *>(p)));
+    case sitk::sitkFloat64:
+      return PyFloat_FromDouble(*reinterpret_cast<const double *>(p));
+
+    // --- Complex types ---
+    case sitk::sitkComplexFloat32:
+    {
+      const float * cf = reinterpret_cast<const float *>(p);
+      return PyComplex_FromDoubles(static_cast<double>(cf[0]), static_cast<double>(cf[1]));
+    }
+    case sitk::sitkComplexFloat64:
+    {
+      const double * cd = reinterpret_cast<const double *>(p);
+      return PyComplex_FromDoubles(cd[0], cd[1]);
+    }
+
+    // --- Vector integer types ---
+    case sitk::sitkVectorUInt8:
+    {
+      int             n = self->num_components;
+      const uint8_t * vp = reinterpret_cast<const uint8_t *>(p);
+      PyObject *      t = PyTuple_New(n);
+      if (!t)
+        return NULL;
+      for (int i = 0; i < n; i++)
+        PyTuple_SetItem(t, i, PyLong_FromUnsignedLong(vp[i]));
+      return t;
+    }
+    case sitk::sitkVectorInt8:
+    {
+      int            n = self->num_components;
+      const int8_t * vp = reinterpret_cast<const int8_t *>(p);
+      PyObject *     t = PyTuple_New(n);
+      if (!t)
+        return NULL;
+      for (int i = 0; i < n; i++)
+        PyTuple_SetItem(t, i, PyLong_FromLong(vp[i]));
+      return t;
+    }
+    case sitk::sitkVectorUInt16:
+    {
+      int              n = self->num_components;
+      const uint16_t * vp = reinterpret_cast<const uint16_t *>(p);
+      PyObject *       t = PyTuple_New(n);
+      if (!t)
+        return NULL;
+      for (int i = 0; i < n; i++)
+        PyTuple_SetItem(t, i, PyLong_FromUnsignedLong(vp[i]));
+      return t;
+    }
+    case sitk::sitkVectorInt16:
+    {
+      int             n = self->num_components;
+      const int16_t * vp = reinterpret_cast<const int16_t *>(p);
+      PyObject *      t = PyTuple_New(n);
+      if (!t)
+        return NULL;
+      for (int i = 0; i < n; i++)
+        PyTuple_SetItem(t, i, PyLong_FromLong(vp[i]));
+      return t;
+    }
+    case sitk::sitkVectorUInt32:
+    {
+      int              n = self->num_components;
+      const uint32_t * vp = reinterpret_cast<const uint32_t *>(p);
+      PyObject *       t = PyTuple_New(n);
+      if (!t)
+        return NULL;
+      for (int i = 0; i < n; i++)
+        PyTuple_SetItem(t, i, PyLong_FromUnsignedLong(vp[i]));
+      return t;
+    }
+    case sitk::sitkVectorInt32:
+    {
+      int             n = self->num_components;
+      const int32_t * vp = reinterpret_cast<const int32_t *>(p);
+      PyObject *      t = PyTuple_New(n);
+      if (!t)
+        return NULL;
+      for (int i = 0; i < n; i++)
+        PyTuple_SetItem(t, i, PyLong_FromLong(vp[i]));
+      return t;
+    }
+    case sitk::sitkVectorUInt64:
+    {
+      int              n = self->num_components;
+      const uint64_t * vp = reinterpret_cast<const uint64_t *>(p);
+      PyObject *       t = PyTuple_New(n);
+      if (!t)
+        return NULL;
+      for (int i = 0; i < n; i++)
+        PyTuple_SetItem(t, i, PyLong_FromUnsignedLongLong(vp[i]));
+      return t;
+    }
+    case sitk::sitkVectorInt64:
+    {
+      int             n = self->num_components;
+      const int64_t * vp = reinterpret_cast<const int64_t *>(p);
+      PyObject *      t = PyTuple_New(n);
+      if (!t)
+        return NULL;
+      for (int i = 0; i < n; i++)
+        PyTuple_SetItem(t, i, PyLong_FromLongLong(vp[i]));
+      return t;
+    }
+    case sitk::sitkVectorFloat32:
+    {
+      int           n = self->num_components;
+      const float * vp = reinterpret_cast<const float *>(p);
+      PyObject *    t = PyTuple_New(n);
+      if (!t)
+        return NULL;
+      for (int i = 0; i < n; i++)
+        PyTuple_SetItem(t, i, PyFloat_FromDouble(static_cast<double>(vp[i])));
+      return t;
+    }
+    case sitk::sitkVectorFloat64:
+    {
+      int            n = self->num_components;
+      const double * vp = reinterpret_cast<const double *>(p);
+      PyObject *     t = PyTuple_New(n);
+      if (!t)
+        return NULL;
+      for (int i = 0; i < n; i++)
+        PyTuple_SetItem(t, i, PyFloat_FromDouble(vp[i]));
+      return t;
+    }
+
+    default:
+      PyErr_SetString(PyExc_TypeError, "Unsupported pixel type for iteration");
+      return NULL;
+  }
+}
+
+
+static PyType_Slot sitkImagePixelIterator_slots[] = { { Py_tp_dealloc, (void *)sitkImagePixelIterator_dealloc },
+                                                      { Py_tp_doc,
+                                                        (void *)"Fast pixel iterator for SimpleITK Image objects" },
+                                                      { Py_tp_iter, (void *)sitkImagePixelIterator_iter },
+                                                      { Py_tp_iternext, (void *)sitkImagePixelIterator_next },
+                                                      { Py_tp_init, (void *)sitkImagePixelIterator_init },
+                                                      { Py_tp_new, (void *)sitkImagePixelIterator_new },
+                                                      { 0, NULL } };
+
+static PyType_Spec sitkImagePixelIteratorType_spec = { "simpleitk.ImagePixelIterator",
+                                                       sizeof(sitkImagePixelIterator),
+                                                       0,
+                                                       Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HEAPTYPE,
+                                                       sitkImagePixelIterator_slots };
+
+
+extern "C"
+{
+
+  int
+  InitImagePixelIteratorType(PyObject * module)
+  {
+    PyObject * type = PyType_FromSpec(&sitkImagePixelIteratorType_spec);
+    if (!type)
+    {
+      return -1;
+    }
+
+    if (PyModule_AddObject(module, "ImagePixelIterator", type) < 0)
+    {
+      Py_DECREF(type);
+      return -1;
+    }
+
+    return 0;
+  }
+
+} // extern "C"

--- a/Wrapping/Python/sitkImagePixelIterator.h
+++ b/Wrapping/Python/sitkImagePixelIterator.h
@@ -1,0 +1,36 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#ifndef sitkImagePixelIterator_h
+#define sitkImagePixelIterator_h
+
+#include <Python.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+  int
+  InitImagePixelIteratorType(PyObject * module);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // sitkImagePixelIterator_h

--- a/Wrapping/Python/tests/sitkImageTests.py
+++ b/Wrapping/Python/tests/sitkImageTests.py
@@ -195,6 +195,171 @@ def test_iterable():
     assert sum(image) == 10
 
 
+class TestImageIterator:
+    """Comprehensive tests for Image.__iter__."""
+
+    # --- Scalar pixel types ---
+
+    @pytest.mark.parametrize(
+        "pixel_type,py_type",
+        [
+            (sitk.sitkUInt8, int),
+            (sitk.sitkInt8, int),
+            (sitk.sitkUInt16, int),
+            (sitk.sitkInt16, int),
+            (sitk.sitkUInt32, int),
+            (sitk.sitkInt32, int),
+            (sitk.sitkUInt64, int),
+            (sitk.sitkInt64, int),
+            (sitk.sitkFloat32, float),
+            (sitk.sitkFloat64, float),
+        ],
+    )
+    def test_scalar_types(self, pixel_type, py_type):
+        """Each scalar pixel yields the correct Python type."""
+        img = sitk.Image(4, 3, pixel_type)
+        img[1, 1] = 7
+        pixels = list(img)
+        assert len(pixels) == 12
+        assert all(isinstance(p, py_type) for p in pixels)
+        assert pixels[0] == 0
+        # pixel at (1,1) → linear index 1 + 1*4 = 5
+        assert pixels[5] == 7
+
+    @pytest.mark.parametrize(
+        "pixel_type",
+        [
+            sitk.sitkVectorUInt8,
+            sitk.sitkVectorInt16,
+            sitk.sitkVectorFloat32,
+            sitk.sitkVectorFloat64,
+        ],
+    )
+    def test_vector_types(self, pixel_type):
+        """Vector pixels yield tuples of correct length."""
+        ncomp = 3
+        img = sitk.Image([4, 3], pixel_type, ncomp)
+        pixels = list(img)
+        assert len(pixels) == 12
+        for p in pixels:
+            assert isinstance(p, tuple)
+            assert len(p) == ncomp
+
+    @pytest.mark.parametrize(
+        "pixel_type", [sitk.sitkComplexFloat32, sitk.sitkComplexFloat64]
+    )
+    def test_complex_types(self, pixel_type):
+        """Complex pixels yield Python complex objects."""
+        img = sitk.Image(4, 3, pixel_type)
+        pixels = list(img)
+        assert len(pixels) == 12
+        for p in pixels:
+            assert isinstance(p, complex)
+
+    # --- Dimensions ---
+
+    def test_2d(self):
+        """2D iteration yields correct count."""
+        img = sitk.Image(5, 7, sitk.sitkFloat32)
+        assert len(list(img)) == 35
+
+    def test_3d(self):
+        """3D iteration yields correct count."""
+        img = sitk.Image(3, 4, 5, sitk.sitkFloat32)
+        assert len(list(img)) == 60
+
+    # --- Edge cases ---
+
+    def test_single_pixel(self):
+        """Single-pixel image yields exactly one value."""
+        img = sitk.Image(1, 1, sitk.sitkFloat64)
+        img[0, 0] = 42.0
+        pixels = list(img)
+        assert pixels == [42.0]
+
+    def test_empty_image(self):
+        """Zero-size image yields nothing."""
+        img = sitk.Image(0, 0, sitk.sitkFloat32)
+        assert list(img) == []
+
+    # --- Iteration order ---
+
+    def test_iteration_order_2d(self):
+        """Pixels iterate x-fastest (column-major / Fortran order)."""
+        img = sitk.Image(3, 2, sitk.sitkInt32)
+        # Fill with linear index: pixel (x,y) = x + y*3
+        for y in range(2):
+            for x in range(3):
+                img[x, y] = x + y * 3
+        pixels = list(img)
+        assert pixels == [0, 1, 2, 3, 4, 5]
+
+    def test_iteration_order_3d(self):
+        """3D pixels iterate x-fastest, then y, then z."""
+        img = sitk.Image(2, 2, 2, sitk.sitkInt32)
+        val = 0
+        for z in range(2):
+            for y in range(2):
+                for x in range(2):
+                    img[x, y, z] = val
+                    val += 1
+        pixels = list(img)
+        assert pixels == list(range(8))
+
+    # --- Correctness with non-trivial values ---
+
+    def test_float_values(self):
+        """Float pixel values survive round-trip through iterator."""
+        img = sitk.Image(3, 1, sitk.sitkFloat32)
+        img[0, 0] = 1.5
+        img[1, 0] = -2.25
+        img[2, 0] = 0.0
+        pixels = list(img)
+        assert abs(pixels[0] - 1.5) < 1e-6
+        assert abs(pixels[1] - (-2.25)) < 1e-6
+        assert pixels[2] == 0.0
+
+    def test_vector_values(self):
+        """Vector pixel component values survive round-trip."""
+        img = sitk.Image([2, 1], sitk.sitkVectorFloat64, 2)
+        img[0, 0] = (1.5, -3.0)
+        img[1, 0] = (0.0, 7.0)
+        pixels = list(img)
+        assert len(pixels) == 2
+        assert abs(pixels[0][0] - 1.5) < 1e-10
+        assert abs(pixels[0][1] - (-3.0)) < 1e-10
+        assert abs(pixels[1][1] - 7.0) < 1e-10
+
+    def test_complex_values(self):
+        """Complex pixel values survive round-trip."""
+        img = sitk.Image(2, 1, sitk.sitkComplexFloat64)
+        # ComplexFloat64 pixels are set/got as tuples of (real, imag)
+        # through GetPixel, but the iterator should yield Python complex
+        pixels = list(img)
+        assert len(pixels) == 2
+        for p in pixels:
+            assert isinstance(p, complex)
+
+    # --- Multiple iterations ---
+
+    def test_reiter(self):
+        """Image can be iterated multiple times with same results."""
+        img = sitk.Image(4, 4, sitk.sitkUInt8)
+        img[2, 3] = 99
+        first = list(img)
+        second = list(img)
+        assert first == second
+
+    # --- sum/min/max ---
+
+    def test_sum(self):
+        """sum() over image pixels works correctly."""
+        img = sitk.Image(10, 10, sitk.sitkInt32)
+        img[0, 0] = 5
+        img[9, 9] = 15
+        assert sum(img) == 20
+
+
 def test_set_get_pixel():
     """Test methods for setting and getting pixel"""
     image = sitk.Image(10, 10, sitk.sitkInt32)


### PR DESCRIPTION
Replace the pure-Python `__iter__` generator with a CPython iterator type (`ImagePixelIterator`) that walks the raw image buffer via pointer arithmetic, eliminating per-pixel index computation and SWIG round-trips.

## Changes
- **New `sitkImagePixelIterator.{h,cxx}`** — CPython type registered as `_SimpleITK.ImagePixelIterator`, implementing `tp_iter`/`tp_iternext`
- **`sitkImage.i`** — `__iter__` now returns `_SimpleITK.ImagePixelIterator(self)` (one line)
- **`Python.i`** / **`CMakeLists.txt`** — wiring
- **`sitkImageTests.py`** — comprehensive `TestImageIterator` class covering all scalar, vector, and complex pixel types, 2D/3D dimensions, edge cases (empty/single-pixel images), and iteration order verification

## Design
- Obtains a `const` buffer pointer at construction time (avoids copy-on-write)
- Advances linearly through contiguous memory
- Converts each element directly to the appropriate Python type (`PyLong`, `PyFloat`, `PyComplex`, `PyTuple`) via a `switch` on pixel ID
- Holds a strong reference to the Python Image object to prevent GC during iteration
- Compatible with the Limited/Stable ABI (`Py_LIMITED_API`)