### PR TITLE
Update FastApproximateRankImageFilter by23 test MD5 hash

### DIFF
--- a/Code/BasicFilters/yaml/FastApproximateRankImageFilter.yaml
+++ b/Code/BasicFilters/yaml/FastApproximateRankImageFilter.yaml
@@ -29,7 +29,7 @@ tests:
   - Input/cthead1.png
 - tag: by23
   description: Test by 23
-  md5hash: 67615832b6f0e0bb877ce03418d3328c
+  md5hash: b8a6f4f77a7df4b1e5d5dba0297945bb
   settings:
   - parameter: Rank
     type: double


### PR DESCRIPTION
## Summary
- ITK [PR #6580](https://github.com/InsightSoftwareConsortium/ITK/pull/6580) / commit [`841f4b66d3`](https://github.com/InsightSoftwareConsortium/ITK/commit/841f4b66d37804907cef5758d80bde19aa08d104) ("BUG: Propagate rank to the last axis in FastApproximateRank") fixed an off-by-one loop bound in `FastApproximateRankImageFilter::SetRank()`: the last axis's per-axis sub-filter never received the requested rank and silently ran at the default median instead.
- The `by23` subtest (`Rank=1`, `Radius=[2,3]`) exercises exactly this last-axis code path, so its output — and therefore the expected MD5 hash — changed after the ITK fix.
- Updated `Code/BasicFilters/yaml/FastApproximateRankImageFilter.yaml`'s `by23` `md5hash` to the new correct value.

## Test plan
- [x] `BasicFilters.FastApproximateRankImageFilter` passes locally against current ITK `main`
- [x] Confirmed no other `BasicFilters.*` tests regressed