### PR TITLE
Slim down kw-pre-commit: drop dead code, delegate to standard hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,8 @@ repos:
    - id: check-yaml
    - id: check-xml
    - id: check-shebang-scripts-are-executable
+   - id: check-executables-have-shebangs
+     exclude: '\.bat$'
    - id: end-of-file-fixer
      types: [text]
    - id: trailing-whitespace

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,6 +88,11 @@ repos:
       language: system
       stages: [pre-commit]
       pass_filenames: false
+    - id: check-file-size
+      name: 'Check staged file sizes'
+      entry: 'Utilities/Hooks/check-file-size.py'
+      language: python
+      stages: [pre-commit]
     - id: forbid-txx
       name: 'forbid txx extensions'
       entry: Files with the .txx extension are deprecated -- please use .hxx instead

--- a/Utilities/Hooks/check-file-size.py
+++ b/Utilities/Hooks/check-file-size.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+# ==========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          https://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ==========================================================================
+#
+# Reject staged files larger than a configurable size limit.
+#
+# The local default limit is set with the git config keys
+# "hooks.MaxObjectKiB" (in KiB) or "hooks.max-size" (in bytes). Either can be
+# overridden for specific paths or patterns via the "hooks.MaxObjectKiB" or
+# "hooks-max-size" attributes in a git attributes file -- see
+# "git help attributes" for the attribute file format.
+#
+# Adapted from the check_size logic formerly in Utilities/Hooks/kw-pre-commit.
+
+import subprocess
+import sys
+
+DEFAULT_MAX_KIB = 1024
+
+
+def die(message):
+    print("pre-commit hook failure", file=sys.stderr)
+    print("-----------------------", file=sys.stderr)
+    print(message, file=sys.stderr)
+    sys.exit(1)
+
+
+def git_config_int(key, default):
+    result = subprocess.run(["git", "config", "--get", key], capture_output=True, text=True)
+    value = result.stdout.strip()
+    return int(value) if value else default
+
+
+def check_attr(attr, path):
+    result = subprocess.run(
+        ["git", "check-attr", attr, "--", path],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    prefix = f"{path}: {attr}: "
+    line = result.stdout.strip()
+    return line[len(prefix) :] if line.startswith(prefix) else "unspecified"
+
+
+def staged_blob(path):
+    """Return (mode, object_id) for a path staged in the index, or None if
+    the path is not currently staged (e.g. deleted)."""
+    result = subprocess.run(
+        ["git", "ls-files", "-s", "--", path],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    line = result.stdout.strip()
+    if not line:
+        return None
+    fields = line.split()
+    return fields[0], fields[1]
+
+
+def blob_size(object_id):
+    result = subprocess.run(
+        ["git", "cat-file", "-s", object_id],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return int(result.stdout.strip())
+
+
+def max_bytes_for(path, default_max_kib, default_max_bytes):
+    """Resolve the size limit, in bytes, for path (None means unlimited)."""
+    max_kib_attr = check_attr("hooks.MaxObjectKiB", path)
+    if max_kib_attr not in ("unset", "set", "unspecified"):
+        try:
+            int(max_kib_attr)
+        except ValueError:
+            die(f'The path \'{path}\' has invalid attribute "hooks.MaxObjectKiB={max_kib_attr}".')
+
+    max_bytes_attr = check_attr("hooks-max-size", path)
+    if max_bytes_attr == "unset":
+        return None
+    if max_bytes_attr == "set":
+        return default_max_bytes
+    if max_bytes_attr == "unspecified":
+        if max_kib_attr == "unset":
+            return None
+        if max_kib_attr == "set":
+            return default_max_kib * 1024
+        if max_kib_attr == "unspecified":
+            return default_max_bytes
+        return int(max_kib_attr) * 1024
+    try:
+        return int(max_bytes_attr)
+    except ValueError:
+        die(f'The path \'{path}\' has invalid attribute "hooks-max-size={max_bytes_attr}".')
+
+
+def main():
+    paths = sys.argv[1:]
+    if not paths:
+        return 0
+
+    default_max_kib = git_config_int("hooks.MaxObjectKiB", DEFAULT_MAX_KIB)
+    default_max_bytes = git_config_int("hooks.max-size", default_max_kib * 1024)
+
+    errors = []
+    for path in paths:
+        staged = staged_blob(path)
+        if staged is None:
+            continue
+        mode, object_id = staged
+        if mode == "160000":  # Nested repository reference -- no blob to size.
+            continue
+
+        max_bytes = max_bytes_for(path, default_max_kib, default_max_bytes)
+        if max_bytes is None or max_bytes <= 0:
+            continue
+
+        size = blob_size(object_id)
+        if size > max_bytes:
+            errors.append(f"The path '{path}' has size {size} bytes, greater than allowed {max_bytes} bytes.")
+
+    if errors:
+        die(
+            "At least one file is staged for commit with size larger than its limit.\n"
+            "We prefer to keep large files out of the main source tree, especially\n"
+            "binary files that do not compress well.  This hook disallows large files\n"
+            'by default but can be configured.  A limit for specific files or patterns\n'
+            'may be set in ".gitattributes" with the "hooks-max-size" attribute.\n'
+            "For example, the line\n\n"
+            "  *.c              hooks-max-size=1500000\n\n"
+            'sets a limit of 1500000 bytes for C source files.  See "git help attributes"\n'
+            "for details on the .gitattributes format.  If no attribute has been set\n"
+            "for a given file then its size is limited by the local default.  Run\n\n"
+            "  git config hooks.max-size <bytes>\n\n"
+            "to set the local default limit (0 to disable).\n\n" + "\n".join(errors)
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Utilities/Hooks/kw-pre-commit
+++ b/Utilities/Hooks/kw-pre-commit
@@ -60,9 +60,6 @@ else
 	against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
 fi
 
-# Merge ("git commit" after "git merge" with conflicts or --no-commit)
-merge_head=$(git rev-parse -q --verify MERGE_HEAD) || merge_head=''
-
 # Disallow non-ascii file names.  The printable range starts at the
 # space character and ends with tilde.
 if test "$(git diff --cached --name-only --diff-filter=A -z $against |
@@ -247,25 +244,6 @@ while read src_mode dst_mode src_obj dst_obj status file; do
 	if test "$dst_mode" != "160000" -a "$dst_mode" != '000000'; then
 		check_size
 	fi
-done
-)
-test -z "$bad" || die "$bad"
-
-#-----------------------------------------------------------------------------
-# Merge checks.
-if test -n "$merge_head"; then
-	merge_diffs=$(git diff-index --cached $merge_head -- |
-	              sed -n '/^:[^:]/ {s/^://;p;}')
-else
-	merge_diffs=''
-fi
-merge_diffs_normal=$(echo "$merge_diffs" | grep -v '^...... 160000')
-merge_diffs_module=$(echo "$merge_diffs" | grep    '^...... 160000')
-bad=$(
-test -n "$merge_diffs_module" && echo "$merge_diffs_module" |
-while read src_mode dst_mode src_obj dst_obj status file; do
-	check_module_rewind MERGE_HEAD "$merge_head" ||
-	break
 done
 )
 test -z "$bad" || die "$bad"

--- a/Utilities/Hooks/kw-pre-commit
+++ b/Utilities/Hooks/kw-pre-commit
@@ -114,50 +114,7 @@ done)
 test -z "$bad" || die "$bad"
 
 #-----------------------------------------------------------------------------
-# Check file modes and sizes.
-mode_looks_exe() {
-	case "$1" in
-		*.bat) return 0 ;;
-		*.cmd) return 0 ;;
-		*.exe) return 0 ;;
-		*.com) return 0 ;;
-	esac
-	git cat-file blob "$2" | head -1 | grep "^#!/" > /dev/null
-}
-mode_not_exe () {
-	echo "The file '$file' looks executable but does not have an executable mode.
-On UNIX, run:
-
-  $ chmod u+x '$file' && git add -u '$file'
-
-On Windows, run:
-
-  $ git update-index --chmod=+x '$file'
-"
-}
-mode_bad_exe () {
-	echo "The file '$file' has executable mode but does not look executable.
-On UNIX, run:
-
-  $ chmod u-x '$file' && git add -u '$file'
-
-On Windows, run:
-
-  $ git update-index --chmod=-x '$file'
-"
-}
-mode_non_file () {
-	echo "The path '$file' has a non-file mode."
-}
-check_mode() {
-	case "$dst_mode" in
-		100755) mode_looks_exe "$file" "$dst_obj" || mode_bad_exe ;;
-		100644) mode_looks_exe "$file" "$dst_obj" && mode_not_exe ;;
-		160000) ;;
-		*)	mode_non_file ;;
-	esac
-}
-
+# Check file sizes.
 size_max_KiB=$(git config hooks.MaxObjectKiB)
 test -n "$size_max_KiB" || size_max_KiB=1024
 size_max_bytes=$(git config hooks.max-size)
@@ -238,9 +195,6 @@ diffs_normal=$(echo "$diffs" | grep -v '^...... 160000')
 bad=$(
 test -n "$diffs_normal" && echo "$diffs_normal" |
 while read src_mode dst_mode src_obj dst_obj status file; do
-	if test "$src_mode" != "$dst_mode" -a "$dst_mode" != "000000"; then
-		check_mode
-	fi
 	if test "$dst_mode" != "160000" -a "$dst_mode" != '000000'; then
 		check_size
 	fi

--- a/Utilities/Hooks/kw-pre-commit
+++ b/Utilities/Hooks/kw-pre-commit
@@ -24,8 +24,6 @@ die() {
 	exit 1
 }
 
-zero='0000000000000000000000000000000000000000'
-
 #-----------------------------------------------------------------------------
 # Check for committer identity.
 advice='
@@ -111,93 +109,4 @@ bad=$(git diff-index --name-only --cached $against -- |
 while read file; do
 	check_whitespace "$file"
 done)
-test -z "$bad" || die "$bad"
-
-#-----------------------------------------------------------------------------
-# Check file sizes.
-size_max_KiB=$(git config hooks.MaxObjectKiB)
-test -n "$size_max_KiB" || size_max_KiB=1024
-size_max_bytes=$(git config hooks.max-size)
-test -n "$size_max_bytes" || size_max_bytes=$((${size_max_KiB} * 1024))
-size_too_large_once=""
-size_too_large_once() {
-	test -z "$size_too_large_once" || return ; size_too_large_once=done
-	echo 'At least one file is staged for commit with size larger than its limit.
-We prefer to keep large files out of the main source tree, especially
-binary files that do not compress well.  This hook disallows large files
-by default but can be configured.  A limit for specific files or patterns
-may be set in ".gitattributes" with the "hooks-max-size" attribute.
-For example, the line
-
-  *.c              hooks-max-size=1500000
-
-sets a limit of 1500000 bytes for C source files.  See "git help attributes"
-for details on the .gitattributes format.  If no attribute has been set
-for a given file then its size is limited by the local default.  Run
-
-  git config hooks.max-size $bytes
-
-to set the local default limit (0 to disable).
-'
-}
-size_too_large() {
-	size_too_large_once
-	echo "The path '$file' has size $file_bytes bytes, greater than allowed $max_bytes bytes."
-}
-size_validate_max_KiB() {
-	test "$max_KiB" -ge "0" 2>/dev/null && return 0
-	echo "The path '$file' has invalid attribute \"hooks.MaxObjectKiB=$max_KiB\"."
-	return 1
-}
-size_validate_max_bytes() {
-	test "$max_bytes" -ge "0" 2>/dev/null && return 0
-	echo "The path '$file' has invalid attribute \"hooks-max-size=$max_bytes\"."
-	return 1
-}
-check_size() {
-	test "$dst_obj" != "$zero" || return
-	max_KiB=$(git check-attr hooks.MaxObjectKiB -- "$file" | sed 's/^[^:]*: hooks.MaxObjectKiB: //')
-	case "$max_KiB" in
-		'unset') ;;
-		'set') ;;
-		'unspecified') ;;
-		*) size_validate_max_KiB || return ;;
-	esac
-	max_bytes=$(git check-attr hooks-max-size -- "$file" | sed 's/^[^:]*: hooks-max-size: //')
-	case "$max_bytes" in
-		'unset')       return ;; # No maximum for this object.
-		'set')         max_bytes="$size_max_bytes" ;; # Use local default.
-		'unspecified')
-			# Fall back to max KiB setting.
-			case "$max_KiB" in
-				'unset')       return ;; # No maximum for this object.
-				'set')         max_bytes=$(("${size_max_KiB}" * 1024)) ;; # Use local default.
-				'unspecified') max_bytes="$size_max_bytes" ;; # Use local default.
-				*) max_bytes=$(("${max_KiB}" * 1024)) ;;
-			esac
-			;;
-		*) size_validate_max_bytes || return ;;
-	esac
-	if test "$max_bytes" -gt "0"; then
-		file_bytes=$(git cat-file -s "$dst_obj")
-		test "$file_bytes" -le "$max_bytes" || size_too_large
-	fi
-}
-
-short_commit() {
-	git rev-parse --short "$1" 2>/dev/null || echo "$1"
-}
-
-
-diffs=$(git diff-index --cached $against -- |
-        sed -n '/^:[^:]/ {s/^://;p;}')
-diffs_normal=$(echo "$diffs" | grep -v '^...... 160000')
-bad=$(
-test -n "$diffs_normal" && echo "$diffs_normal" |
-while read src_mode dst_mode src_obj dst_obj status file; do
-	if test "$dst_mode" != "160000" -a "$dst_mode" != '000000'; then
-		check_size
-	fi
-done
-)
 test -z "$bad" || die "$bad"


### PR DESCRIPTION
Clean up `Utilities/Hooks/kw-pre-commit` by removing logic that is either
dead or now duplicated by standard `pre-commit-hooks`, and by extracting
the remaining custom file-size check into its own Python hook.

## Changes

- **Remove the broken submodule/merge-rewind check** — it called an
  undefined `check_module_rewind` function and is redundant now that
  `forbid-submodules` is enabled.
- **Remove the executable/shebang mode check** (`check_mode`,
  `mode_looks_exe`, `mode_not_exe`, `mode_bad_exe`, `mode_non_file`) —
  superseded by the standard `check-shebang-scripts-are-executable`
  (already enabled) and newly-added `check-executables-have-shebangs`
  hooks. This also drops a bug where the catch-all branch mis-flagged
  newly added symlinks as an invalid file mode.
- **Extract the file-size check into `Utilities/Hooks/check-file-size.py`**,
  registered as its own local `check-file-size` hook (`language: python`).
  Behavior is preserved: per-path overrides via `hooks-max-size`/
  `hooks.MaxObjectKiB` git attributes, falling back to the
  `hooks.max-size`/`hooks.MaxObjectKiB` git config defaults. There's no
  standard-hook equivalent since `check-added-large-files` has no
  per-path attribute-driven override mechanism.

## Remaining in kw-pre-commit

Committer-identity validation, non-ascii filename rejection, and the
`.gitattributes`-driven whitespace checks (`tab-in-indent`,
`no-lf-at-eof`) — none of these have standard `pre-commit-hooks`
equivalents.