### PR TITLE
Change TWeights in MultiLabelSTAPLE to double

### DIFF
--- a/Code/BasicFilters/yaml/MultiLabelSTAPLEImageFilter.yaml
+++ b/Code/BasicFilters/yaml/MultiLabelSTAPLEImageFilter.yaml
@@ -3,7 +3,7 @@ template_code_filename: MultiInputImageFilter
 template_test_filename: ImageFilter
 number_of_inputs: 1
 pixel_types: UnsignedIntegerPixelIDTypeList
-filter_type: itk::MultiLabelSTAPLEImageFilter<InputImageType, OutputImageType, float>
+filter_type: itk::MultiLabelSTAPLEImageFilter<InputImageType, OutputImageType, double>
 members:
 - name: LabelForUndecidedPixels
   type: uint64_t
@@ -43,8 +43,8 @@ members:
   detaileddescriptionGet: >-
     Set maximum number of iterations.
 - name: PriorProbabilities
-  type: std::vector<float>
-  default: std::vector<float>()
+  type: std::vector<double>
+  default: std::vector<double>()
   briefdescriptionSet: ''
   custom_itk_cast: |-
     if (!m_PriorProbabilities.empty()) filter->SetPriorProbabilities(typename FilterType::PriorProbabilitiesType(&this->m_PriorProbabilities[0],this->m_PriorProbabilities.size()));
@@ -64,9 +64,9 @@ members:
     this function.
 measurements:
 - name: ConfusionMatrix
-  type: std::vector<float>
+  type: std::vector<double>
   no_print: true
-  custom_cast: std::vector<float>(value.begin(), value.end())
+  custom_cast: std::vector<double>(value.begin(), value.end())
   active: true
   parameters:
   - name: input


### PR DESCRIPTION
The WeightsType `TWeights` of the `itk::MultiLabelSTAPLEImageFilter` is set to the default `float`. 
There is one big problem with this. 

In [itkMultiLabelSTAPLEImageFilter.hxx](https://github.com/InsightSoftwareConsortium/ITK/blob/c01976d239314ab9b9251410232cf35ea569021c/Modules/Segmentation/LabelVoting/include/itkMultiLabelSTAPLEImageFilter.hxx#L209)
the frequency of the labels is computed like this: 
``` 
      for (in.GoToBegin(); !in.IsAtEnd(); ++in)
      {
        ++(this->m_PriorProbabilities[in.Get()]);
      }
```
where this->m_PriorProbabilities is of course an `Array<WeightsType>`. 
Ultimately, the code is doing this: 
```
float frequency = 0;
for (int i = 0; i < num_voxels; i++) {
  frequency = frequency + 1
}
```
At some point, precisely at $frequency = 2^{24} = 16,777,216$, the float representation of frequency and frequency + 1 is the same and the counter stops increasing. This number easily reached in even a modest 3D images, and the whole `m_PriorProbabilities` will be completely wrong. 

Short of changing the ITK code, a simple fix is to use double as the weights type, which raises this problematic threshold to $2^{53} = 9,007,199,254,740,992$ (over 9 quadrillion). 