### PR TITLE
Add regression tests for writable-buffer rejection in Image buffer protocol

### DIFF
--- a/Wrapping/Python/tests/sitkImageBufferTest.py
+++ b/Wrapping/Python/tests/sitkImageBufferTest.py
@@ -378,6 +378,27 @@ def test_get_weak_memoryview_with_flags():
     assert mv.format == 'i'
 
 
+def test_get_weak_memoryview_writable_rejected():
+    """Test that requesting a writable buffer is explicitly rejected"""
+    import inspect
+
+    if not hasattr(inspect, 'BufferFlags'):
+        pytest.skip("BufferFlags not available (requires Python 3.12+)")
+
+    BufferFlags = inspect.BufferFlags
+    img = sitk.Image([4, 6], sitk.sitkInt32)
+    buf = ImageBuffer(img)
+
+    with pytest.raises(BufferError, match="Cannot create writable buffer"):
+        buf.get_weak_memoryview(BufferFlags.WRITABLE)
+
+    with pytest.raises(BufferError, match="Cannot create writable buffer"):
+        buf.get_weak_memoryview(BufferFlags.FULL)
+
+    with pytest.raises(BufferError, match="Cannot create writable buffer"):
+        buf.get_weak_memoryview(BufferFlags.RECORDS)
+
+
 def test_get_weak_memoryview_readonly_enforcement():
     """Test that get_weak_memoryview always returns read-only memoryview"""
     img = sitk.Image([3, 5], sitk.sitkFloat64)

--- a/Wrapping/Python/tests/sitkImageProtocolTest.py
+++ b/Wrapping/Python/tests/sitkImageProtocolTest.py
@@ -155,6 +155,18 @@ class TestBufferProtocol:
         assert mv1.format == mv2.format
         assert mv1.strides == mv2.strides
 
+    def test_buffer_writable_rejected(self):
+        """Test that Image.__buffer__ rejects a writable buffer request"""
+        import inspect
+
+        img = sitk.Image([3, 5], sitk.sitkFloat32)
+
+        with pytest.raises(BufferError, match="Cannot create writable buffer"):
+            img.__buffer__(inspect.BufferFlags.WRITABLE)
+
+        with pytest.raises(BufferError, match="Cannot create writable buffer"):
+            img.__buffer__(inspect.BufferFlags.FULL)
+
 
 # ============================================================================
 # __array_interface__ Tests (requires numpy)


### PR DESCRIPTION
## Summary
- `Image`'s PEP 688 buffer protocol (`ImageBuffer` / `Image.__buffer__`, added in #2447) explicitly rejects any `PyBUF_WRITABLE` request with `BufferError: Cannot create writable buffer for image`, but that rejection path had no test coverage — existing tests only exercised read-only flag combinations (`FULL_RO`, `RECORDS_RO`, `SIMPLE`).
- Adds a test at the low-level `ImageBuffer.get_weak_memoryview` entry point (`sitkImageBufferTest.py`) and one at the high-level `Image.__buffer__` entry point (`sitkImageProtocolTest.py`), so this safety guard is locked in and any future change to allow writable buffers is a deliberate, visible decision rather than an accidental regression.
- Related to the discussion in #2683 (feature request for a buffer-reuse path in `GetImageFromArray`), where a writable-buffer relaxation was considered as an alternative design and rejected in favor of a smaller, safer change.

## Test plan
- [x] Ran both new tests plus the full `sitkImageBufferTest.py`/`sitkImageProtocolTest.py` suites (98 tests) against the released `simpleitk==3.0.0a2` wheel — all pass.
- [x] No production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)