### PR TITLE
CI: move WRAP_RUBY testing from macOS to Linux batch build job

### DIFF
--- a/.github/workflows/BatchBuild.yml
+++ b/.github/workflows/BatchBuild.yml
@@ -138,6 +138,7 @@ jobs:
             CC: "gcc-12"
             use-superbuild: true
             ctest-cache: |
+              WRAP_RUBY:BOOL=ON
               WRAP_DEFAULT:BOOL=OFF
 
           - os: macos-15
@@ -157,7 +158,6 @@ jobs:
             python-version: "3.10"
             ctest-cache: |
               WRAP_PYTHON:BOOL=ON
-              WRAP_RUBY:BOOL=ON
 
           - os: macos-14
             cmake-build-type: "MinSizeRel"


### PR DESCRIPTION
## Summary

The macOS GitHub Actions runner images (see [actions/runner-images macOS 15 readme](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md)) now list Ruby only under *Cached Tools* rather than as a build-ready system default, making the bare system Ruby unreliable for building native/SWIG extensions such as SimpleITK's Ruby wrapping.

## Changes

- Removed `WRAP_RUBY:BOOL=ON` from the `macos-14` (Xcode 15.4, Python 3.10) job.
- Added `WRAP_RUBY:BOOL=ON` to the existing `ubuntu-22.04` gcc-12 job, which already has a full GCC toolchain and apt-provided Ruby development headers.

## Testing

CI will validate the moved WRAP_RUBY build on the ubuntu-22.04/gcc-12 job.