### PR TITLE
FIX: Use standard [[tool.dynamic-metadata]] for version provider

### DIFF
--- a/Wrapping/Python/CMakeLists.txt
+++ b/Wrapping/Python/CMakeLists.txt
@@ -365,7 +365,7 @@ set(PYPROJECT_TOML_EXTRA "")
 if(SimpleITK_PYTHON_USE_LIMITED_API)
   set(
     PYPROJECT_TOML_EXTRA
-    "${PYPROJECT_TOML_EXTRA}\n[tool.scikit-build]\nwheel.py-api = \"cp311\"\n"
+    "${PYPROJECT_TOML_EXTRA}\nwheel.py-api = \"cp311\"\n"
   )
 endif()
 

--- a/Wrapping/Python/Packaging/pyproject.toml.in
+++ b/Wrapping/Python/Packaging/pyproject.toml.in
@@ -40,6 +40,8 @@ Homepage = "http://simpleitk.org/"
 Documentation = "https://simpleitk.readthedocs.io/en/release/"
 "Source Code" = "https://github.com/SimpleITK/SimpleITK"
 
+[tool.scikit-build]
+minimum-version = "build-system.requires"
 @PYPROJECT_TOML_EXTRA@
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 requires-python = ">=3.10"
 dynamic = ["version"]
 
-[tool.scikit-build.metadata.version]
+[[tool.dynamic-metadata]]
 provider = "scikit_build_core.metadata.setuptools_scm"
 
 [tool.setuptools_scm]
@@ -47,7 +47,7 @@ version_file = "Wrapping/Python/SimpleITK/_version.py"
 tag_regex = "^v(?P<version>[^\\+]+)(?P<suffix>.*)?$"
 
 [tool.scikit-build]
-minimum-version = "0.11"
+minimum-version = "build-system.requires"
 cmake.version = ">=3.26.1"
 cmake.build-type = "Release"
 wheel.packages = []


### PR DESCRIPTION
## Problem

`scikit-build-core` 1.0 deprecates the `[tool.scikit-build.metadata.<field>]` table syntax, emitting a deprecation warning at build time.

## Fix

Replace the deprecated form with the standard `[[tool.dynamic-metadata]]` top-level array table introduced in scikit-build-core 1.0 (per the [dynamic-metadata 0.4 spec](https://scikit-build-core.readthedocs.io/en/stable/configuration/dynamic.html)):

```toml
[[tool.dynamic-metadata]]
provider = "scikit_build_core.metadata.setuptools_scm"
```

Also updates `minimum-version` to `"build-system.requires"` so it is always derived from the pinned `scikit-build-core` version in `build-system.requires`, removing a second place to maintain the constraint.

## Validation

Confirmed via `SettingsReader` with `verify_conf=True` (scikit-build-core 1.0): config loads with no deprecation warnings.