### PR TITLE
ENH: Add outputImage argument to GetImageFromArray

### DIFF
--- a/Wrapping/Python/SimpleITK/extra.py
+++ b/Wrapping/Python/SimpleITK/extra.py
@@ -281,12 +281,23 @@ def GetArrayFromImage(image: Image) -> "numpy.ndarray":
     return numpy.array(image, copy=True)
 
 
-def GetImageFromArray(arr: "numpy.ndarray", isVector: Optional[bool] = None) -> Image:
+def GetImageFromArray(
+    arr: "numpy.ndarray",
+    isVector: Optional[bool] = None,
+    outputImage: Optional[Image] = None,
+) -> Image:
     """Get a SimpleITK Image from a numpy array.
 
     If isVector is True, then the Image will have a Vector pixel type, and the last dimension of the array will be
     considered the component index. By default when isVector is None, 4D arrays
     are automatically considered 3D vector images, but 3D arrays are 3D images.
+
+    If outputImage is given, the array is copied into that image and that image is returned, instead of a newly
+    constructed one. It must already have the size, pixel ID and number of components per pixel the array
+    converts to, otherwise a ValueError is raised. Its origin, spacing, direction and metadata are left
+    unchanged. Converting a sequence of arrays of the same shape and dtype into one reused image avoids an
+    allocation and a zero fill per array. Copy-on-write still applies: if the image shares its buffer with
+    another Image, that image is left untouched and this call allocates a new buffer.
     """
 
     if not HAVE_NUMPY:
@@ -311,8 +322,30 @@ def GetImageFromArray(arr: "numpy.ndarray", isVector: Optional[bool] = None) -> 
         id = _get_sitk_pixelid(z)
         shape = z.shape[::-1]
 
-    # SimpleITK throws an exception if the image dimension is not supported
-    img = Image(shape, id, number_of_components)
+    if outputImage is None:
+        # SimpleITK throws an exception if the image dimension is not supported
+        img = Image(shape, id, number_of_components)
+    else:
+        # _SetImageFromArray checks the total number of bytes only, so the image is matched to the array here.
+        img = outputImage
+        size = tuple(int(s) for s in shape)
+        if (
+            img.GetSize() != size
+            or img.GetPixelID() != id
+            or img.GetNumberOfComponentsPerPixel() != number_of_components
+        ):
+            raise ValueError(
+                "The outputImage does not match the array. The array converts to size {0}, pixel type"
+                ' "{1}" and {2} component(s) per pixel, while the image has size {3}, pixel type "{4}" and'
+                " {5} component(s) per pixel.".format(
+                    size,
+                    GetPixelIDValueAsString(id),
+                    number_of_components,
+                    img.GetSize(),
+                    img.GetPixelIDTypeAsString(),
+                    img.GetNumberOfComponentsPerPixel(),
+                )
+            )
 
     _SetImageFromArray(z, img)
 

--- a/Wrapping/Python/tests/sitkNumpyArrayConversionTest.py
+++ b/Wrapping/Python/tests/sitkNumpyArrayConversionTest.py
@@ -247,3 +247,81 @@ def test_legacy_array2sitk(dims, dtype):
     assert (image[0, 0, 0] if len(dims) == 3 else image[0, 0]) == 0
     assert (image[1, 1, 0] if len(dims) == 3 else image[1, 1]) == 5
     assert (image[2, 2, 0] if len(dims) == 3 else image[2, 2]) == 10
+
+
+def test_output_image():
+    """Test filling a given image with GetImageFromArray's outputImage argument"""
+    image = sitk.Image((sizeX, sizeY, sizeZ), sitk.sitkInt16)
+    image.SetOrigin((1.0, 2.0, 3.0))
+    image.SetSpacing((0.5, 0.5, 2.0))
+
+    arr = np.arange(sizeX * sizeY * sizeZ, dtype=np.int16).reshape(sizeZ, sizeY, sizeX)
+    result = sitk.GetImageFromArray(arr, outputImage=image)
+
+    assert result is image, "The given image should be filled and returned"
+    assert np.array_equal(sitk.GetArrayViewFromImage(image), arr)
+    assert image.GetOrigin() == (1.0, 2.0, 3.0), "The image's geometry should be left unchanged"
+    assert image.GetSpacing() == (0.5, 0.5, 2.0), "The image's geometry should be left unchanged"
+
+    # The same image can be filled again with another array of the same shape and dtype.
+    other = arr[::-1].copy()
+    assert sitk.GetImageFromArray(other, outputImage=image) is image
+    assert np.array_equal(sitk.GetArrayViewFromImage(image), other)
+
+
+def test_output_image_is_equivalent_to_a_fresh_one():
+    """Test that outputImage produces the image GetImageFromArray would have constructed"""
+    arr = np.arange(2 * 3 * 5, dtype=np.float32).reshape(2, 3, 5)
+
+    for is_vector in (None, False, True):
+        expected = sitk.GetImageFromArray(arr, isVector=is_vector)
+        image = sitk.Image(
+            expected.GetSize(),
+            expected.GetPixelID(),
+            expected.GetNumberOfComponentsPerPixel(),
+        )
+        result = sitk.GetImageFromArray(arr, isVector=is_vector, outputImage=image)
+
+        assert result is image
+        assert sitk.Hash(result) == sitk.Hash(expected), f"Different content for isVector={is_vector}"
+
+
+@pytest.mark.parametrize("size,pixel_id,components", [
+    ((sizeX, sizeY, sizeZ + 1), sitk.sitkUInt16, 1),
+    ((sizeY, sizeX, sizeZ), sitk.sitkUInt16, 1),
+    ((sizeX, sizeY), sitk.sitkUInt16, 1),
+    ((sizeX, sizeY, sizeZ), sitk.sitkInt16, 1),
+    ((sizeX * 2, sizeY, sizeZ), sitk.sitkUInt8, 1),
+    ((sizeX, sizeY, sizeZ), sitk.sitkVectorUInt16, 1),
+])
+def test_output_image_mismatch(size, pixel_id, components):
+    """Test that an outputImage which does not match the array is rejected"""
+    arr = np.zeros((sizeZ, sizeY, sizeX), dtype=np.uint16)
+    image = sitk.Image(size, pixel_id, components)
+
+    with pytest.raises(ValueError, match="outputImage"):
+        sitk.GetImageFromArray(arr, outputImage=image)
+
+
+def test_output_image_vector():
+    """Test the outputImage argument with a vector image"""
+    arr = np.arange(2 * 3 * 5 * 4, dtype=np.uint8).reshape(2, 3, 5, 4)
+    image = sitk.Image((5, 3, 2), sitk.sitkVectorUInt8, 4)
+
+    assert sitk.GetImageFromArray(arr, outputImage=image) is image
+    assert np.array_equal(sitk.GetArrayViewFromImage(image), arr)
+
+    with pytest.raises(ValueError, match="component"):
+        sitk.GetImageFromArray(arr, outputImage=sitk.Image((5, 3, 2), sitk.sitkVectorUInt8, 2))
+
+
+def test_output_image_copy_on_write():
+    """Test that filling an image does not modify another image sharing its buffer"""
+    arr = np.zeros((sizeZ, sizeY, sizeX), dtype=np.uint16)
+    image = sitk.GetImageFromArray(arr)
+    shared = sitk.Image(image)
+
+    sitk.GetImageFromArray(arr + 1, outputImage=image)
+
+    assert np.array_equal(sitk.GetArrayFromImage(shared), arr)
+    assert np.array_equal(sitk.GetArrayFromImage(image), arr + 1)


### PR DESCRIPTION
Implements #2683.

`GetImageFromArray(arr, isVector=None, outputImage=None)`. When `outputImage` is given, the array is copied into that image and that image is returned. Without it, nothing changes.

The image has to match what the array converts to: size, pixel ID, and number of components per pixel. Anything else raises `ValueError`. `_SetImageFromArray` checks the total number of bytes only, so an image with the same byte count but a different pixel type, a different shape, or transposed axes gets filled silently today.

The image keeps its origin, spacing, direction and metadata. Copy-on-write still holds: if the image shares its buffer with another `Image`, that other image keeps its values and the call allocates a new buffer.

### Numbers

384³ uint16 (113 MB), best and median of 11 to 21 repetitions, with this patch applied to the `3.0.0b1.post145` dev wheel, on a Linux box under load (1-minute average 7 to 10):

| run | fresh | outputImage | speedup |
|---|---|---|---|
| 1 (11 reps) | 52.3 / 64.2 ms | 6.1 / 8.1 ms | 8.5x / 7.9x |
| 2 (21 reps) | 59.6 / 67.7 ms | 8.4 / 11.3 ms | 7.1x / 6.0x |
| 3 (21 reps) | 61.6 / 67.7 ms | 8.5 / 8.9 ms | 7.3x / 7.6x |

That lines up with the 7.9x measured in the issue. Running a `Resample` on the image between two fills does not force a reallocation: those fills stay at 5.9 to 7.7 ms.

### Tests

Ten cases in `sitkNumpyArrayConversionTest.py`: the image is filled and returned as the same object, can be filled again, and keeps its geometry; the result matches a fresh conversion for `isVector` None, False and True; a mismatched image is rejected for a different size, transposed axes, a different dimension, a different pixel type, a pixel type of the same byte count, and a scalar against a vector image; vector images work, including a wrong component count; and an image sharing its buffer is left alone.

They fail without the change and pass with it, and the whole `Wrapping/Python/tests` suite is 390 passed, 1 skipped against the dev wheel.
