### PR TITLE
Backport #2691: Add packaging for Python 3.15t free-threaded pre-release

### DIFF
--- a/.github/actions/package_python/action.yml
+++ b/.github/actions/package_python/action.yml
@@ -10,7 +10,11 @@ inputs:
     required: false
     default: false
   use_limited_api:
-    description: "Use limited API"
+    description: "Use limited API (ignored, and forced off, for free-threaded 't' interpreters)"
+    required: false
+    default: false
+  allow_prereleases:
+    description: "Allow installing a pre-release interpreter (e.g. alpha/beta/rc) when no matching stable release exists"
     required: false
     default: false
   VCVAR_OPTIONS:
@@ -25,12 +29,23 @@ runs:
       id: cpy
       with:
         python-version: ${{ inputs.python-version }}
+        allow-prereleases: ${{ inputs.allow_prereleases }}
+    - name: Resolve build options
+      id: opts
+      shell: bash
+      run: |
+        use_limited_api="${{ inputs.use_limited_api }}"
+        # Free-threaded ("t") interpreters have no stable/limited ABI to build against.
+        if [[ "${{ inputs.python-version }}" == *t ]]; then
+          use_limited_api="false"
+        fi
+        echo "use_limited_api=${use_limited_api}" >> "$GITHUB_OUTPUT"
     - name: Build Python ${{ steps.cpy.outputs.python-version }}
       continue-on-error: ${{ inputs.continue-on-error == 'true' }}
       shell: bash
       if: runner.os == 'macOS'
       env:
-        USE_LIMITED_API: ${{ inputs.use_limited_api }}
+        USE_LIMITED_API: ${{ steps.opts.outputs.use_limited_api }}
       run: |
         ${{ github.action_path }}/scripts/mac_build_python.sh
     - name: Build Python ${{ steps.cpy.outputs.python-version }}
@@ -38,7 +53,7 @@ runs:
       shell: cmd
       if: runner.os == 'Windows'
       env:
-        USE_LIMITED_API: ${{ inputs.use_limited_api }}
+        USE_LIMITED_API: ${{ steps.opts.outputs.use_limited_api }}
       run: |
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"  ${{ inputs.VCVAR_OPTIONS }}
         bash ${{ github.action_path }}/scripts/win_build_python.sh

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build ${{ matrix.dockerfile }}
         shell: bash
         env:
-          PYTHON_VERSIONS: "cp39-cp39 cp310-cp310 cp314-cp314t"
+          PYTHON_VERSIONS: "cp39-cp39 cp310-cp310 cp314-cp314t cp315-cp315t"
           BUILD_CSHARP: ${{ contains(matrix.os, 'arm') && '0' || '1' }}
           BUILD_JAVA: 1
           BUILD_PYTHON_LIMITED_API: 1
@@ -229,7 +229,12 @@ jobs:
         with:
           python-version: "3.14t"
           continue-on-error: true
-
+      - name: Package Python 3.15t (pre-release)
+        uses: ./.github/actions/package_python
+        with:
+          python-version: "3.15t"
+          allow_prereleases: true
+          continue-on-error: true
       - name: Upload Artifacts
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
## Summary
Backport of #2691 to `release`.

- Refactor `package_python` composite action: add an `allow_prereleases` input (wired to setup-python's `allow-prereleases`), and force `use_limited_api` off for free-threaded (`t`) interpreters, since they have no stable/limited ABI to build against.
- Add a "Package Python 3.15t (pre-release)" step to the macOS/Windows `build` job, alongside the existing 3.14t step.
- Add `cp315-cp315t` to the manylinux Docker job's `PYTHON_VERSIONS` (`cp39-cp39 cp310-cp310 cp314-cp314t cp315-cp315t`), matching the existing `cp314-cp314t` coverage. The upstream pypa/manylinux2014/manylinux_2_28 images already bake in CPython 3.15.0rc1 (regular and free-threaded/nogil).

Note: `release`'s `package_python/action.yml` predates the `cmake_osx_architectures` input and passes `VCVAR_OPTIONS` inline rather than via env, so this backport preserves that existing structure rather than porting those unrelated differences from `main`.

## Test plan
- [ ] CI: `Package` workflow runs successfully on this branch, producing 3.15t wheels for macOS, Windows, and manylinux (best-effort; steps are marked `continue-on-error` where applicable given the pre-release interpreter)
