### PR TITLE
WIP: ENH: Add order-explicit spatial keys to the Python Image dict interface

### DIFF
--- a/Wrapping/Python/sitkImage.i
+++ b/Wrapping/Python/sitkImage.i
@@ -611,16 +611,35 @@
 
         # set/get pixel methods
 
+        _RESERVED_SPATIAL_KEYS = (
+            'origin', 'spacing', 'direction',
+            'origin_xyz', 'spacing_xyz', 'direction_xyz', 'index_xyz', 'size_xyz',
+            'origin_zyx', 'spacing_zyx', 'direction_zyx', 'index_zyx', 'size_zyx' )
+
+        def _warn_bare_spatial_key( self, key ):
+            import warnings
+            import os
+            future = os.environ.get('SITK_FUTURE_LEGACY_REMOVE', '0').lower() in ('1', 'on', 'true', 'yes')
+            category = FutureWarning if future else DeprecationWarning
+            warnings.warn(
+                f"Image['{key}'] is deprecated because the bare key is "
+                f"order-ambiguous across toolkits: SimpleITK returns (x,y,z) "
+                f"order while ITK returns NumPy (z,y,x) order for the same "
+                f"key. Use '{key}_xyz' (same values as this key) or "
+                f"'{key}_zyx' (NumPy array-axis order). See "
+                f"InsightSoftwareConsortium/ITK issue #6706.",
+                category, stacklevel=3 )
+
         def __delitem__( self, key ):
             """Remove an item from the meta-data dictionary.
 
-            It is an exception to delete the "origin", "spacing" and "direction" reserved keys.
+            It is an exception to delete the reserved spatial keys.
 
             If the key does not exist in the dictionary no action or exception occours.
             """
             if not isinstance(key, str):
               raise TypeError("MetaData dictionary key must be str")
-            if key in [ 'origin', 'spacing', 'direction' ]:
+            if key in self._RESERVED_SPATIAL_KEYS:
               raise KeyError(f"'{key} is read-only")
             return self.EraseMetaData( key )
 
@@ -630,7 +649,7 @@
             """
             if not isinstance(key, str):
               raise TypeError("MetaData dictionary key must be str")
-            return key in [ 'origin', 'spacing', 'direction' ] or self.HasMetaDataKey( key )
+            return key in self._RESERVED_SPATIAL_KEYS or self.HasMetaDataKey( key )
 
         def _expand_ellipsis(self, idx):
             """Expand "..." in idx with slice(None) to fill to dimension."""
@@ -678,19 +697,27 @@
             """
 
             if isinstance(idx, str):
-              if idx == 'origin':
-                return self.GetOrigin()
-              elif idx == 'spacing':
-                return self.GetSpacing()
-              elif idx == 'direction':
-                return self.GetDirection()
-              else:
-                try:
-                  return self.GetMetaData(idx)
-                except RuntimeError as e:
-                    if not self.HasMetaDataKey( idx ):
-                      raise KeyError(f"\"{idx}\" not in meta-data dictionary")
-                    raise e
+              xyz_getters = {
+                'origin_xyz': self.GetOrigin,
+                'spacing_xyz': self.GetSpacing,
+                'direction_xyz': self.GetDirection,
+                'size_xyz': self.GetSize,
+                'index_xyz': lambda: (0,) * self.GetDimension() }
+              if idx in xyz_getters:
+                return xyz_getters[idx]()
+              if idx.endswith('_zyx') and idx[:-4] + '_xyz' in xyz_getters:
+                # reversing the flat row-major direction tuple flips both
+                # matrix axes, matching itk.Image['direction_zyx']
+                return tuple(reversed(xyz_getters[idx[:-4] + '_xyz']()))
+              if idx in ('origin', 'spacing', 'direction'):
+                self._warn_bare_spatial_key(idx)
+                return xyz_getters[idx + '_xyz']()
+              try:
+                return self.GetMetaData(idx)
+              except RuntimeError as e:
+                  if not self.HasMetaDataKey( idx ):
+                    raise KeyError(f"\"{idx}\" not in meta-data dictionary")
+                  raise e
 
             if sys.version_info[0] < 3:
               def isint( i ):
@@ -808,16 +835,26 @@
             """
 
             if isinstance(idx, str):
-              if idx == 'origin':
-                return self.SetOrigin(rvalue)
-              elif idx == 'spacing':
-                return self.SetSpacing(rvalue)
-              elif idx == 'direction':
-                return self.SetDirection(rvalue)
-              else:
-                if not isinstance(rvalue, str):
-                  raise TypeError("metadata item must be a string")
-                return self.SetMetaData(idx, rvalue)
+              xyz_setters = {
+                'origin': self.SetOrigin,
+                'spacing': self.SetSpacing,
+                'direction': self.SetDirection }
+              if idx.endswith('_xyz') and idx[:-4] in xyz_setters:
+                return xyz_setters[idx[:-4]](rvalue)
+              if idx.endswith('_zyx') and idx[:-4] in xyz_setters:
+                return xyz_setters[idx[:-4]](tuple(reversed(tuple(rvalue))))
+              if idx in ('size_xyz', 'size_zyx'):
+                raise KeyError(f"'{idx}' is read-only; Image size is fixed at construction")
+              if idx in ('index_xyz', 'index_zyx'):
+                if any(int(v) for v in rvalue):
+                  raise ValueError("SimpleITK images always start at index 0")
+                return
+              if idx in ('origin', 'spacing', 'direction'):
+                self._warn_bare_spatial_key(idx)
+                return xyz_setters[idx](rvalue)
+              if not isinstance(rvalue, str):
+                raise TypeError("metadata item must be a string")
+              return self.SetMetaData(idx, rvalue)
 
             if isinstance(idx, Image):
                return self.__imasked_assign(idx, rvalue)

--- a/Wrapping/Python/tests/sitkImageTests.py
+++ b/Wrapping/Python/tests/sitkImageTests.py
@@ -93,6 +93,61 @@ def test_get_item_metadata():
         img["does_not_exit"]
 
 
+def test_spatial_key_protocol():
+    """Test order-explicit spatial keys (ITK issue #6706)"""
+    import warnings
+
+    img = sitk.Image([10, 9, 11], sitk.sitkFloat32)
+    img.SetSpacing([0.3, 0.1, 0.2])
+    img.SetOrigin([-3.0, -2.0, -1.0])
+    direction = (0.0, -1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0)
+    img.SetDirection(direction)
+
+    assert img["spacing_xyz"] == (0.3, 0.1, 0.2)
+    assert img["origin_xyz"] == (-3.0, -2.0, -1.0)
+    assert img["direction_xyz"] == direction
+    assert img["size_xyz"] == (10, 9, 11)
+    assert img["index_xyz"] == (0, 0, 0)
+
+    assert img["spacing_zyx"] == (0.2, 0.1, 0.3)
+    assert img["origin_zyx"] == (-1.0, -2.0, -3.0)
+    assert img["direction_zyx"] == tuple(reversed(direction))
+    assert img["size_zyx"] == (11, 9, 10)
+    assert img["index_zyx"] == (0, 0, 0)
+
+    img["spacing_zyx"] = (0.6, 0.5, 0.4)
+    assert img.GetSpacing() == (0.4, 0.5, 0.6)
+    img["origin_xyz"] = (1.0, 2.0, 3.0)
+    assert img.GetOrigin() == (1.0, 2.0, 3.0)
+    img["direction_zyx"] = tuple(reversed(direction))
+    assert img.GetDirection() == direction
+
+    with pytest.raises(KeyError):
+        img["size_xyz"] = (2, 2, 2)
+    with pytest.raises(ValueError):
+        img["index_zyx"] = (1, 0, 0)
+    img["index_xyz"] = (0, 0, 0)
+
+    for key in ("spacing_xyz", "index_zyx"):
+        assert key in img
+        with pytest.raises(KeyError):
+            del img[key]
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        assert img["spacing"] == img["spacing_xyz"]
+        img["spacing"] = img["spacing_xyz"]
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert len(deprecations) == 2
+    assert "6706" in str(deprecations[0].message)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        img["spacing_xyz"]
+        img["origin_zyx"]
+    assert not [w for w in caught if issubclass(w.category, DeprecationWarning)]
+
+
 def test_setitem_metadata():
     """Test the __setitem__ with a string to access meta-data dictionary"""
 


### PR DESCRIPTION
Adds order-explicit spatial keys (`origin|spacing|direction|index|size` × `_xyz|_zyx`) to the Python `Image` dict interface and deprecates the order-ambiguous bare keys. Companion to ITK PR InsightSoftwareConsortium/ITK#6710 — both PRs implement the identical cross-toolkit protocol (InsightSoftwareConsortium/ITK#6706, relates to #2531).

<details>
<summary>Design summary</summary>

- Bare `img['spacing']` returns (x,y,z) in SimpleITK but NumPy (z,y,x) in ITK — same key, opposite conventions, so generic cross-toolkit consumers silently corrupt geometry.
- `_xyz` keys return the native getter values unchanged; `_zyx` keys are `tuple(reversed(...))`.
- `direction_zyx = tuple(reversed(flat_direction))`: reversing a flat row-major matrix flips both axes, exactly matching `itk.Image['direction_zyx']` (= `np.flip(D, axis=None)` = P·D·P) with no numpy dependency.
- `index_*` keys state SimpleITK's always-zero start index explicitly (ITK images can have non-zero start index; converters can now check instead of guessing). `size_*`/`index_*` writes are rejected.
- Bare keys keep exact current behavior + `DeprecationWarning`; `SITK_FUTURE_LEGACY_REMOVE=1` escalates to always-visible `FutureWarning`.
- All ten names become reserved keys in `__contains__`/`__delitem__`.

</details>

<details>
<summary>Testing</summary>

- New `test_spatial_key_protocol` in `sitkImageTests.py`: both suffix families, setter round-trips, read-only enforcement, reserved-key behavior, warning assertions.
- Validated against SimpleITK 2.5.4 wheel via method-extraction harness (new + 4 legacy metadata tests pass); full toolkit build pending — hence WIP.

</details>

WIP pending: joint design sign-off with the ITK PR (key naming, flat-vs-nested direction tuple), and a full local build.

<!--
provenance: claude-code session 2026-07-26 (hjmjohnson)
key_facts: branch hjmjohnson/SimpleITK python-geometry-protocol commit 2eff1f64 off upstream/master e5f882fa;
  worktree ~/src/SimpleITK-python-geometry-protocol-src; kw-commit-msg hook broken locally (hooks_config not found), content hooks all pass;
  companion ITK PR 6710 branch python-geometry-protocol b2f233dea67
-->
