### PR TITLE
CI: Enable dependabot for GitHub Actions on release branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "release"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Add a second dependabot update entry targeting the `release` branch so GitHub Actions dependencies are kept current there too, matching the existing entry for `main`.