### PR TITLE
Add Image.buffer property: read-only get, validated in-place set

### DIFF
--- a/Wrapping/Python/sitkImage.i
+++ b/Wrapping/Python/sitkImage.i
@@ -330,6 +330,100 @@
               'data': memoryview(_SimpleITK.ImageBuffer(self))
           }
 
+        @property
+        def buffer(self):
+          """
+          Read-only memoryview of the image's pixel buffer.
+
+          Uses the same shape/format conventions as __array_interface__. The
+          returned memoryview holds a strong reference to this Image (via an
+          internal ImageBuffer object), so it remains valid even after the
+          original Image variable goes out of scope.
+          """
+          return memoryview(_SimpleITK.ImageBuffer(self))
+
+        @buffer.setter
+        def buffer(self, value):
+          """
+          Copy new pixel data into this image's existing buffer, in place.
+
+          `value` must be a buffer-protocol object (bytes, bytearray,
+          memoryview, array.array, a NumPy array, ...) whose format and shape
+          exactly match this image's pixel type, size, and number of
+          components per pixel. This overwrites only the pixel data; this
+          image's spacing, origin, direction, and metadata are unchanged.
+
+          Raises:
+          -------
+          TypeError
+              If the image pixel type is not compatible with the buffer
+              interface, or the given buffer's format does not match.
+          ValueError
+              If the given buffer's shape does not match this image's shape.
+          """
+          _sitk_buffer_format = {
+              sitkUInt8: 'B',
+              sitkInt8: 'b',
+              sitkUInt16: 'H',
+              sitkInt16: 'h',
+              sitkUInt32: 'I',
+              sitkInt32: 'i',
+              sitkUInt64: 'Q',
+              sitkInt64: 'q',
+              sitkFloat32: 'f',
+              sitkFloat64: 'd',
+              sitkComplexFloat32: 'Zf',
+              sitkComplexFloat64: 'Zd',
+              sitkVectorUInt8: 'B',
+              sitkVectorInt8: 'b',
+              sitkVectorUInt16: 'H',
+              sitkVectorInt16: 'h',
+              sitkVectorUInt32: 'I',
+              sitkVectorInt32: 'i',
+              sitkVectorUInt64: 'Q',
+              sitkVectorInt64: 'q',
+              sitkVectorFloat32: 'f',
+              sitkVectorFloat64: 'd'
+          }
+          sitk_pixel_id = self.GetPixelIDValue()
+
+          expected_format = _sitk_buffer_format.get(sitk_pixel_id, None)
+
+          if expected_format is None:
+            raise TypeError("The SimpleITK image pixel type is not compatible with the buffer interface")
+
+          src = memoryview(value)
+
+          if src.format != expected_format:
+            raise TypeError(f"Buffer format '{src.format}' does not match the image's pixel type (expected '{expected_format}')")
+
+          expected_shape = self.GetSize()[::-1]
+          if sitk_pixel_id in { sitkVectorUInt8, sitkVectorInt8, sitkVectorUInt16, sitkVectorInt16,
+                               sitkVectorUInt32, sitkVectorInt32, sitkVectorUInt64, sitkVectorInt64,
+                               sitkVectorFloat32, sitkVectorFloat64 }:
+            expected_shape = expected_shape + (self.GetNumberOfComponentsPerPixel(),)
+
+          expected_count = 1
+          for dim in expected_shape:
+            expected_count *= dim
+
+          # A flat 1-D buffer (e.g. bytes/bytearray/array.array, or the pickled
+          # state in __setstate__) carries no shape information to validate,
+          # so only its total element count is checked - the same convention
+          # already relied on elsewhere for flat buffers. Anything with more
+          # dimensions is assumed to be shape-aware (e.g. a NumPy array) and
+          # must match this image's shape exactly, to catch the silent
+          # reinterpretation/transposition that plain _SetImageFromArray does
+          # not.
+          if src.ndim == 1:
+            if src.shape[0] != expected_count:
+              raise ValueError(
+                  f"Buffer has {src.shape[0]} elements, expected {expected_count} for image shape {expected_shape}")
+          elif src.shape != expected_shape:
+            raise ValueError(f"Buffer shape {src.shape} does not match the image's shape {expected_shape}")
+
+          _SetImageFromArray(value, self)
+
         def __copy__(self):
           """Create a SimpleITK shallow copy, where the internal image share is shared with copy on write implementation."""
           return Image(self)

--- a/Wrapping/Python/tests/sitkImageProtocolTest.py
+++ b/Wrapping/Python/tests/sitkImageProtocolTest.py
@@ -305,6 +305,138 @@ class TestArrayInterface:
 
 
 # ============================================================================
+# Image.buffer property Tests
+# ============================================================================
+
+@pytest.mark.skipif(not NUMPY_AVAILABLE, reason="Requires numpy")
+class TestBufferProperty:
+    """Tests for the Image.buffer property (read-only get, validated in-place set)"""
+
+    def test_getter_matches_array_interface_shape_and_format(self):
+        img = sitk.Image([3, 5, 7], sitk.sitkUInt16)
+        mv = img.buffer
+
+        assert mv.shape == (7, 5, 3)
+        assert mv.format == 'H'
+        assert mv.readonly
+
+    def test_getter_readonly(self):
+        img = sitk.Image([3, 5], sitk.sitkFloat32)
+        mv = img.buffer
+
+        with pytest.raises(TypeError, match="cannot modify read-only memory"):
+            mv[0, 0] = 1.0
+
+    def test_getter_vector_shape(self):
+        img = sitk.Image([5, 7], sitk.sitkVectorFloat32, 3)
+        mv = img.buffer
+
+        assert mv.shape == (7, 5, 3)
+        assert mv.format == 'f'
+
+    def test_getter_survives_source_variable_going_out_of_scope(self):
+        """The returned memoryview must keep the source Image alive on its own -
+        NOT rely on the caller separately holding a reference (e.g. a temporary
+        Image expression). Regression test for a dangling-buffer bug found while
+        designing this property: ImageBuffer.get_weak_memoryview() does NOT keep
+        the source Image alive, memoryview(ImageBuffer(img)) does."""
+
+        def get_buffer():
+            img = sitk.Image([4, 4], sitk.sitkFloat32)
+            img[0, 0] = 42.0
+            return img.buffer
+
+        mv = get_buffer()
+        gc.collect()
+
+        assert mv[0, 0] == 42.0
+
+    def test_setter_updates_pixel_data(self):
+        img = sitk.Image([3, 5, 7], sitk.sitkUInt16)
+        arr = np.arange(3 * 5 * 7, dtype=np.uint16).reshape(7, 5, 3)
+
+        img.buffer = arr
+
+        assert np.array_equal(sitk.GetArrayFromImage(img), arr)
+
+    def test_setter_accepts_plain_bytes_without_numpy(self):
+        img = sitk.Image([2, 2], sitk.sitkUInt8)
+        data = bytes([1, 2, 3, 4])
+
+        img.buffer = data
+
+        assert list(sitk.GetArrayFromImage(img).flatten()) == [1, 2, 3, 4]
+
+    def test_setter_accepts_array_module(self):
+        import array
+
+        img = sitk.Image([2, 2], sitk.sitkInt32)
+        data = array.array('i', [10, 20, 30, 40])
+
+        img.buffer = data
+
+        assert list(sitk.GetArrayFromImage(img).flatten()) == [10, 20, 30, 40]
+
+    def test_setter_rejects_format_mismatch(self):
+        img = sitk.Image([3, 5], sitk.sitkUInt16)
+        arr = np.zeros((5, 3), dtype=np.float32)
+
+        with pytest.raises(TypeError, match="does not match"):
+            img.buffer = arr
+
+    def test_setter_rejects_shape_mismatch_same_byte_length(self):
+        """The private _SetImageFromArray only checks byte length, so a buffer
+        of a different shape (or dtype) with the same total byte count is
+        silently accepted and reinterpreted/transposed. The buffer setter must
+        catch this instead of delegating to that unchecked byte-length compare."""
+        img = sitk.Image([6, 5, 4], sitk.sitkUInt16)  # 6*5*4*2 = 240 bytes
+        arr = np.zeros((6, 5, 8), dtype=np.uint8)  # 6*5*8*1 = 240 bytes, wrong shape/dtype
+
+        with pytest.raises((TypeError, ValueError)):
+            img.buffer = arr
+
+    def test_setter_rejects_transposed_shape(self):
+        img = sitk.Image([6, 5, 4], sitk.sitkUInt16)  # correct array shape is (4, 5, 6)
+        arr = np.zeros((6, 5, 4), dtype=np.uint16)  # same size and dtype, axes swapped
+
+        with pytest.raises(ValueError, match="does not match"):
+            img.buffer = arr
+
+    def test_setter_vector_image(self):
+        img = sitk.Image([3, 4], sitk.sitkVectorFloat32, 2)
+        arr = np.arange(4 * 3 * 2, dtype=np.float32).reshape(4, 3, 2)
+
+        img.buffer = arr
+
+        assert np.array_equal(sitk.GetArrayFromImage(img), arr)
+
+    def test_setter_rejects_vector_component_mismatch(self):
+        img = sitk.Image([3, 4], sitk.sitkVectorFloat32, 2)
+        arr = np.zeros((4, 3, 3), dtype=np.float32)  # 3 components instead of 2
+
+        with pytest.raises(ValueError, match="does not match"):
+            img.buffer = arr
+
+    def test_setter_preserves_metadata(self):
+        img = sitk.Image([3, 5], sitk.sitkFloat32)
+        img.SetOrigin([1.0, 2.0])
+        img.SetSpacing([2.0, 3.0])
+        img.SetMetaData("key", "value")
+
+        img.buffer = np.ones((5, 3), dtype=np.float32)
+
+        assert img.GetOrigin() == (1.0, 2.0)
+        assert img.GetSpacing() == (2.0, 3.0)
+        assert img.GetMetaData("key") == "value"
+
+    def test_setter_rejects_label_pixel_type(self):
+        img = sitk.Image([3, 5], sitk.sitkLabelUInt8)
+
+        with pytest.raises(TypeError, match="not compatible"):
+            img.buffer = np.zeros((5, 3), dtype=np.uint8)
+
+
+# ============================================================================
 # Integration Tests with numpy
 # ============================================================================
 


### PR DESCRIPTION
## Summary
- Adds `Image.buffer`, a property that gives read access to the pixel buffer (same as `__array_interface__`'s `data` field) and a validating setter that copies new data into the image's *existing* memory in place.
- Motivated by #2683: the issue's `outputImage=` proposal for `GetImageFromArray` would need to call the private `_SetImageFromArray`, which is not meant to be public and only checks byte length - a buffer with the same total size but the wrong shape or dtype is silently reinterpreted or transposed. `Image.buffer`'s setter validates format and shape first, then delegates to that function internally, so the copy-into-existing-buffer benefit is available without exposing the private API or its footgun.
- Considered and rejected relaxing the PEP 688 `__buffer__`/`ImageBuffer` write-protection instead (see #2685) - a writable memoryview can outlive SimpleITK's copy-on-write uniqueness check, so a later `Image(img)` copy could silently alias and corrupt. The `buffer` setter avoids this entirely: it never hands out a writable reference, it validates and copies immediately.
- The getter deliberately does not call `self.__buffer__()` (that method's default-flags path needs Python 3.12's `inspect.BufferFlags`, but this project supports `>=3.10`) or `ImageBuffer.get_weak_memoryview()` directly (empirically verified that path returns a dangling memoryview once the source Image's only other reference is dropped). It mirrors `__array_interface__`'s existing `memoryview(_SimpleITK.ImageBuffer(self))` call, which keeps the source Image alive via its own reference chain.

## Example
```python
import SimpleITK as sitk
import numpy as np

img = sitk.Image([384, 384, 384], sitk.sitkUInt16)  # allocate once
for arr in generate_arrays():  # each same shape/dtype as img
    img.buffer = arr           # validated copy into img's existing memory
    process(img)
```

## Test plan
- [x] New `TestBufferProperty` class in `sitkImageProtocolTest.py` (getter parity with `__array_interface__`, reference-safety after the source variable goes out of scope, setter success with NumPy/`bytes`/`array.array`, format/shape/transposition/vector-component rejection, metadata preservation, label-type rejection).
- [x] Built from source and ran the full Image/buffer/array-view ctest suite (`Test.ImageTests`, `Test.ImageIndexing`, `Test.ImageReadWrite`, `Test.ImageBuffer`, `Test.ImageProtocol`, `Test.ArrayView`) - all pass, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)