### PR TITLE
BUG: Fix free-threaded GIL declaration for CPython 3.15

### DIFF
--- a/Wrapping/Python/CMakeLists.txt
+++ b/Wrapping/Python/CMakeLists.txt
@@ -18,9 +18,7 @@ find_package(
     Development.SABIModule
 )
 
-# Free-threaded Python (PEP 703, e.g. Python 3.13t/3.14t) requires CMake >= 3.30 for
-# correct FindPython support. Earlier versions link against python3XX.lib instead of
-# python3XXt.lib, causing a crash (access violation) on module import.
+# Free-threaded Python (PEP 703) requires CMake >= 3.30 for correct FindPython support.
 if(Python_SOABI MATCHES "t-" OR Python_SOABI MATCHES "t$")
   if(CMAKE_VERSION VERSION_LESS "3.30")
     message(
@@ -28,6 +26,15 @@ if(Python_SOABI MATCHES "t-" OR Python_SOABI MATCHES "t$")
       "Free-threaded Python (detected SOABI: '${Python_SOABI}') requires CMake >= 3.30. "
       "CMake ${CMAKE_VERSION} will link against the wrong Python DLL, causing crashes. "
       "Please upgrade CMake to 3.30 or later."
+    )
+  endif()
+  # Required version for SWIG's -nogil flag, which declares the module thread-safe for free-threaded Python.
+  if(SWIG_VERSION VERSION_LESS "4.4.0")
+    message(
+      FATAL_ERROR
+      "Free-threaded Python (detected SOABI: '${Python_SOABI}') requires SWIG >= 4.4.0 "
+      "for the -nogil flag. SWIG ${SWIG_VERSION} does not support it. "
+      "Please upgrade SWIG to 4.4.0 or later."
     )
   endif()
 endif()
@@ -159,6 +166,16 @@ if(
     CMAKE_SWIG_FLAGS
     ${CMAKE_SWIG_FLAGS}
     -flatstaticmethod
+  )
+endif()
+if(SWIG_VERSION VERSION_GREATER_EQUAL "4.4.0")
+  # Declares the module thread-safe for free-threaded Python (PEP 703) via the
+  # Py_mod_gil module slot, a no-op on Python builds without free-threading
+  # support.
+  set(
+    CMAKE_SWIG_FLAGS
+    ${CMAKE_SWIG_FLAGS}
+    -nogil
   )
 endif()
 set(CMAKE_SWIG_OUTDIR ${CMAKE_CURRENT_BINARY_DIR}/SimpleITK)

--- a/Wrapping/Python/Python.i
+++ b/Wrapping/Python/Python.i
@@ -37,10 +37,6 @@
         // init module, PEP 489) returns int, not PyObject*.
         return -1;
     }
-#ifdef Py_GIL_DISABLED
-    // Declare this module as safe to use without the GIL (PEP 703 / free-threaded).
-    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
-#endif
 %}
 
 %include "sitkPathType.i"


### PR DESCRIPTION
## Summary

CPython 3.15 requires the free-threading-safe declaration to be made via a static `Py_mod_gil` module slot. The runtime-only `PyUnstable_Module_SetGIL()` call used since 3.13t/3.14t support was added is no longer sufficient to keep the GIL disabled after import.

This switches to SWIG's own `-nogil` flag (SWIG >= 4.4.0), which emits the correct static slot natively, instead of the manual declaration in `Python.i`. The configure now fails with a clear error, rather than degrading silently, if a free-threaded Python build is targeted with an older SWIG that doesn't support the flag.

This is split out from the larger `abi3t`/limited-API generalization work (see #3550-style follow-ups) so the free-threading GIL fix itself can be reviewed and merged independently.

## Changes

- `Wrapping/Python/CMakeLists.txt`: add `-nogil` to `CMAKE_SWIG_FLAGS` when `SWIG_VERSION >= 4.4.0` and the target Python is free-threaded; fail the configure with a clear error if an older SWIG is used with a free-threaded Python build.
- `Wrapping/Python/Python.i`: remove the manual `PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED)` call under `#ifdef Py_GIL_DISABLED` — this declaration is now handled natively by SWIG via `-nogil`.

## Testing

Built and tested against free-threaded CPython 3.15.0rc1 (`python3.15t`), with SWIG 4.5.0:

- `sys._is_gil_enabled()` is `False` both before and after `import SimpleITK` (previously, only the runtime-only declaration was made, which CPython 3.15 no longer honors).
- Basic image construction/pixel access, and running `SmoothingRecursiveGaussianImageFilter`, work correctly with the GIL still disabled afterward.
- 8 threads running filters concurrently complete correctly, with the GIL still disabled throughout.
- Ran the project's Python test suite (`ctest -L Python`, 311 tests) against an installed wheel built from this branch: the 17 core infrastructure tests (`ImageBuffer`, `Numpy`, `ArrayView`, `ImageReadWrite`, `ImageIndexing`, `TransformTests`, `ProcessObject`, `BasicFiltersTests`, `ImageTests`, `ImageProtocol`, `FlatStaticMethod`, `GetGDCMSeriesIDs`, `ExternalViewer`) all pass. The remaining per-filter tests fail only due to environment gaps unrelated to this change (missing `ExternalData` baseline images and the `sitkCompareDriver` helper binary, neither fetched/built in this scoped test build).
