### PR TITLE
Add GetImageViewFromArray: zero-copy Image view of a writable buffer

### DIFF
--- a/Code/Common/include/sitkImage.h
+++ b/Code/Common/include/sitkImage.h
@@ -27,6 +27,7 @@
 #include <vector>
 #include <memory>
 #include <type_traits>
+#include <functional>
 
 namespace itk
 {
@@ -199,6 +200,23 @@ public:
   const itk::DataObject *
   GetITKBase() const;
   /**@}*/
+
+  /** \brief Tie an external resource's lifetime to this image's underlying pixel data.
+   *
+   * releaseCallback is invoked exactly once, when the last Image (including
+   * shallow copies made via the copy constructor) sharing this image's
+   * current underlying pixel data is destroyed. This is intended for
+   * language wrappings that import a foreign, externally-owned buffer as
+   * this image's pixel data (e.g. via ImportImageFilter) and need the
+   * foreign buffer's owner kept alive for exactly that long, released
+   * automatically - and only - once it becomes safe to do so.
+   *
+   * releaseCallback must not throw, and must not itself call any method on
+   * this Image (e.g. GetITKBase, MakeUnique), since it may run during this
+   * image's own destruction.
+   */
+  void
+  TieBufferLifetime(std::function<void()> releaseCallback);
 
   /** Get the pixel type
    *

--- a/Code/Common/src/sitkImage.cxx
+++ b/Code/Common/src/sitkImage.cxx
@@ -19,6 +19,7 @@
 
 #include "itkMetaDataObject.h"
 #include "itkDataObject.h"
+#include "itkCommand.h"
 
 #include "sitkExceptionObject.h"
 #include "sitkPimpleImageBase.h"
@@ -123,6 +124,70 @@ Image::GetITKBase() const
   {
     return nullptr;
   }
+}
+
+namespace
+{
+// Local itk::Command which invokes an arbitrary std::function exactly once,
+// on its own destruction. Registering an instance as an itk::DeleteEvent
+// observer on an itk::Object ties the callback to that object's ITK
+// reference count: itk::Object's own observer-list clean-up releases this
+// Command automatically once the observed object is destroyed - no
+// explicit RemoveObserver call is needed (see itk::HolderCommand for the
+// same pattern used elsewhere in this codebase for a copyable payload).
+class StdFunctionDeleteCommand : public itk::Command
+{
+public:
+  using Self = StdFunctionDeleteCommand;
+  using Superclass = itk::Command;
+  using Pointer = itk::SmartPointer<Self>;
+
+  itkNewMacro(Self);
+
+  void
+  SetCallback(std::function<void()> callback)
+  {
+    m_Callback = std::move(callback);
+  }
+
+  void
+  Execute(itk::Object *, const itk::EventObject &) override
+  {}
+  void
+  Execute(const itk::Object *, const itk::EventObject &) override
+  {}
+
+  StdFunctionDeleteCommand(const StdFunctionDeleteCommand &) = delete;
+  void
+  operator=(const StdFunctionDeleteCommand &) = delete;
+
+protected:
+  StdFunctionDeleteCommand() = default;
+  ~StdFunctionDeleteCommand() override
+  {
+    if (m_Callback)
+    {
+      m_Callback();
+    }
+  }
+
+private:
+  std::function<void()> m_Callback;
+};
+} // namespace
+
+void
+Image::TieBufferLifetime(std::function<void()> releaseCallback)
+{
+  itk::DataObject * itkBase = this->GetITKBase();
+  if (!itkBase)
+  {
+    sitkExceptionMacro("Unable to tie buffer lifetime: image has been moved.");
+  }
+
+  StdFunctionDeleteCommand::Pointer cmd = StdFunctionDeleteCommand::New();
+  cmd->SetCallback(std::move(releaseCallback));
+  itkBase->AddObserver(itk::DeleteEvent(), cmd);
 }
 
 PixelIDValueType

--- a/Wrapping/Python/Python.i
+++ b/Wrapping/Python/Python.i
@@ -71,6 +71,7 @@
 // is declared static.
 %{
 #include "sitkNumpyArrayConversion.cxx"
+#include "sitkGetImageViewFromArray.cxx"
 
 // Helper function to extract sitk::Image* from a SWIG-wrapped PyObject
 // This function is used by sitkImageBuffer.cxx
@@ -92,6 +93,7 @@ itk::simple::Image* sitk_GetImagePointerFromPyObject(PyObject* pyImage)
 %}
 // Numpy array conversion support
 %native(_SetImageFromArray) PyObject *sitk_SetImageFromArray( PyObject *self, PyObject *args );
+%native(_GetImageViewFromArray) PyObject *sitk_GetImageViewFromArray( PyObject *self, PyObject *args );
 
 // Enable Python classes derived from Command Execute method to be
 // called from C++

--- a/Wrapping/Python/SimpleITK/extra.py
+++ b/Wrapping/Python/SimpleITK/extra.py
@@ -19,6 +19,7 @@
 from pathlib import Path
 from SimpleITK.SimpleITK import *
 from SimpleITK.SimpleITK import _SetImageFromArray
+from SimpleITK.SimpleITK import _GetImageViewFromArray
 
 from typing import Iterable, List, Optional, Type, Union, Tuple
 
@@ -319,6 +320,60 @@ def GetImageFromArray(arr: "numpy.ndarray", isVector: Optional[bool] = None) -> 
     return img
 
 
+def GetImageViewFromArray(arr: "numpy.ndarray", isVector: Optional[bool] = None) -> Image:
+    """Get a SimpleITK Image that is a zero-copy view of a NumPy array's memory.
+
+    Unlike GetImageFromArray, no new memory is allocated and no data is copied: the returned
+    Image's pixel buffer *is* arr's underlying memory. A write through either the Image or arr
+    is visible through the other.
+
+    arr must be writable and C-contiguous; a ValueError is raised otherwise (e.g. for a read-only
+    array, or a transposed/strided view). isVector has the same meaning as in GetImageFromArray.
+
+    It is safe for arr to go out of scope or be deleted while the returned Image (or any Image
+    derived from it via a shallow copy, e.g. img2 = img) still exists - SimpleITK pins a
+    reference to arr's buffer for exactly as long as needed and releases it automatically. It is
+    a programming error to resize arr (e.g. via ndarray.resize) while the returned Image exists.
+
+    Only 2D and 3D images are supported.
+    """
+    if not HAVE_NUMPY:
+        raise ImportError("Numpy not available.")
+
+    z = numpy.asarray(arr)
+
+    if not z.flags["WRITEABLE"]:
+        raise ValueError("The array must be writable to create a zero-copy Image view.")
+    if not z.flags["C_CONTIGUOUS"]:
+        raise ValueError("The array must be C-contiguous to create a zero-copy Image view.")
+
+    if isVector is None:
+        if z.ndim == 4 and z.dtype != numpy.complex64 and z.dtype != numpy.complex128:
+            isVector = True
+
+    if isVector:
+        id = _get_sitk_vector_pixelid(z)
+        if z.ndim > 2:
+            number_of_components = z.shape[-1]
+            shape = z.shape[-2::-1]
+        else:
+            number_of_components = 1
+            shape = z.shape[::-1]
+    else:
+        number_of_components = 1
+        id = _get_sitk_pixelid(z)
+        shape = z.shape[::-1]
+
+    if len(shape) not in (2, 3):
+        raise ValueError(f"GetImageViewFromArray only supports 2D or 3D images, got {len(shape)}D.")
+
+    spacing = [1.0] * len(shape)
+    origin = [0.0] * len(shape)
+    direction: List[float] = []
+
+    return _GetImageViewFromArray(z, list(shape), int(id), int(number_of_components), spacing, origin, direction)
+
+
 def ReadImage(
     fileName: PathType,
     outputPixelType: int = sitkUnknown,
@@ -483,6 +538,7 @@ __all__ = [
     "GetArrayViewFromImage",
     "GetArrayFromImage",
     "GetImageFromArray",
+    "GetImageViewFromArray",
     "ReadImage",
     "WriteImage",
     "SmoothingRecursiveGaussian",

--- a/Wrapping/Python/sitkGetImageViewFromArray.cxx
+++ b/Wrapping/Python/sitkGetImageViewFromArray.cxx
@@ -1,0 +1,235 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#include <cstring>
+#include <vector>
+
+#include "sitkImage.h"
+#include "sitkImportImageFilter.h"
+
+namespace sitk = itk::simple;
+
+// Python is written in C
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+  // NOTE: PySequence_Fast()/PySequence_Fast_GET_ITEM() are not usable here -
+  // this module is built against the Limited API (Py_LIMITED_API), which
+  // does not expose the direct-struct-access macros those rely on. Use the
+  // slower but ABI-stable PySequence_Size()/PySequence_GetItem() instead.
+  static bool
+  PySequenceToVectorUInt(PyObject * seq, std::vector<unsigned int> & out)
+  {
+    const Py_ssize_t n = PySequence_Size(seq);
+    if (n < 0)
+    {
+      return false;
+    }
+    out.resize(static_cast<size_t>(n));
+    for (Py_ssize_t i = 0; i < n; ++i)
+    {
+      PyObject * item = PySequence_GetItem(seq, i);
+      if (!item)
+      {
+        return false;
+      }
+      const long v = PyLong_AsLong(item);
+      Py_DECREF(item);
+      if (v == -1 && PyErr_Occurred())
+      {
+        return false;
+      }
+      out[static_cast<size_t>(i)] = static_cast<unsigned int>(v);
+    }
+    return true;
+  }
+
+  static bool
+  PySequenceToVectorDouble(PyObject * seq, std::vector<double> & out)
+  {
+    const Py_ssize_t n = PySequence_Size(seq);
+    if (n < 0)
+    {
+      return false;
+    }
+    out.resize(static_cast<size_t>(n));
+    for (Py_ssize_t i = 0; i < n; ++i)
+    {
+      PyObject * item = PySequence_GetItem(seq, i);
+      if (!item)
+      {
+        return false;
+      }
+      const double v = PyFloat_AsDouble(item);
+      Py_DECREF(item);
+      if (v == -1.0 && PyErr_Occurred())
+      {
+        return false;
+      }
+      out[static_cast<size_t>(i)] = v;
+    }
+    return true;
+  }
+
+  /** Construct a SimpleITK Image that is a zero-copy view of a writable,
+   * C-contiguous Python buffer-protocol object. The buffer's Py_buffer
+   * export is pinned (not just given an extra reference) for exactly as long as the
+   * underlying ITK image object exists, via Image::TieBufferLifetime() -
+   * see sitkImage.h.
+   */
+  static PyObject *
+  sitk_GetImageViewFromArray(PyObject * SWIGUNUSEDPARM(self), PyObject * args)
+  {
+    PyObject *   pyBufferObj = NULL;
+    PyObject *   pySize = NULL;
+    PyObject *   pySpacing = NULL;
+    PyObject *   pyOrigin = NULL;
+    PyObject *   pyDirection = NULL;
+    int          pixelIDValue = 0;
+    unsigned int numberOfComponents = 1;
+
+    if (!PyArg_ParseTuple(args,
+                          "OOiIOOO",
+                          &pyBufferObj,
+                          &pySize,
+                          &pixelIDValue,
+                          &numberOfComponents,
+                          &pySpacing,
+                          &pyOrigin,
+                          &pyDirection))
+    {
+      return NULL;
+    }
+
+    std::vector<unsigned int> size;
+    std::vector<double>       spacing;
+    std::vector<double>       origin;
+    std::vector<double>       direction;
+
+    if (!PySequenceToVectorUInt(pySize, size) || !PySequenceToVectorDouble(pySpacing, spacing) ||
+        !PySequenceToVectorDouble(pyOrigin, origin) || !PySequenceToVectorDouble(pyDirection, direction))
+    {
+      return NULL;
+    }
+
+    // Require a writable, C-contiguous export - this single call rejects
+    // read-only objects (e.g. bytes, read-only NumPy arrays) and
+    // non-contiguous views (e.g. transposed NumPy arrays) with a BufferError,
+    // since ImportImageFilter assumes one flat, natural-order buffer and
+    // writing into memory Python believes is read-only would be undefined
+    // behavior.
+    Py_buffer view;
+    std::memset(&view, 0, sizeof(Py_buffer));
+    if (PyObject_GetBuffer(pyBufferObj, &view, PyBUF_C_CONTIGUOUS | PyBUF_WRITABLE | PyBUF_FORMAT) != 0)
+    {
+      return NULL;
+    }
+
+    sitk::Image image;
+    try
+    {
+      switch (static_cast<sitk::PixelIDValueEnum>(pixelIDValue))
+      {
+        case sitk::sitkInt8:
+        case sitk::sitkVectorInt8:
+          image =
+            sitk::ImportAsInt8(static_cast<int8_t *>(view.buf), size, spacing, origin, direction, numberOfComponents);
+          break;
+        case sitk::sitkUInt8:
+        case sitk::sitkVectorUInt8:
+          image =
+            sitk::ImportAsUInt8(static_cast<uint8_t *>(view.buf), size, spacing, origin, direction, numberOfComponents);
+          break;
+        case sitk::sitkInt16:
+        case sitk::sitkVectorInt16:
+          image =
+            sitk::ImportAsInt16(static_cast<int16_t *>(view.buf), size, spacing, origin, direction, numberOfComponents);
+          break;
+        case sitk::sitkUInt16:
+        case sitk::sitkVectorUInt16:
+          image = sitk::ImportAsUInt16(
+            static_cast<uint16_t *>(view.buf), size, spacing, origin, direction, numberOfComponents);
+          break;
+        case sitk::sitkInt32:
+        case sitk::sitkVectorInt32:
+          image =
+            sitk::ImportAsInt32(static_cast<int32_t *>(view.buf), size, spacing, origin, direction, numberOfComponents);
+          break;
+        case sitk::sitkUInt32:
+        case sitk::sitkVectorUInt32:
+          image = sitk::ImportAsUInt32(
+            static_cast<uint32_t *>(view.buf), size, spacing, origin, direction, numberOfComponents);
+          break;
+        case sitk::sitkInt64:
+        case sitk::sitkVectorInt64:
+          image =
+            sitk::ImportAsInt64(static_cast<int64_t *>(view.buf), size, spacing, origin, direction, numberOfComponents);
+          break;
+        case sitk::sitkUInt64:
+        case sitk::sitkVectorUInt64:
+          image = sitk::ImportAsUInt64(
+            static_cast<uint64_t *>(view.buf), size, spacing, origin, direction, numberOfComponents);
+          break;
+        case sitk::sitkFloat32:
+        case sitk::sitkVectorFloat32:
+          image =
+            sitk::ImportAsFloat(static_cast<float *>(view.buf), size, spacing, origin, direction, numberOfComponents);
+          break;
+        case sitk::sitkFloat64:
+        case sitk::sitkVectorFloat64:
+          image =
+            sitk::ImportAsDouble(static_cast<double *>(view.buf), size, spacing, origin, direction, numberOfComponents);
+          break;
+        default:
+          PyErr_SetString(PyExc_TypeError,
+                          "GetImageViewFromArray does not support this pixel type "
+                          "(e.g. complex and label pixel types are not supported "
+                          "by the underlying Import filter).");
+          PyBuffer_Release(&view);
+          return NULL;
+      }
+    }
+    catch (const std::exception & e)
+    {
+      PyBuffer_Release(&view);
+      std::string msg = "Exception thrown in SimpleITK GetImageViewFromArray: ";
+      msg += e.what();
+      PyErr_SetString(PyExc_RuntimeError, msg.c_str());
+      return NULL;
+    }
+
+    // From here on, `image` is the sole reference (ITK refcount 1) to the
+    // freshly-imported itk::Image, so pin the buffer export to it now,
+    // before any other sitk::Image copy can be made or the wrapper is
+    // handed back to Python. Image::TieBufferLifetime() calls this callback
+    // exactly once, when the last Image sharing this same underlying data
+    // is destroyed - view is captured by value, so the callback owns its
+    // own copy of the Py_buffer descriptor.
+    image.TieBufferLifetime([view]() mutable {
+      PyGILState_STATE gstate = PyGILState_Ensure();
+      PyBuffer_Release(&view);
+      PyGILState_Release(gstate);
+    });
+
+    return SWIG_NewPointerObj(new sitk::Image(std::move(image)), SWIGTYPE_p_itk__simple__Image, SWIG_POINTER_OWN);
+  }
+
+#ifdef __cplusplus
+} // end extern "C"
+#endif

--- a/Wrapping/Python/tests/CMakeLists.txt
+++ b/Wrapping/Python/tests/CMakeLists.txt
@@ -90,6 +90,11 @@ sitk_add_pytest_test(
   "${CMAKE_CURRENT_SOURCE_DIR}/sitkGetArrayViewFromImageTest.py"
 )
 
+sitk_add_pytest_test(
+  Test.ImageView
+  "${CMAKE_CURRENT_SOURCE_DIR}/sitkGetImageViewFromArrayTest.py"
+)
+
 # Test data directory
 set(
   TEST_HARNESS_TEMP_DIRECTORY

--- a/Wrapping/Python/tests/sitkGetImageViewFromArrayTest.py
+++ b/Wrapping/Python/tests/sitkGetImageViewFromArrayTest.py
@@ -1,0 +1,158 @@
+# ==========================================================================
+#
+#   Copyright NumFOCUS
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ==========================================================================
+
+import gc
+import weakref
+
+import numpy as np
+import pytest
+import SimpleITK as sitk
+
+
+def test_scalar_2d_roundtrip():
+    arr = np.zeros((7, 5), dtype=np.uint16)
+    img = sitk.GetImageViewFromArray(arr)
+
+    assert img.GetSize() == (5, 7)
+    assert img.GetPixelID() == sitk.sitkUInt16
+
+
+def test_scalar_3d_roundtrip():
+    arr = np.zeros((7, 5, 3), dtype=np.float32)
+    img = sitk.GetImageViewFromArray(arr)
+
+    assert img.GetSize() == (3, 5, 7)
+    assert img.GetPixelID() == sitk.sitkFloat32
+
+
+def test_vector_image():
+    arr = np.zeros((6, 4, 3), dtype=np.float32)
+    img = sitk.GetImageViewFromArray(arr, isVector=True)
+
+    assert img.GetSize() == (4, 6)
+    assert img.GetNumberOfComponentsPerPixel() == 3
+    assert img.GetPixelID() == sitk.sitkVectorFloat32
+
+
+def test_write_through_array_to_image():
+    arr = np.zeros((5, 3), dtype=np.int32)
+    img = sitk.GetImageViewFromArray(arr)
+
+    arr[2, 1] = 42
+    assert img[1, 2] == 42
+
+
+def test_write_through_image_to_array():
+    arr = np.zeros((5, 3), dtype=np.int32)
+    img = sitk.GetImageViewFromArray(arr)
+
+    img[1, 2] = 99
+    assert arr[2, 1] == 99
+
+
+def test_default_geometry():
+    arr = np.zeros((5, 3), dtype=np.uint8)
+    img = sitk.GetImageViewFromArray(arr)
+
+    assert img.GetSpacing() == (1.0, 1.0)
+    assert img.GetOrigin() == (0.0, 0.0)
+
+
+def test_rejects_read_only_array():
+    arr = np.zeros((5, 3), dtype=np.uint8)
+    arr.flags.writeable = False
+
+    with pytest.raises(ValueError, match="writable"):
+        sitk.GetImageViewFromArray(arr)
+
+
+def test_rejects_non_contiguous_array():
+    arr = np.zeros((5, 6), dtype=np.uint8)
+    non_contiguous = arr[:, ::2]  # every-other-column view, not C-contiguous
+
+    with pytest.raises(ValueError, match="contiguous"):
+        sitk.GetImageViewFromArray(non_contiguous)
+
+
+def test_rejects_transposed_array():
+    arr = np.zeros((5, 6), dtype=np.uint8)
+
+    with pytest.raises(ValueError, match="contiguous"):
+        sitk.GetImageViewFromArray(arr.T)
+
+
+def test_rejects_unsupported_dimension():
+    arr = np.zeros((5,), dtype=np.uint8)
+
+    with pytest.raises(ValueError, match="2D or 3D"):
+        sitk.GetImageViewFromArray(arr)
+
+
+def test_rejects_complex_dtype():
+    arr = np.zeros((5, 3), dtype=np.complex64)
+
+    with pytest.raises(TypeError):
+        sitk.GetImageViewFromArray(arr)
+
+
+def test_buffer_pinned_after_array_deleted():
+    """The Image must keep working after the original array variable is
+    gone - this is the entire point of the feature."""
+    arr = np.arange(5 * 3, dtype=np.int32).reshape(5, 3)
+    img = sitk.GetImageViewFromArray(arr)
+
+    del arr
+    gc.collect()
+
+    assert img[1, 2] == 2 * 3 + 1  # img[x, y] corresponds to arr[y, x]
+    img[0, 0] = 123
+    assert img[0, 0] == 123
+
+
+def test_buffer_released_when_image_is_deleted():
+    """The pinned buffer export must actually be released - and release the
+    array - once the last Image referencing it is gone, not held forever."""
+    arr = np.zeros((5, 3), dtype=np.float32)
+    img = sitk.GetImageViewFromArray(arr)
+
+    released = []
+    finalizer = weakref.finalize(arr, released.append, True)
+
+    del arr
+    gc.collect()
+    assert not released, "array must stay alive while the Image still references its buffer"
+
+    del img
+    gc.collect()
+    assert released, "array must be released once the Image referencing its buffer is gone"
+    assert finalizer.alive is False
+
+
+def test_buffer_pinned_through_shallow_copy():
+    """A shallow copy (img2 = img, or Image(img)) shares the same underlying
+    ITK image, so the pinned buffer must survive as long as either exists."""
+    arr = np.zeros((5, 3), dtype=np.uint16)
+    img = sitk.GetImageViewFromArray(arr)
+    img2 = sitk.Image(img)  # shallow copy - shares the same underlying ITK image
+
+    del arr
+    del img
+    gc.collect()
+
+    img2[0, 0] = 7
+    assert img2[0, 0] == 7


### PR DESCRIPTION
## Summary
- Adds `sitk.GetImageViewFromArray(arr, isVector=None)`: a genuinely zero-copy counterpart to `GetImageFromArray` - the returned `Image`'s pixel buffer *is* `arr`'s memory, imported via the existing `ImportImageFilter` (which already shares memory with the caller's pointer and does no copying itself).
- The missing piece that has historically blocked this kind of API (see the Discourse thread referenced in #2683, which is why `GetImageViewFromArray` was rejected before) is buffer lifetime safety: nothing tied the caller's buffer lifetime to the `Image` using it. This adds `Image::TieBufferLifetime(std::function<void()>)` (`Code/Common/include/sitkImage.h`) to close that gap generically: it registers a callback as an `itk::DeleteEvent` observer on the underlying ITK image, invoked exactly once when the last `Image` (including shallow copies) sharing that data is destroyed - the same `itk::Command`/`DeleteEvent` mechanism `itk::HolderCommand` already uses elsewhere in this codebase (`sitkImageConvert.hxx`, `sitkTransform.cxx`) for tying an external resource's lifetime to an ITK object's.
- `GetImageViewFromArray` uses this to pin the Python buffer's `Py_buffer` export (not just an incref) for exactly that long, so it's safe for the caller's array to go out of scope while the returned `Image` (or any shallow copy of it) still exists.
- Requires a writable, C-contiguous buffer - rejected otherwise via `PyObject_GetBuffer`'s own flag negotiation, since `ImportImageFilter` assumes one flat, natural-order buffer, and writing into memory Python believes is read-only would be undefined behavior.

Note: the buffer-pinning logic originally lived entirely in `Wrapping/Python`, using raw `itk::Command`/`AddObserver` directly - but `Wrapping/Python`'s build deliberately has no ITK include path (SimpleITK hides ITK behind its own headers there), so that didn't compile. Moving the `itk::Command`/`DeleteEvent` wiring into `Code/Common::Image::TieBufferLifetime()` fixed that and made the mechanism itk-free at the public API boundary, and reusable by any future language wrapping, not just Python.

## Example
```python
img = sitk.Image([384, 384, 384], sitk.sitkUInt16)
arr = sitk.GetArrayViewFromImage(img)  # or your own numpy array
view = sitk.GetImageViewFromArray(arr)  # zero-copy
view[0, 0, 0] = 5  # visible through arr too
del arr  # safe - view keeps the buffer alive
```

## Test plan
- [x] New `Wrapping/Python/tests/sitkGetImageViewFromArrayTest.py` (14 tests): scalar/vector roundtrip, write-through in both directions, default geometry, rejection of read-only/non-contiguous/transposed/unsupported-dimension/complex-dtype input, and the core lifetime guarantees - buffer survives `del arr` (verified by reading through the Image), and is actually released (verified via `weakref.finalize`) once the last `Image` referencing it is gone, including through a shallow copy (`Image(img)`).
- [x] Built from source; full regression sweep passes with no failures: 10 Python test suites (`Image`, `ImageIndexing`, `ProcessObject`, `ImageBuffer`, `ImageProtocol`, `ArrayView`, `Transform`, `ImageReadWrite`, `TransformixImageFilterTest`, `ImageView`) and the C++ `Image`/`Import`/`Command` gtest suites (32 tests, including `Image.CopyOnWrite`, `Image.MoveOperations`, `Import.Shallow`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)