### PR TITLE
BUG: Remove copy=False kwarg from reshape in GetArrayViewFromImage

### DIFF
--- a/Wrapping/Python/SimpleITK/extra.py
+++ b/Wrapping/Python/SimpleITK/extra.py
@@ -281,7 +281,7 @@ def GetArrayViewFromImage(image: Image) -> "numpy.ndarray":
 
     image_memory_view = _GetMemoryViewFromImage(image)
     array_view = numpy.asarray(image_memory_view).view(dtype=dtype)
-    return array_view.reshape(shape[::-1], copy=False)
+    return array_view.reshape(shape[::-1])
 
 
 def GetArrayFromImage(image: Image) -> "numpy.ndarray":


### PR DESCRIPTION
## Summary
- `GetArrayViewFromImage` calls `array_view.reshape(shape[::-1], copy=False)`, but the `copy` keyword was only added to `ndarray.reshape()` in NumPy 2.1.0.
- Any environment on NumPy < 2.1 (including all Python 3.9 environments, since NumPy dropped 3.9 support before 2.1) raises `TypeError: 'copy' is an invalid keyword argument for this function`.
- `array_view` is always a freshly created, C-contiguous array, so reshaping it to a same-size C-order shape can never actually require a copy - the `copy=False` kwarg was not guarding against anything that could occur here.
- Introduced in 1ae7b55c2 ("Use reshape over setting ndarray shape").

## Test plan
- [ ] CI passes on py39 legs
- [ ] GetArrayViewFromImage/GetArrayFromImage still return views/copies as expected across supported NumPy versions
