### PR TITLE
ENH: Update scikit-build-core to 1.0.x

### DIFF
--- a/Wrapping/Python/Packaging/pyproject.toml.in
+++ b/Wrapping/Python/Packaging/pyproject.toml.in
@@ -2,7 +2,7 @@
 
 [build-system]
 requires = [
-  "scikit-build-core>=0.10"
+  "scikit-build-core~=1.0.0"
 ]
 build-backend = "scikit_build_core.build"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "scikit-build-core==0.11.5",
+  "scikit-build-core~=1.0.0",
   "setuptools-scm>=8.0",
   "swig~=4.4.0",
   "jinja2~=3.1",


### PR DESCRIPTION
Bump scikit-build-core to the 1.0 series in the root build metadata and the Python packaging template.

Release-note note: scikit-build-core 1.0.0 changes SDist symlink defaults and tightens handling of renamed config fields, but this repo already sets a minimum-version and does not use those renamed fields.