### PR TITLE
SWIG: Update to version 4.5.0

### DIFF
--- a/.github/workflows/BatchBuild.yml
+++ b/.github/workflows/BatchBuild.yml
@@ -205,7 +205,7 @@ jobs:
           python -m pip install -r ./.github/workflows/requirements-build.txt
 
           if [[ '${{ matrix.use-superbuild }}' != 'true' ]]; then
-            python -m pip install jinja2~=3.1 jsonschema~=4.24 pyyaml~=6.0 swig~=4.4.0
+            python -m pip install jinja2~=3.1 jsonschema~=4.24 pyyaml~=6.0 swig~=4.5.0
           fi
 
           if [  ! -z "${{ matrix.xcode-version }}" ]; then

--- a/Utilities/Doxygen/docker/run.sh
+++ b/Utilities/Doxygen/docker/run.sh
@@ -24,7 +24,7 @@ python3 -m venv ${BLD_DIR}/venv && \
     python -m pip install --upgrade pip
 
 if [ -f ${SRC_DIR}/.github/workflows/requirements-build.txt ]; then
-   python -m pip install -r ${SRC_DIR}/.github/workflows/requirements-build.txt jinja2~=3.1 jsonschema~=4.24 pyyaml~=6.0 swig~=4.4.0
+   python -m pip install -r ${SRC_DIR}/.github/workflows/requirements-build.txt jinja2~=3.1 jsonschema~=4.24 pyyaml~=6.0 swig~=4.5.0
 fi
 
 # Build SimpleITK with FetchContent for ITK

--- a/Wrapping/Common/SimpleITK_Common.i
+++ b/Wrapping/Common/SimpleITK_Common.i
@@ -20,6 +20,18 @@
 // Remove some warnings
 #pragma SWIG nowarn=362,503,401,389,516,511
 
+// SWIG >= 4.5.0's Ruby -autorename drops these std::vector partial
+// specializations as duplicate "Vector" names (Warning 302), breaking
+// %template(VectorBool) below. Give them distinct default names.
+#if SWIGRUBY
+namespace std
+{
+  %rename(SwigVectorPtr) vector< _Tp *, _Alloc >;
+  %rename(SwigVectorConstPtr) vector< _Tp const *, _Alloc >;
+  %rename(SwigVectorBool) vector< bool, _Alloc >;
+}
+#endif
+
 // Use STL support
 %include <std_vector.i>
 %include <std_string.i>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
   "scikit-build-core~=1.0.0",
   "setuptools-scm>=8.0",
-  "swig~=4.4.0",
+  "swig~=4.5.0",
   "jinja2~=3.1",
   "jsonschema~=4.24",
   "pyyaml~=6.0"


### PR DESCRIPTION
Update SWIG from 4.4.0 to 4.5.0 across all build configurations:
- pyproject.toml: Build system requirement
- BatchBuild.yml: CI workflow
- Utilities/Doxygen/docker/run.sh: Docker build script