### PR TITLE
BUG: Pin numpy <2.5 for manylinux2014 python test venv

### DIFF
--- a/Wrapping/Python/LegacyPackaging.cmake
+++ b/Wrapping/Python/LegacyPackaging.cmake
@@ -99,11 +99,14 @@ if (SimpleITK_PYTHON_USE_VIRTUALENV)
   add_custom_command( OUTPUT "${VIRTUAL_PYTHON_EXECUTABLE}"
     COMMAND ${PYTHON_COMMAND_PREFIX} "${Python_EXECUTABLE}" "-m" "venv" "--clear" "${PythonVirtualenvHome}"
     COMMAND ${PYTHON_COMMAND_PREFIX} "${VIRTUAL_PYTHON_EXECUTABLE}" "-m" "pip" "install" "--upgrade" "pip"
-    COMMAND ${PYTHON_COMMAND_PREFIX} "${VIRTUAL_PYTHON_EXECUTABLE}" "-m" "pip" "install" "wheel" "numpy!=1.24.1,!=1.24.0" "setuptools" "."
+    # numpy<2.5 is required for building from source with GCC < 10.3 (e.g. manylinux2014's
+    # devtoolset-10), needed for Python ABIs without a manylinux2014-tagged numpy wheel (e.g. cp314t).
+    COMMAND ${PYTHON_COMMAND_PREFIX} "${VIRTUAL_PYTHON_EXECUTABLE}" "-m" "pip" "install" "wheel" "numpy!=1.24.1,!=1.24.0,<2.5" "setuptools" "."
     WORKING_DIRECTORY "${SimpleITK_Python_BINARY_DIR}"
     DEPENDS
     "${SWIG_MODULE_SimpleITKPython_TARGET_NAME}"
     COMMENT "Creating python virtual environment..."
+    VERBATIM
     )
 
 endif()


### PR DESCRIPTION
## Problem
The `Package.yml` `package-docker` job (manylinux2014, both x86_64 and aarch64) fails when building the `cp314-cp314t` (free-threaded Python 3.14) leg:

```
../meson.build:25:4: ERROR: Problem encountered: NumPy requires GCC >= 10.3
```

manylinux2014 (CentOS 7) is fixed at devtoolset-10 (GCC 10.2.1), which is the newest toolchain that image ships. NumPy publishes wheels for `cp314t` only tagged `manylinux_2_27`/`manylinux_2_28`, so pip falls back to building numpy 2.5.x from source on manylinux2014 aarch64/x86_64, which now hard-requires GCC >= 10.3 and aborts the whole `make` step (this happens while creating the local python virtualenv used for CI testing, per `Wrapping/Python/LegacyPackaging.cmake`, before the wheel is even packaged).

## Fix
NumPy 2.4.x already supports Python 3NumPy 2.4.x already supports Python 3NumPy 2.4.x already supports Python 3NumPy 2.4.x already supports Python 3NumPyleNumPy 2.4.x already supports Python 3NumPy 2.4.x already supposfully NumPy 2.4.x already jNumPy 2.4.x already supports Python 3NumPy 2.4.x already supports Python 3NumPy 2.4.x already supports Python 3NumPy 2.4.x already supports Python 3NumPylePythNumPyrsNumPy 2.4.x already supports Python 3NumPy 2.4.x already supports Pytg/Python/LegacyPackaging.cmake`) — it does not change the distributed wheel's build or runtime requirements.

## Follow-up
Long-term, manylinux2014's toolchain will keep falling further behind newer numpy/Python releases. Worth tracking whether to move newer Python ABI legs (e.g. free-threaded builds) to a manylinux_2_28-based image.