### PR TITLE
Improvements to the statistics scripts.

### DIFF
--- a/Utilities/Statistics/README.md
+++ b/Utilities/Statistics/README.md
@@ -33,7 +33,7 @@ The script `pypi_monthly_download_analysis` outputs two pdfs, `pypi_downloads_by
 Before running the analysis we need to obtain the PyPI download data. This requires a Google account as the PyPI download statistics dataset is hosted on Google BigQuery. The PyPI table schema describing the data is [available here](https://console.cloud.google.com/bigquery?p=bigquery-public-data&d=pypi&page=dataset&project=advance-stratum-298519&ws=!1m9!1m4!4m3!1sbigquery-public-data!2spypi!3ssimple_requests!1m3!3m2!1sbigquery-public-data!2spypi
 ).
 
-To obtain download information for the past 5 years, sorted by month with columns titled "month", "operating_system", "python_version", "ci", "country_code", "download_count" run the following SQL query on [BigQuery](https://console.cloud.google.com/bigquery) (change the time interval to your needs):
+To obtain download information for the past 5 years, sorted by month with columns titled "month", "operating_system", "python_version", "ci", "country_code", "download_count" run the following SQL query on [BigQuery](https://console.cloud.google.com/bigquery). Change the time interval to your needs:
 ```
 SELECT
 FORMAT_TIMESTAMP('%Y-%m', timestamp) as month,
@@ -50,6 +50,9 @@ month, operating_system, python_version, country_code, ci
 ORDER BY
 month
 ```
+
+Another useful date range is between the release of the first major toolkit version in April 2017 and the current date: `TIMESTAMP('2017-04-01 00:00:00') AND CURRENT_TIMESTAMP()`
+
 Download the resulting csv for analysis.
 
 Note that the country encoding in the csv is [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2). To plot downloads using the `plotly.express.choropleth` function we need to denote the country using [ISO 3166-1 alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) or country name. To convert between the alpha-2 and country name or alpha-3 we use the [pycountry](https://github.com/pycountry/pycountry) package which provides us with the full country information (alpha-2, alpha-3, name, flag etc.).

--- a/Utilities/Statistics/github_downloads_analysis.py
+++ b/Utilities/Statistics/github_downloads_analysis.py
@@ -239,7 +239,7 @@ def main():
         # graphs, x axis tag location is based on date, so correct dates are critical.
         # We could obtain the original release date but that overly complicates the script,
         # so will continue to ignore releases prior to 1.0.0.
-        pre_1_0_pattern = re.compile(r"v?0\.\d+\.\d+")
+        pre_1_0_pattern = re.compile(r"v?0\.\d+.*")
         all_releases = [
             r for r in all_releases if not pre_1_0_pattern.match(r["tag_name"])
         ]

--- a/Utilities/Statistics/pypi_monthly_download_analysis.py
+++ b/Utilities/Statistics/pypi_monthly_download_analysis.py
@@ -42,6 +42,7 @@ import pandas as pd
 import requests
 import pycountry
 import plotly.express as px
+import re
 
 
 def csv_path(path, required_columns={}):
@@ -289,7 +290,9 @@ def pypi_monthly_downloads_country_report(
     ]
     country_stats_df = pd.DataFrame(country_stats_data)
     csv_file = output_file_name.replace(".pdf", "_stats.csv")
-    country_stats_df.to_csv(csv_file, index=False)
+    # Write with utf-8 encoding and BOM for better compatibility with Excel
+    # so that it reads country names with non-ASCII characters correctly
+    country_stats_df.to_csv(csv_file, index=False, encoding="utf-8-sig")
 
 
 def pypi_monthly_downloads_os_report(
@@ -339,9 +342,24 @@ def pypi_monthly_downloads_os_report(
         [col for col in plot_os if col in monthly_os_downloads.columns]
     ]
 
-    # Create the stacked bar chart
-    fig, ax = plt.subplots(figsize=(14, 8))
+    # Create the stacked bar chart; scale width so bars never crowd each other
+    n_bars = len(monthly_os_downloads_plot)
+    fig_width = max(14, n_bars * 0.5)
+    fig, ax = plt.subplots(figsize=(fig_width, 8))
     monthly_os_downloads_plot.plot(kind="bar", stacked=True, ax=ax, colormap="tab10")
+
+    # Add total download counts above the bars (rounded to nearest 500 and
+    # shortened with K and M suffixes).
+    totals = monthly_os_downloads_plot.sum(axis=1)
+    for i, total in enumerate(totals):
+        rounded_total = round(total / 500) * 500
+        if rounded_total >= 1000000:
+            label = f"{rounded_total / 1000000:.3f}M".rstrip("0").rstrip(".")
+        elif rounded_total >= 1000:
+            label = f"{rounded_total / 1000:.1f}K".replace(".0", "")
+        else:
+            label = str(int(rounded_total))
+        ax.text(i, total, label, ha="center", va="bottom", fontsize=9, fontweight="bold")
 
     # Customize the plot
     ax.set_xlabel("Month", fontsize=12, fontweight="bold")
@@ -356,6 +374,15 @@ def pypi_monthly_downloads_os_report(
     handles, labels = ax.get_legend_handles_labels()
     if overlay_releases:
         releases_df = retrieve_official_releases_and_dates()
+        # Drop pre-1.0 releases from the DataFrame
+        pre_1_0_pattern = re.compile(r"0\.\d+.*")
+        releases_df = releases_df[~releases_df["version"].str.match(pre_1_0_pattern)]
+        print(releases_df[["version", "date"]])
+
+        # If there is more than one release in a given month, keep the latest one
+        releases_df = releases_df.loc[
+            releases_df.groupby(releases_df["date"].dt.strftime("%Y-%m"))["date"].idxmax()
+        ]
         release_information_color = "green"
 
         month_labels = monthly_os_downloads_plot.index.tolist()


### PR DESCRIPTION
Add total at the top of the stacked bar for monthly downloads by OS (easier to read actual download counts). Scale the width of the figure so that the labels do not overlap.

Drop pre 1.0.0 releases as those are not relevant for the analysis.