### PR TITLE
CI: Migrate BatchBuild macOS jobs off deprecated macos-13 runner

### DIFF
--- a/.github/workflows/BatchBuild.yml
+++ b/.github/workflows/BatchBuild.yml
@@ -97,28 +97,27 @@ jobs:
             ctest-cache: |
               WRAP_DEFAULT:BOOL=OFF
 
-          - os: macos-13
+          - os: macos-15-intel
             cmake-build-type: "Release"
             cmake-generator: "Ninja"
-            xcode-version: 15.2
+            xcode-version: 16.4
             ctest-cache: |
               WRAP_PYTHON:BOOL=ON
 
-          - os: macos-13
+          - os: macos-15-intel
             cmake-build-type: "Release"
             cmake-generator: "Ninja"
-            xcode-version: 14.3.1
+            xcode-version: 16.1
             ctest-cache: |
               WRAP_PYTHON:BOOL=ON
 
-          - os: macos-13
+          - os: macos-15-intel
             cmake-build-type: "MinSizeRel"
             cmake-generator: "Ninja"
-            xcode-version: 15.2
+            xcode-version: 16.2
             ctest-cache: |
               WRAP_PYTHON:BOOL=ON
               WRAP_JAVA:BOOL=ON
-              WRAP_CSHARP:BOOL=ON
 
           - os: mac-arm64
             cmake-build-type: "Release"


### PR DESCRIPTION
## Summary
- The GitHub-hosted `macos-13` runner is fully retired (unsupported as of Dec 2025), breaking the macOS jobs in `BatchBuild.yml` on the `release` branch.
- Move the three Intel macOS matrix entries from `macos-13` to `macos-15-intel` and bump pinned Xcode versions (16.4, 16.1, 16.2) to versions available on that image.
- Drop `WRAP_CSHARP:BOOL=ON` from the MinSizeRel job since C# wrapping is not available on `macos-15-intel`.
- The `mac-arm64` self-hosted runner entry is unaffected.

## Test plan
- [ ] Confirm the BatchBuild workflow runs green on `macos-15-intel` for all three Intel jobs
- [ ] Confirm Xcode 16.4/16.1/16.2 are available and builds succeed with each