### PR TITLE
BUG: Fix incorrect NULL return in Python module init

### DIFF
--- a/Wrapping/Python/Python.i
+++ b/Wrapping/Python/Python.i
@@ -33,11 +33,9 @@
 %init %{
     // Initialize the ImageBuffer type when the module loads
     if (InitImageBufferType(m) < 0) {
-#if PY_VERSION_HEX >= 0x03000000
-        return NULL;
-#else
-        return;
-#endif
+        // SWIG_mod_exec (the Py_mod_exec slot function for the multi-phase
+        // init module, PEP 489) returns int, not PyObject*.
+        return -1;
     }
 #ifdef Py_GIL_DISABLED
     // Declare this module as safe to use without the GIL (PEP 703 / free-threaded).


### PR DESCRIPTION
Fixes incorrect NULL return in Python module init that was causing compilation failures on Alpine/musl with GCC 14.

## Problem
SWIG_mod_exec is the Py_mod_exec slot function for the Python 3 multi-phase module init (PEP 489) and returns int, not PyObject*. The %init block incorrectly returned NULL on error, which most toolchains tolerate since NULL/__null is implicitly convertible to int, but fails to compile on toolchains (e.g. Alpine/musl with GCC 14) where NULL expands to nullptr, a hard error to convert to int.

This was exposed by the new musllinux wheel builds added to the Package CI workflow.

## Changes
- Modified Wrapping/Python/Python.i to return proper int error codes instead of NULL
