### PR TITLE
Add packaging for Python 3.15t free-threaded pre-release

### DIFF
--- a/.github/actions/package_python/action.yml
+++ b/.github/actions/package_python/action.yml
@@ -10,7 +10,11 @@ inputs:
     required: false
     default: 'false'
   use_limited_api:
-    description: "Use limited API"
+    description: "Use limited API (ignored, and forced off, for free-threaded 't' interpreters)"
+    required: false
+    default: false
+  allow_prereleases:
+    description: "Allow installing a pre-release interpreter (e.g. alpha/beta/rc) when no matching stable release exists"
     required: false
     default: false
   cmake_osx_architectures:
@@ -29,12 +33,23 @@ runs:
       id: cpy
       with:
         python-version: ${{ inputs.python-version }}
+        allow-prereleases: ${{ inputs.allow_prereleases }}
+    - name: Resolve build options
+      id: opts
+      shell: bash
+      run: |
+        use_limited_api="${{ inputs.use_limited_api }}"
+        # Free-threaded ("t") interpreters have no stable/limited ABI to build against.
+        if [[ "${{ inputs.python-version }}" == *t ]]; then
+          use_limited_api="false"
+        fi
+        echo "use_limited_api=${use_limited_api}" >> "$GITHUB_OUTPUT"
     - name: Build Python ${{ steps.cpy.outputs.python-version }}
       continue-on-error: ${{ inputs.continue-on-error == 'true' }}
       shell: bash
       if: runner.os == 'macOS'
       env:
-        USE_LIMITED_API: ${{ inputs.use_limited_api }}
+        USE_LIMITED_API: ${{ steps.opts.outputs.use_limited_api }}
         CMAKE_OSX_ARCHITECTURES: ${{ inputs.cmake_osx_architectures }}
       run: |
         ${{ github.action_path }}/scripts/mac_build_python.sh
@@ -43,7 +58,7 @@ runs:
       shell: cmd
       if: runner.os == 'Windows'
       env:
-        USE_LIMITED_API: ${{ inputs.use_limited_api }}
+        USE_LIMITED_API: ${{ steps.opts.outputs.use_limited_api }}
         VCVAR_OPTIONS: ${{ inputs.VCVAR_OPTIONS }}
       run: |
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"  %VCVAR_OPTIONS%

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Build ${{ matrix.dockerfile }}
         shell: bash
         env:
-          PYTHON_VERSIONS: "cp310-cp310 cp314-cp314t"
+          PYTHON_VERSIONS: "cp310-cp310 cp314-cp314t cp315-cp315t"
           BUILD_CSHARP: ${{ matrix.build_csharp }}
           BUILD_JAVA: ${{ matrix.build_java }}
           BUILD_PYTHON_LIMITED_API: 1
@@ -224,6 +224,13 @@ jobs:
         uses: ./.github/actions/package_python
         with:
           python-version: "3.14t"
+          continue-on-error: true
+          cmake_osx_architectures: ${{ matrix.cmake_osx_architectures || '' }}
+      - name: Package Python 3.15t (pre-release)
+        uses: ./.github/actions/package_python
+        with:
+          python-version: "3.15t"
+          allow_prereleases: true
           continue-on-error: true
           cmake_osx_architectures: ${{ matrix.cmake_osx_architectures || '' }}
       - name: Upload Artifacts


### PR DESCRIPTION
## Summary
- Refactor `package_python` composite action: add an `allow_prereleases` input (wired to setup-python's `allow-prereleases`), and force `use_limited_api` off for free-threaded (`t`) interpreters, since they have no stable/limited ABI to build against.
- Add a "Package Python 3.15t (pre-release)" step to the macOS/Windows `build` job, alongside the existing 3.14t step.
- Add `cp315-cp315t` to the manylinux Docker job's `PYTHON_VERSIONS`, matching the existing `cp314-cp314t` coverage. The upstream pypa/manylinux image already bakes in CPython 3.15.0rc1 (regular and free-threaded/nogil).

## Test plan
- [ ] CI: `Package` workflow runs successfully, producing 3.15t wheels for macOS, Windows, and manylinux (best-effort; steps are marked `continue-on-error` where applicable given the pre-release interpreter)
- [ ] Verify uploaded `artifacts-*` contain a cp315 wheel
