### PR TITLE
CI: Fix always-truthy if expression in BatchBuild.yml

### DIFF
--- a/.github/workflows/BatchBuild.yml
+++ b/.github/workflows/BatchBuild.yml
@@ -155,7 +155,7 @@ jobs:
           python-version: 3.11
       - name: Update Path for shared libraries
         shell: bash
-        if: contains( ${{ matrix.ctest-cache }}, 'BUILD_SHARED_LIBS:BOOL=ON' ) && contains( ${{ matrix.os }}, 'windows' )
+        if: contains(matrix.ctest-cache, 'BUILD_SHARED_LIBS:BOOL=ON') && contains(matrix.os, 'windows')
         run: |
           echo "${{ env.CTEST_BINARY_DIRECTORY }}\ITK-prefix\bin" >> $GITHUB_PATH
           echo "${{ env.CTEST_BINARY_DIRECTORY }}\SimpleITK-build\bin\${{ matrix.cmake-build-type }}" >> $GITHUB_PATH


### PR DESCRIPTION
## Summary
- The `if:` condition on the "Update Path for shared libraries" step wrapped `matrix.ctest-cache` and `matrix.os` in `${{ }}` inside an already-implicit expression context. GitHub Actions parsed the surrounding text as a literal string rather than as part of the expression, so the condition always evaluated truthy regardless of the actual matrix values.
- Fixed by removing the redundant `${{ }}` wrappers, using bare `contains(matrix.ctest-cache, ...)` / `contains(matrix.os, ...)` syntax as required for expressions already inside an implicit `if:` context.

## Test plan
- [ ] Confirm the workflow syntax is valid (GitHub Actions lint / a run of BatchBuild.yml)
- [ ] Confirm the "Update Path for shared libraries" step only runs for Windows + BUILD_SHARED_LIBS:BOOL=ON matrix entries