### PR TITLE
CI: prototype replacing wheel builds with cibuildwheel

### DIFF
--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -90,14 +90,32 @@ jobs:
         include:
           - os: ubuntu-latest
             cibw_archs: x86_64
+            cibw_build: "cp310-* cp311-* cp314t-*"
+            artifact_suffix: all
           - os: ubuntu-22.04-arm
             cibw_archs: aarch64
+            cibw_build: "cp310-* cp311-* cp314t-*"
+            artifact_suffix: all
           - os: macos-15-intel
             cibw_archs: x86_64
+            cibw_build: "cp310-* cp311-* cp314t-*"
+            artifact_suffix: all
           - os: macos-15
             cibw_archs: arm64
+            cibw_build: "cp310-*"
+            artifact_suffix: cp310
+          - os: macos-15
+            cibw_archs: arm64
+            cibw_build: "cp311-*"
+            artifact_suffix: cp311
+          - os: macos-15
+            cibw_archs: arm64
+            cibw_build: "cp314t-*"
+            artifact_suffix: cp314t
           - os: windows-2022
             cibw_archs: AMD64
+            cibw_build: "cp310-* cp311-* cp314t-*"
+            artifact_suffix: all
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
@@ -109,7 +127,7 @@ jobs:
       - name: Build Python wheels with cibuildwheel
         uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e # v3.3.1
         env:
-          CIBW_BUILD: "cp310-* cp311-* cp314t-*"
+          CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_ENABLE: cpython-freethreading
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_SKIP: "*-musllinux_* *-manylinux_i686 *-win32"
@@ -122,7 +140,7 @@ jobs:
       - name: Upload wheel artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: artifacts-wheels-${{ matrix.os }}-${{ matrix.cibw_archs }}
+          name: artifacts-wheels-${{ matrix.os }}-${{ matrix.cibw_archs }}-${{ matrix.artifact_suffix }}
           path: wheelhouse/*.whl
 
   build:

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -102,13 +102,18 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
           fetch-depth: 0
+      - name: Prepare short temp path for Windows wheel builds
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: New-Item -Path C:\t -ItemType Directory -Force | Out-Null
       - name: Build Python wheels with cibuildwheel
         uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e # v3.3.1
         env:
           CIBW_BUILD: "cp310-* cp311-* cp314t-*"
           CIBW_ENABLE: cpython-freethreading
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
-          CIBW_SKIP: "pp* *-musllinux_* *-manylinux_i686 *-win32"
+          CIBW_SKIP: "*-musllinux_* *-manylinux_i686 *-win32"
+          CIBW_ENVIRONMENT_WINDOWS: "TMP=C:\\t TEMP=C:\\t"
           CIBW_TEST_SKIP: "*"
           CIBW_BUILD_VERBOSITY: 1
         with:

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -140,6 +140,7 @@ jobs:
             cibw_build: "cp310-* cp311-* cp314t-*"
             cibw_skip: "*-manylinux_i686 *-win32 *-musllinux*"
             artifact_suffix: all
+            cibw_environment_windows: "CMAKE_ARGS='-DITK_SKIP_PATH_LENGTH_CHECKS:BOOL=ON'"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
@@ -155,7 +156,7 @@ jobs:
           CIBW_ENABLE: cpython-freethreading
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_SKIP: ${{ matrix.cibw_skip }}
-          CIBW_ENVIRONMENT_WINDOWS: "TMP=C:\t TEMP=C:\t"
+          CIBW_ENVIRONMENT_WINDOWS: "TMP=C:\t TEMP=C:\t ${{ matrix.cibw_environment_windows || '' }}"
           CIBW_ENVIRONMENT_LINUX: ${{ matrix.cibw_environment_linux || '' }}
           CIBW_TEST_SKIP: "*"
           CIBW_BUILD_VERBOSITY: 1

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -30,13 +30,50 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            dockerfile: Dockerfile-2-28-x86_64
-            build_csharp: 1
-            build_java: 1
+            cibw_archs: x86_64
+            cibw_build: "cp310-* cp311-* cp314t-*"
+            cibw_skip: "*-manylinux_i686 *-win32 *-musllinux*"
+            artifact_suffix: manylinux-x86_64
           - os: ubuntu-22.04-arm
-            dockerfile: Dockerfile-2-28-aarch64
-            build_csharp: 0
-            build_java: 1
+            cibw_archs: aarch64
+            cibw_build: "cp310-* cp311-* cp314t-*"
+            cibw_skip: "*-manylinux_i686 *-win32 *-musllinux*"
+            artifact_suffix: manylinux-aarch64
+          - os: ubuntu-latest
+            cibw_archs: x86_64
+            cibw_build: "cp310-* cp311-* cp314t-*"
+            cibw_skip: "*-manylinux_i686 *-win32 *-manylinux*"
+            artifact_suffix: musllinux-x86_64
+          - os: ubuntu-22.04-arm
+            cibw_archs: aarch64
+            cibw_build: "cp310-* cp311-* cp314t-*"
+            cibw_skip: "*-manylinux_i686 *-win32 *-manylinux*"
+            artifact_suffix: musllinux-aarch64
+          - os: macos-15-intel
+            cibw_archs: x86_64
+            cibw_build: "cp310-* cp311-* cp314t-*"
+            cibw_skip: "*"
+            artifact_suffix: all
+          - os: macos-15
+            cibw_archs: arm64
+            cibw_build: "cp310-*"
+            cibw_skip: "*"
+            artifact_suffix: cp310
+          - os: macos-15
+            cibw_archs: arm64
+            cibw_build: "cp311-*"
+            cibw_skip: "*"
+            artifact_suffix: cp311
+          - os: macos-15
+            cibw_archs: arm64
+            cibw_build: "cp314t-*"
+            cibw_skip: "*"
+            artifact_suffix: cp314t
+          - os: windows-2022
+            cibw_archs: AMD64
+            cibw_build: "cp310-* cp311-* cp314t-*"
+            cibw_skip: "*-manylinux_i686 *-win32 *-musllinux*"
+            artifact_suffix: all
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
@@ -91,30 +128,47 @@ jobs:
           - os: ubuntu-latest
             cibw_archs: x86_64
             cibw_build: "cp310-* cp311-* cp314t-*"
-            artifact_suffix: all
+            cibw_skip: "*-manylinux_i686 *-win32 *-musllinux*"
+            artifact_suffix: manylinux-x86_64
           - os: ubuntu-22.04-arm
             cibw_archs: aarch64
             cibw_build: "cp310-* cp311-* cp314t-*"
-            artifact_suffix: all
+            cibw_skip: "*-manylinux_i686 *-win32 *-musllinux*"
+            artifact_suffix: manylinux-aarch64
+          - os: ubuntu-latest
+            cibw_archs: x86_64
+            cibw_build: "cp310-* cp311-* cp314t-*"
+            cibw_skip: "*-manylinux_i686 *-win32 *-manylinux*"
+            artifact_suffix: musllinux-x86_64
+          - os: ubuntu-22.04-arm
+            cibw_archs: aarch64
+            cibw_build: "cp310-* cp311-* cp314t-*"
+            cibw_skip: "*-manylinux_i686 *-win32 *-manylinux*"
+            artifact_suffix: musllinux-aarch64
           - os: macos-15-intel
             cibw_archs: x86_64
             cibw_build: "cp310-* cp311-* cp314t-*"
+            cibw_skip: "*"
             artifact_suffix: all
           - os: macos-15
             cibw_archs: arm64
             cibw_build: "cp310-*"
+            cibw_skip: "*"
             artifact_suffix: cp310
           - os: macos-15
             cibw_archs: arm64
             cibw_build: "cp311-*"
+            cibw_skip: "*"
             artifact_suffix: cp311
           - os: macos-15
             cibw_archs: arm64
             cibw_build: "cp314t-*"
+            cibw_skip: "*"
             artifact_suffix: cp314t
           - os: windows-2022
             cibw_archs: AMD64
             cibw_build: "cp310-* cp311-* cp314t-*"
+            cibw_skip: "*-manylinux_i686 *-win32 *-musllinux*"
             artifact_suffix: all
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
@@ -130,7 +184,7 @@ jobs:
           CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_ENABLE: cpython-freethreading
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
-          CIBW_SKIP: "*-manylinux_i686 *-win32"
+          CIBW_SKIP: ${{ matrix.cibw_skip }}
           CIBW_ENVIRONMENT_WINDOWS: "TMP=C:\\t TEMP=C:\\t"
           CIBW_TEST_SKIP: "*"
           CIBW_BUILD_VERBOSITY: 1
@@ -160,40 +214,51 @@ jobs:
       max-parallel: 5
       matrix:
         include:
+          - os: ubuntu-latest
+            cibw_archs: x86_64
+            cibw_build: "cp310-* cp311-* cp314t-*"
+            cibw_skip: "*-manylinux_i686 *-win32 *-musllinux*"
+            artifact_suffix: manylinux-x86_64
+          - os: ubuntu-22.04-arm
+            cibw_archs: aarch64
+            cibw_build: "cp310-* cp311-* cp314t-*"
+            cibw_skip: "*-manylinux_i686 *-win32 *-musllinux*"
+            artifact_suffix: manylinux-aarch64
+          - os: ubuntu-latest
+            cibw_archs: x86_64
+            cibw_build: "cp310-* cp311-* cp314t-*"
+            cibw_skip: "*-manylinux_i686 *-win32 *-manylinux*"
+            artifact_suffix: musllinux-x86_64
+          - os: ubuntu-22.04-arm
+            cibw_archs: aarch64
+            cibw_build: "cp310-* cp311-* cp314t-*"
+            cibw_skip: "*-manylinux_i686 *-win32 *-manylinux*"
+            artifact_suffix: musllinux-aarch64
           - os: macos-15-intel
-            cmake-build-type: "Release"
-            cmake-generator: "Ninja"
-            ctest-cache: |
-              CMAKE_CXX_FLAGS:STRING=-fvisibility=hidden -fvisibility-inlines-hidden
-              CMAKE_C_FLAGS:STRING=-fvisibility=hidden
-              CMAKE_OSX_DEPLOYMENT_TARGET=10.9
-              ITK_C_OPTIMIZATION_FLAGS:STRING=
-              ITK_CXX_OPTIMIZATION_FLAGS:STRING=
-              SimpleITK_BUILD_DISTRIBUTE:BOOL=ON
-              SimpleITK_BUILD_STRIP:BOOL=1
+            cibw_archs: x86_64
+            cibw_build: "cp310-* cp311-* cp314t-*"
+            cibw_skip: "*"
+            artifact_suffix: all
           - os: macos-15
-            cmake-build-type: "Release"
-            cmake-generator: "Ninja"
-            ctest-cache: |
-              CMAKE_CXX_FLAGS:STRING=-fvisibility=hidden -fvisibility-inlines-hidden
-              CMAKE_C_FLAGS:STRING=-fvisibility=hidden
-              CMAKE_OSX_DEPLOYMENT_TARGET=11.0
-              ITK_C_OPTIMIZATION_FLAGS:STRING=
-              ITK_CXX_OPTIMIZATION_FLAGS:STRING=
-              SimpleITK_BUILD_DISTRIBUTE:BOOL=ON
-              SimpleITK_BUILD_STRIP:BOOL=1
+            cibw_archs: arm64
+            cibw_build: "cp310-*"
+            cibw_skip: "*"
+            artifact_suffix: cp310
+          - os: macos-15
+            cibw_archs: arm64
+            cibw_build: "cp311-*"
+            cibw_skip: "*"
+            artifact_suffix: cp311
+          - os: macos-15
+            cibw_archs: arm64
+            cibw_build: "cp314t-*"
+            cibw_skip: "*"
+            artifact_suffix: cp314t
           - os: windows-2022
-            cmake-build-type: "Release"
-            cmake-generator: "Visual Studio 17 2022"
-            cmake-generator-toolset: v142,host=x64
-            cmake-generator-platform: x64
-            ctest-cache: |
-              BUILD_EXAMPLES:BOOL=ON
-              BUILD_TESTING:BOOL=ON
-              ITK_C_OPTIMIZATION_FLAGS:STRING=
-              ITK_CXX_OPTIMIZATION_FLAGS:STRING=
-              SimpleITK_BUILD_DISTRIBUTE:BOOL=ON
-              CXXFLAGS:STRING= /MP
+            cibw_archs: AMD64
+            cibw_build: "cp310-* cp311-* cp314t-*"
+            cibw_skip: "*-manylinux_i686 *-win32 *-musllinux*"
+            artifact_suffix: all
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -30,50 +30,13 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            cibw_archs: x86_64
-            cibw_build: "cp310-* cp311-* cp314t-*"
-            cibw_skip: "*-manylinux_i686 *-win32 *-musllinux*"
-            artifact_suffix: manylinux-x86_64
+            dockerfile: Dockerfile-2-28-x86_64
+            build_csharp: 1
+            build_java: 1
           - os: ubuntu-22.04-arm
-            cibw_archs: aarch64
-            cibw_build: "cp310-* cp311-* cp314t-*"
-            cibw_skip: "*-manylinux_i686 *-win32 *-musllinux*"
-            artifact_suffix: manylinux-aarch64
-          - os: ubuntu-latest
-            cibw_archs: x86_64
-            cibw_build: "cp310-* cp311-* cp314t-*"
-            cibw_skip: "*-manylinux_i686 *-win32 *-manylinux*"
-            artifact_suffix: musllinux-x86_64
-          - os: ubuntu-22.04-arm
-            cibw_archs: aarch64
-            cibw_build: "cp310-* cp311-* cp314t-*"
-            cibw_skip: "*-manylinux_i686 *-win32 *-manylinux*"
-            artifact_suffix: musllinux-aarch64
-          - os: macos-15-intel
-            cibw_archs: x86_64
-            cibw_build: "cp310-* cp311-* cp314t-*"
-            cibw_skip: "*"
-            artifact_suffix: all
-          - os: macos-15
-            cibw_archs: arm64
-            cibw_build: "cp310-*"
-            cibw_skip: "*"
-            artifact_suffix: cp310
-          - os: macos-15
-            cibw_archs: arm64
-            cibw_build: "cp311-*"
-            cibw_skip: "*"
-            artifact_suffix: cp311
-          - os: macos-15
-            cibw_archs: arm64
-            cibw_build: "cp314t-*"
-            cibw_skip: "*"
-            artifact_suffix: cp314t
-          - os: windows-2022
-            cibw_archs: AMD64
-            cibw_build: "cp310-* cp311-* cp314t-*"
-            cibw_skip: "*-manylinux_i686 *-win32 *-musllinux*"
-            artifact_suffix: all
+            dockerfile: Dockerfile-2-28-aarch64
+            build_csharp: 0
+            build_java: 1
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
@@ -148,22 +111,22 @@ jobs:
           - os: macos-15-intel
             cibw_archs: x86_64
             cibw_build: "cp310-* cp311-* cp314t-*"
-            cibw_skip: "*"
+            cibw_skip: "*-manylinux_i686 *-win32 *-musllinux*"
             artifact_suffix: all
           - os: macos-15
             cibw_archs: arm64
             cibw_build: "cp310-*"
-            cibw_skip: "*"
+            cibw_skip: "*-manylinux_i686 *-win32 *-musllinux*"
             artifact_suffix: cp310
           - os: macos-15
             cibw_archs: arm64
             cibw_build: "cp311-*"
-            cibw_skip: "*"
+            cibw_skip: "*-manylinux_i686 *-win32 *-musllinux*"
             artifact_suffix: cp311
           - os: macos-15
             cibw_archs: arm64
             cibw_build: "cp314t-*"
-            cibw_skip: "*"
+            cibw_skip: "*-manylinux_i686 *-win32 *-musllinux*"
             artifact_suffix: cp314t
           - os: windows-2022
             cibw_archs: AMD64
@@ -185,7 +148,7 @@ jobs:
           CIBW_ENABLE: cpython-freethreading
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_SKIP: ${{ matrix.cibw_skip }}
-          CIBW_ENVIRONMENT_WINDOWS: "TMP=C:\\t TEMP=C:\\t"
+          CIBW_ENVIRONMENT_WINDOWS: "TMP=C:\t TEMP=C:\t"
           CIBW_TEST_SKIP: "*"
           CIBW_BUILD_VERBOSITY: 1
         with:
@@ -214,51 +177,40 @@ jobs:
       max-parallel: 5
       matrix:
         include:
-          - os: ubuntu-latest
-            cibw_archs: x86_64
-            cibw_build: "cp310-* cp311-* cp314t-*"
-            cibw_skip: "*-manylinux_i686 *-win32 *-musllinux*"
-            artifact_suffix: manylinux-x86_64
-          - os: ubuntu-22.04-arm
-            cibw_archs: aarch64
-            cibw_build: "cp310-* cp311-* cp314t-*"
-            cibw_skip: "*-manylinux_i686 *-win32 *-musllinux*"
-            artifact_suffix: manylinux-aarch64
-          - os: ubuntu-latest
-            cibw_archs: x86_64
-            cibw_build: "cp310-* cp311-* cp314t-*"
-            cibw_skip: "*-manylinux_i686 *-win32 *-manylinux*"
-            artifact_suffix: musllinux-x86_64
-          - os: ubuntu-22.04-arm
-            cibw_archs: aarch64
-            cibw_build: "cp310-* cp311-* cp314t-*"
-            cibw_skip: "*-manylinux_i686 *-win32 *-manylinux*"
-            artifact_suffix: musllinux-aarch64
           - os: macos-15-intel
-            cibw_archs: x86_64
-            cibw_build: "cp310-* cp311-* cp314t-*"
-            cibw_skip: "*"
-            artifact_suffix: all
+            cmake-build-type: "Release"
+            cmake-generator: "Ninja"
+            ctest-cache: |
+              CMAKE_CXX_FLAGS:STRING=-fvisibility=hidden -fvisibility-inlines-hidden
+              CMAKE_C_FLAGS:STRING=-fvisibility=hidden
+              CMAKE_OSX_DEPLOYMENT_TARGET=10.9
+              ITK_C_OPTIMIZATION_FLAGS:STRING=
+              ITK_CXX_OPTIMIZATION_FLAGS:STRING=
+              SimpleITK_BUILD_DISTRIBUTE:BOOL=ON
+              SimpleITK_BUILD_STRIP:BOOL=1
           - os: macos-15
-            cibw_archs: arm64
-            cibw_build: "cp310-*"
-            cibw_skip: "*"
-            artifact_suffix: cp310
-          - os: macos-15
-            cibw_archs: arm64
-            cibw_build: "cp311-*"
-            cibw_skip: "*"
-            artifact_suffix: cp311
-          - os: macos-15
-            cibw_archs: arm64
-            cibw_build: "cp314t-*"
-            cibw_skip: "*"
-            artifact_suffix: cp314t
+            cmake-build-type: "Release"
+            cmake-generator: "Ninja"
+            ctest-cache: |
+              CMAKE_CXX_FLAGS:STRING=-fvisibility=hidden -fvisibility-inlines-hidden
+              CMAKE_C_FLAGS:STRING=-fvisibility=hidden
+              CMAKE_OSX_DEPLOYMENT_TARGET=11.0
+              ITK_C_OPTIMIZATION_FLAGS:STRING=
+              ITK_CXX_OPTIMIZATION_FLAGS:STRING=
+              SimpleITK_BUILD_DISTRIBUTE:BOOL=ON
+              SimpleITK_BUILD_STRIP:BOOL=1
           - os: windows-2022
-            cibw_archs: AMD64
-            cibw_build: "cp310-* cp311-* cp314t-*"
-            cibw_skip: "*-manylinux_i686 *-win32 *-musllinux*"
-            artifact_suffix: all
+            cmake-build-type: "Release"
+            cmake-generator: "Visual Studio 17 2022"
+            cmake-generator-toolset: v142,host=x64
+            cmake-generator-platform: x64
+            ctest-cache: |
+              BUILD_EXAMPLES:BOOL=ON
+              BUILD_TESTING:BOOL=ON
+              ITK_C_OPTIMIZATION_FLAGS:STRING=
+              ITK_CXX_OPTIMIZATION_FLAGS:STRING=
+              SimpleITK_BUILD_DISTRIBUTE:BOOL=ON
+              CXXFLAGS:STRING= /MP
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -135,6 +135,11 @@ jobs:
             cibw_build: "cp310-* cp311-* cp314t-*"
             cibw_skip: "*-manylinux_i686 *-win32 *-musllinux*"
             artifact_suffix: all
+          - os: windows-11-arm
+            cibw_archs: ARM64
+            cibw_build: "cp310-* cp311-* cp314t-*"
+            cibw_skip: "*-manylinux_i686 *-win32 *-musllinux*"
+            artifact_suffix: all
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -49,10 +49,10 @@ jobs:
       - name: Build ${{ matrix.dockerfile }}
         shell: bash
         env:
-          PYTHON_VERSIONS: "cp310-cp310 cp314-cp314t"
+          PYTHON_VERSIONS: ""
           BUILD_CSHARP: ${{ matrix.build_csharp }}
           BUILD_JAVA: ${{ matrix.build_java }}
-          BUILD_PYTHON_LIMITED_API: 1
+          BUILD_PYTHON_LIMITED_API: 0
           SIMPLEITK_USE_ELASTIX: 1
         run: |
           echo "BUILD_CSHARP: ${BUILD_CSHARP}"
@@ -78,8 +78,47 @@ jobs:
         with:
           name: artifacts-${{ matrix.os }}-${{matrix.dockerfile}}
           path: |
-            Utilities/Distribution/manylinux/wheelhouse/*.whl
             Utilities/Distribution/manylinux/SimpleITK*.zip
+
+  python-wheels:
+    if: github.repository == 'SimpleITK/SimpleITK'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix:
+        include:
+          - os: ubuntu-latest
+            cibw_archs: x86_64
+          - os: ubuntu-22.04-arm
+            cibw_archs: aarch64
+          - os: macos-15-intel
+            cibw_archs: x86_64
+          - os: macos-15
+            cibw_archs: arm64
+          - os: windows-2022
+            cibw_archs: AMD64
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          fetch-depth: 0
+      - name: Build Python wheels with cibuildwheel
+        uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e # v3.3.1
+        env:
+          CIBW_BUILD: "cp310-* cp311-* cp314t-*"
+          CIBW_ENABLE: cpython-freethreading
+          CIBW_ARCHS: ${{ matrix.cibw_archs }}
+          CIBW_SKIP: "pp* *-musllinux_* *-manylinux_i686 *-win32"
+          CIBW_TEST_SKIP: "*"
+          CIBW_BUILD_VERBOSITY: 1
+        with:
+          package-dir: .
+          output-dir: wheelhouse
+      - name: Upload wheel artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: artifacts-wheels-${{ matrix.os }}-${{ matrix.cibw_archs }}
+          path: wheelhouse/*.whl
 
   build:
     if: github.repository == 'SimpleITK/SimpleITK'
@@ -209,29 +248,11 @@ jobs:
         with:
           continue-on-error: true
           cmake_osx_architectures: ${{ matrix.cmake_osx_architectures || '' }}
-      - name: Package Python 3.11
-        uses: ./.github/actions/package_python
-        with:
-          python-version: 3.11
-          use_limited_api: true
-          cmake_osx_architectures: ${{ matrix.cmake_osx_architectures || '' }}
-      - name: Package Python 3.10
-        uses: ./.github/actions/package_python
-        with:
-          python-version: "3.10"
-          cmake_osx_architectures: ${{ matrix.cmake_osx_architectures || '' }}
-      - name: Package Python 3.14t
-        uses: ./.github/actions/package_python
-        with:
-          python-version: "3.14t"
-          continue-on-error: true
-          cmake_osx_architectures: ${{ matrix.cmake_osx_architectures || '' }}
       - name: Upload Artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: artifacts-${{ matrix.os }}
           path: |
-            ${{ github.workspace }}/artifacts/*.whl
             ${{ github.workspace }}/artifacts/*.zip
             ${{ github.workspace }}/artifacts/*.gz
   doxygen:
@@ -291,6 +312,7 @@ jobs:
       - build
       - doxygen
       - package-docker
+      - python-wheels
       - sdist
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -130,7 +130,7 @@ jobs:
           CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_ENABLE: cpython-freethreading
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
-          CIBW_SKIP: "*-musllinux_* *-manylinux_i686 *-win32"
+          CIBW_SKIP: "*-manylinux_i686 *-win32"
           CIBW_ENVIRONMENT_WINDOWS: "TMP=C:\\t TEMP=C:\\t"
           CIBW_TEST_SKIP: "*"
           CIBW_BUILD_VERBOSITY: 1

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -103,11 +103,13 @@ jobs:
             cibw_build: "cp310-* cp311-* cp314t-*"
             cibw_skip: "*-manylinux_i686 *-win32 *-manylinux*"
             artifact_suffix: musllinux-x86_64
+            cibw_environment_linux: "CMAKE_ARGS='-DITK_GIT_TAG:STRING=7fae0b606bffb9cba8bd8db5132c504cc461b36a -DITK_GIT_REPOSITORY:STRING=https://github.com/blowekamp/ITK.git'"
           - os: ubuntu-22.04-arm
             cibw_archs: aarch64
             cibw_build: "cp310-* cp311-* cp314t-*"
             cibw_skip: "*-manylinux_i686 *-win32 *-manylinux*"
             artifact_suffix: musllinux-aarch64
+            cibw_environment_linux: "CMAKE_ARGS='-DITK_GIT_TAG:STRING=7fae0b606bffb9cba8bd8db5132c504cc461b36a -DITK_GIT_REPOSITORY:STRING=https://github.com/blowekamp/ITK.git'"
           - os: macos-15-intel
             cibw_archs: x86_64
             cibw_build: "cp310-* cp311-* cp314t-*"
@@ -149,6 +151,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_SKIP: ${{ matrix.cibw_skip }}
           CIBW_ENVIRONMENT_WINDOWS: "TMP=C:\t TEMP=C:\t"
+          CIBW_ENVIRONMENT_LINUX: ${{ matrix.cibw_environment_linux || '' }}
           CIBW_TEST_SKIP: "*"
           CIBW_BUILD_VERBOSITY: 1
         with:

--- a/Wrapping/Python/Python.i
+++ b/Wrapping/Python/Python.i
@@ -33,11 +33,9 @@
 %init %{
     // Initialize the ImageBuffer type when the module loads
     if (InitImageBufferType(m) < 0) {
-#if PY_VERSION_HEX >= 0x03000000
-        return NULL;
-#else
-        return;
-#endif
+        // SWIG_mod_exec (the Py_mod_exec slot function for the multi-phase
+        // init module, PEP 489) returns int, not PyObject*.
+        return -1;
     }
 #ifdef Py_GIL_DISABLED
     // Declare this module as safe to use without the GIL (PEP 703 / free-threaded).


### PR DESCRIPTION
## Summary
- add a dedicated `python-wheels` matrix job in `.github/workflows/Package.yml` using `pypa/cibuildwheel`
- replace wheel generation in both existing paths:
  - manylinux `package-docker` wheel path
  - macOS/Windows `build` job `package_python` path
- keep non-wheel packaging artifacts intact and wire `publish-github` to depend on `python-wheels`
- wheel matrix covers Linux x86_64/aarch64 (manylinux + musllinux as separate jobs), macOS x86_64 + arm64 (arm64 split per Python version), Windows x64, and native Windows ARM64 (`windows-11-arm`)

## Notable fixes along the way
- Windows wheel builds failed due to ITK's source path-length limit; added a short temp directory (`C:\t`) for cibuildwheel on Windows
- macOS arm64 wheel builds timed out when building all Python variants together; split into one job per Python version (cp310/cp311/cp314t)
- musllinux wheel builds failed on an ITK/GDCM off64_t portability issue on musl libc; pinned musllinux-only matrix entries to a fix (upstream ITK PR https://github.com/InsightSoftwareConsortium/ITK/pull/6779)
- Fixed a real SimpleITK bug in `Wrapping/Python/Python.i` exposed by Alpine/musl's GCC 14 toolchain: the module init (`%init`) block returned `NULL` from `SWIG_mod_exec`, which returns `int` (PEP 489 slot function), not `PyObject*`
- Added native Windows ARM64 wheel building using the `windows-11-arm` GitHub-hosted runner (cibuildwheel's Windows ARM64 cross-compile path only supports setuptools/setuptools_rust backends, not scikit-build-core, so a native runner is used instead)

## Notes
- This is a prototype branch intended to validate replacing the existing GitHub Actions wheel-building flow with ciwheelbuild infrastructure.