### PR TITLE
Add setup-externaldata script to configure .ExternalData clone

### DIFF
--- a/.github/skills/sitk-upload-binary-data/SKILL.md
+++ b/.github/skills/sitk-upload-binary-data/SKILL.md
@@ -100,10 +100,11 @@ test -d .ExternalData/.git
 If this fails, **stop** and tell the user:
 
 > The `.ExternalData` directory must be a clone of
-> `SimpleITK/SimpleITKExternalData`. To set it up, run:
+> `SimpleITK/SimpleITKExternalData`. To set it up (including a
+> configured push remote), run:
 >
 > ```
-> gh repo clone SimpleITK/SimpleITKExternalData .ExternalData
+> Utilities/GitSetup/setup-externaldata
 > ```
 
 Otherwise, list its remotes to identify both the upstream and the remote
@@ -114,17 +115,26 @@ git -C .ExternalData remote -v
 ```
 
 - The remote pointing at `SimpleITK/SimpleITKExternalData` itself
-  (typically `origin`/`upstream`) is `<upstream-remote>` — used in Step 4
-  to fetch and base the branch on `main`. Do not assume it is named
-  `origin`; read the actual name from the `remote -v` output.
-- Do **not** run `gh repo fork` — never create a fork automatically.
-  Among the *other* remotes (not `<upstream-remote>`):
+  (typically `origin`) is `<upstream-remote>` — used in Step 4 to fetch
+  and base the branch on `main`. Do not assume it is named `origin`, read
+  the actual name from the `remote -v` output.
+- `Utilities/GitSetup/setup-externaldata` configures a fork push remote
+  in `.ExternalData` automatically, using the same remote name as
+  `github.fork.remote` in the main SimpleITK repo (mirroring the fork
+  account already set up for SimpleITK's own GitHub remote via
+  `setup-github`). Prefer this convention over guessing:
+
+  ```bash
+  fork_remote=$(git config --get github.fork.remote)
+  ```
+
+  If `<fork_remote>` is non-empty and also exists as a remote in
+  `.ExternalData` (per the `remote -v` output above), use it directly as
+  `<push-remote>` — no need to ask the user.
+- Otherwise, fall back to inspecting the *other* remotes (not
+  `<upstream-remote>`):
   - If exactly one remains, use its name as `<push-remote>`.
-  - Otherwise (zero or multiple candidates), ask the user which remote
-    name to use as `<push-remote>`, listing whatever remote names were
-    found. If none exist, tell the user they need to add one first
-    (e.g. by running `gh repo fork --remote --remote-name <name>`
-    themselves).
+  - Otherwise (zero or multiple candidates), ask the user to rerun the SetupForDevelopment scripts.
 
 Use `<upstream-remote>` and `<push-remote>` in Step 4.
 

--- a/.github/skills/sitk-upload-binary-data/scripts/hash_and_stage.sh
+++ b/.github/skills/sitk-upload-binary-data/scripts/hash_and_stage.sh
@@ -47,7 +47,7 @@ SOURCE_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" \
 ED_DIR="${SOURCE_ROOT}/.ExternalData"
 
 [[ -d "${ED_DIR}/.git" ]] \
-    || die ".ExternalData is not a git clone. Run:\n  gh repo clone SimpleITK/SimpleITKExternalData ${ED_DIR}"
+    || die ".ExternalData is not a git clone. Run:\n  Utilities/GitSetup/setup-externaldata"
 
 git -C "${ED_DIR}" remote -v 2>/dev/null | grep -q SimpleITKExternalData \
     || die ".ExternalData is not a clone of SimpleITK/SimpleITKExternalData."

--- a/.github/workflows/additional_dictionary.txt
+++ b/.github/workflows/additional_dictionary.txt
@@ -1258,6 +1258,7 @@ expr
 extendible
 extensibility
 extern
+externaldata
 extrapolaters
 extrapolator
 extrema

--- a/Utilities/GitSetup/setup-externaldata
+++ b/Utilities/GitSetup/setup-externaldata
@@ -34,17 +34,32 @@ externaldata_dir="$(git rev-parse --show-toplevel)/.ExternalData"
 
 if test -d "${externaldata_dir}/.git"; then
 	echo "Updating \"${externaldata_dir}\" clone..." &&
-	git -C "${externaldata_dir}" fetch --quiet origin &&
+	(cd "${externaldata_dir}" && git fetch --quiet origin) &&
 	echo "Done." ||
 	die "Failed to update \"${externaldata_dir}\"."
-elif test -e "${externaldata_dir}"; then
-	die "\"${externaldata_dir}\" exists but is not a Git clone of
+else
+	if test -e "${externaldata_dir}"; then
+		# The source tree ships a skeleton ".ExternalData" directory containing
+		# only a checked-in "README.rst" placeholder (see .gitignore). Only
+		# remove the directory automatically when its contents exactly match
+		# that skeleton, so any real user data placed there is never deleted.
+		# Use "ls -A" rather than "find -printf" since -printf is a GNU
+		# extension not supported by BSD/macOS find.
+		skeleton_contents=$(ls -A "${externaldata_dir}" | sort)
+		if test "${skeleton_contents}" != "README.rst"; then
+			die "\"${externaldata_dir}\" exists but is not a Git clone of
 
   ${externaldata_url}
 
-Binary data uploads and local resolution of ExternalData content links may
-not work as expected until this is corrected."
-else
+and contains files other than the expected \"README.rst\" placeholder, so it
+will not be removed automatically. Please move or remove it manually, then
+re-run this script."
+		fi
+		echo "Removing existing \"${externaldata_dir}\" (placeholder/skeleton directory)..." &&
+		rm -f "${externaldata_dir}/README.rst" &&
+		rmdir "${externaldata_dir}" ||
+		die "Failed to remove existing \"${externaldata_dir}\"."
+	fi
 	echo "Cloning \"${externaldata_dir}\" (local object store for CMake ExternalData and staging area for binary data uploads)..." &&
 	git clone --quiet "${externaldata_url}" "${externaldata_dir}" &&
 	echo "Done." ||
@@ -68,15 +83,16 @@ else
 		echo "No GitHub fork is configured for this repository yet (run
 Utilities/GitSetup/setup-github first); skipping fork remote setup for
 \"${externaldata_dir}\"."
-	elif git -C "${externaldata_dir}" config --get remote."${fork_remote}".url > /dev/null 2>&1; then
+	elif (cd "${externaldata_dir}" && git config --get remote."${fork_remote}".url) > /dev/null 2>&1; then
 		echo "\"${externaldata_dir}\" already has a \"${fork_remote}\" remote configured."
 	else
 		github_username=$(echo "${fork_remote_url}" | sed -E 's#.*[:/]([^/]+)/[^/]+$#\1#') &&
 		fork_fetchurl="https://github.com/${github_username}/${externaldata_repo}.git" &&
 		fork_pushurl="git@github.com:${github_username}/${externaldata_repo}.git" &&
 		echo "Configuring \"${fork_remote}\" remote in \"${externaldata_dir}\" for pushing to ${github_username}/${externaldata_repo}..." &&
-		git -C "${externaldata_dir}" remote add "${fork_remote}" "${fork_fetchurl}" &&
-		git -C "${externaldata_dir}" config remote."${fork_remote}".pushurl "${fork_pushurl}" &&
+		(cd "${externaldata_dir}" &&
+		 git remote add "${fork_remote}" "${fork_fetchurl}" &&
+		 git config remote."${fork_remote}".pushurl "${fork_pushurl}") &&
 		echo "Done. If you have not already, fork
   https://github.com/${externaldata_organization}/${externaldata_repo}
 to your account (${github_username}) using the Fork button on GitHub." ||

--- a/Utilities/GitSetup/setup-externaldata
+++ b/Utilities/GitSetup/setup-externaldata
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#==========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#==========================================================================*/
+
+# Set up ".ExternalData" as a local clone of the SimpleITKExternalData
+# repository. CMake ExternalData resolves content links from this
+# directory as a local object store (see CMake/sitkExternalData.cmake),
+# and the "sitk-upload-binary-data" skill uses it as the staging area
+# when uploading new binary test data.
+
+die() {
+	echo 1>&2 "$@" ; exit 1
+}
+
+externaldata_organization='SimpleITK'
+externaldata_repo='SimpleITKExternalData'
+externaldata_url="https://github.com/${externaldata_organization}/${externaldata_repo}.git"
+externaldata_dir='.ExternalData'
+
+if test -d "${externaldata_dir}/.git"; then
+	echo "Updating \"${externaldata_dir}\" clone..." &&
+	git -C "${externaldata_dir}" fetch --quiet origin &&
+	echo "Done." ||
+	die "Failed to update \"${externaldata_dir}\"."
+elif test -e "${externaldata_dir}"; then
+	die "\"${externaldata_dir}\" exists but is not a Git clone of
+
+  ${externaldata_url}
+
+Binary data uploads and local resolution of ExternalData content links may
+not work as expected until this is corrected."
+else
+	echo "Cloning \"${externaldata_dir}\" (local object store for CMake ExternalData and staging area for binary data uploads)..." &&
+	git clone --quiet "${externaldata_url}" "${externaldata_dir}" &&
+	echo "Done." ||
+	die "Failed to clone \"${externaldata_dir}\"."
+fi
+
+# The "sitk-upload-binary-data" skill pushes new binary data to a personal
+# fork of SimpleITKExternalData. Mirror the fork account already configured
+# for this repository's own GitHub remote (see setup-github) so a push
+# remote is ready in ".ExternalData" without prompting again.
+fork_remote=$(git config --get github.fork.remote || echo "github")
+fork_remote_url=$(git config --get remote."${fork_remote}".url || echo '')
+if test -z "${fork_remote_url}"; then
+	echo "No GitHub fork is configured for this repository yet (run
+Utilities/GitSetup/setup-github first); skipping fork remote setup for
+\"${externaldata_dir}\"."
+elif git -C "${externaldata_dir}" config --get remote."${fork_remote}".url > /dev/null 2>&1; then
+	echo "\"${externaldata_dir}\" already has a \"${fork_remote}\" remote configured."
+else
+	github_username=$(echo "${fork_remote_url}" | sed -E 's#.*[:/]([^/]+)/[^/]+$#\1#') &&
+	fork_fetchurl="https://github.com/${github_username}/${externaldata_repo}.git" &&
+	fork_pushurl="git@github.com:${github_username}/${externaldata_repo}.git" &&
+	echo "Configuring \"${fork_remote}\" remote in \"${externaldata_dir}\" for pushing to ${github_username}/${externaldata_repo}..." &&
+	git -C "${externaldata_dir}" remote add "${fork_remote}" "${fork_fetchurl}" &&
+	git -C "${externaldata_dir}" config remote."${fork_remote}".pushurl "${fork_pushurl}" &&
+	echo "Done. If you have not already, fork
+  https://github.com/${externaldata_organization}/${externaldata_repo}
+to your account (${github_username}) using the Fork button on GitHub." ||
+	die "Failed to configure \"${fork_remote}\" remote in \"${externaldata_dir}\"."
+fi

--- a/Utilities/GitSetup/setup-externaldata
+++ b/Utilities/GitSetup/setup-externaldata
@@ -30,7 +30,7 @@ die() {
 externaldata_organization='SimpleITK'
 externaldata_repo='SimpleITKExternalData'
 externaldata_url="https://github.com/${externaldata_organization}/${externaldata_repo}.git"
-externaldata_dir='.ExternalData'
+externaldata_dir="$(git rev-parse --show-toplevel)/.ExternalData"
 
 if test -d "${externaldata_dir}/.git"; then
 	echo "Updating \"${externaldata_dir}\" clone..." &&
@@ -55,23 +55,31 @@ fi
 # fork of SimpleITKExternalData. Mirror the fork account already configured
 # for this repository's own GitHub remote (see setup-github) so a push
 # remote is ready in ".ExternalData" without prompting again.
-fork_remote=$(git config --get github.fork.remote || echo "github")
-fork_remote_url=$(git config --get remote."${fork_remote}".url || echo '')
-if test -z "${fork_remote_url}"; then
+fork_remote=$(git config --get github.fork.remote)
+if test -z "${fork_remote}"; then
 	echo "No GitHub fork is configured for this repository yet (run
 Utilities/GitSetup/setup-github first); skipping fork remote setup for
 \"${externaldata_dir}\"."
-elif git -C "${externaldata_dir}" config --get remote."${fork_remote}".url > /dev/null 2>&1; then
-	echo "\"${externaldata_dir}\" already has a \"${fork_remote}\" remote configured."
 else
-	github_username=$(echo "${fork_remote_url}" | sed -E 's#.*[:/]([^/]+)/[^/]+$#\1#') &&
-	fork_fetchurl="https://github.com/${github_username}/${externaldata_repo}.git" &&
-	fork_pushurl="git@github.com:${github_username}/${externaldata_repo}.git" &&
-	echo "Configuring \"${fork_remote}\" remote in \"${externaldata_dir}\" for pushing to ${github_username}/${externaldata_repo}..." &&
-	git -C "${externaldata_dir}" remote add "${fork_remote}" "${fork_fetchurl}" &&
-	git -C "${externaldata_dir}" config remote."${fork_remote}".pushurl "${fork_pushurl}" &&
-	echo "Done. If you have not already, fork
+	fork_remote_pushurl=$(git config --get remote."${fork_remote}".pushurl)
+	fork_remote_fetchurl=$(git config --get remote."${fork_remote}".url || echo '')
+	fork_remote_url="${fork_remote_pushurl:-${fork_remote_fetchurl}}"
+	if test -z "${fork_remote_url}"; then
+		echo "No GitHub fork is configured for this repository yet (run
+Utilities/GitSetup/setup-github first); skipping fork remote setup for
+\"${externaldata_dir}\"."
+	elif git -C "${externaldata_dir}" config --get remote."${fork_remote}".url > /dev/null 2>&1; then
+		echo "\"${externaldata_dir}\" already has a \"${fork_remote}\" remote configured."
+	else
+		github_username=$(echo "${fork_remote_url}" | sed -E 's#.*[:/]([^/]+)/[^/]+$#\1#') &&
+		fork_fetchurl="https://github.com/${github_username}/${externaldata_repo}.git" &&
+		fork_pushurl="git@github.com:${github_username}/${externaldata_repo}.git" &&
+		echo "Configuring \"${fork_remote}\" remote in \"${externaldata_dir}\" for pushing to ${github_username}/${externaldata_repo}..." &&
+		git -C "${externaldata_dir}" remote add "${fork_remote}" "${fork_fetchurl}" &&
+		git -C "${externaldata_dir}" config remote."${fork_remote}".pushurl "${fork_pushurl}" &&
+		echo "Done. If you have not already, fork
   https://github.com/${externaldata_organization}/${externaldata_repo}
 to your account (${github_username}) using the Fork button on GitHub." ||
-	die "Failed to configure \"${fork_remote}\" remote in \"${externaldata_dir}\"."
+		die "Failed to configure \"${fork_remote}\" remote in \"${externaldata_dir}\"."
+	fi
 fi

--- a/Utilities/SetupForDevelopment.sh
+++ b/Utilities/SetupForDevelopment.sh
@@ -85,6 +85,8 @@ Utilities/GitSetup/setup-user && echo &&
  echo 'Failed to setup GitHub.  Run this again to retry.') && echo &&
 (Utilities/GitSetup/setup-precommit  ||
  echo 'Failed to setup pre-commit.') && echo &&
+(Utilities/GitSetup/setup-externaldata ||
+ echo 'Failed to setup ExternalData.  Run this again to retry.') && echo &&
 Utilities/GitSetup/tips &&
 Utilities/GitSetup/github-tips
 
@@ -115,5 +117,5 @@ git config --get remote.stage.url > /dev/null &&
 
 
 # Record the version of this setup so Hooks/pre-commit can check it.
-SetupForDevelopment_VERSION=6
+SetupForDevelopment_VERSION=7
 git config hooks.SetupForDevelopment ${SetupForDevelopment_VERSION}


### PR DESCRIPTION
Add a new `Utilities/GitSetup/setup-externaldata` script, wired into
`Utilities/SetupForDevelopment.sh`, to set up `.ExternalData` as expected
by the `sitk-upload-binary-data` skill and by CMake ExternalData's local
object store resolution.

## Changes

- **New `Utilities/GitSetup/setup-externaldata`**:
  - Clones `.ExternalData` from `SimpleITK/SimpleITKExternalData` if it
    doesn't exist yet, or fetches `origin` to keep it current if it does.
  - Warns (without touching anything) if `.ExternalData` exists but isn't
    a Git clone.
  - Configures a push/fork remote in `.ExternalData` mirroring this
    repository's own GitHub fork setup (reusing the username from
    `github.fork.remote`/`setup-github`), so the `sitk-upload-binary-data`
    skill has a `<push-remote>` ready without prompting again. Skips if
    no fork is configured yet for the main repo, or if the remote already
    exists (idempotent). Never calls `gh repo fork` automatically.
  - Added directly to `Utilities/GitSetup/` (not the shared subtree) —
    `setup-main` and `setup-precommit` were added the same way, as this
    directory allows project-specific scripts alongside the upstream
    subtree-merged ones.
- **`Utilities/SetupForDevelopment.sh`**: calls the new script using the
  same `(script || echo 'Failed to setup ...') && echo &&` soft-failure
  pattern as the other optional setup steps, and bumps
  `SetupForDevelopment_VERSION` to 7 so existing checkouts are prompted
  to re-run setup and pick up the new `.ExternalData` configuration.

## Testing

- `bash -n` syntax-checked both scripts.
- Deleted a local `.ExternalData` clone and re-ran `setup-externaldata`
  to exercise both the clone and update code paths.
- Verified the fork remote is created correctly and that re-running the
  script is idempotent (detects the existing remote and skips).
- Ran the full `Utilities/SetupForDevelopment.sh` end-to-end.