### PR TITLE
BUG: Fix free-threaded GIL declaration for CPython 3.15 (backport #2693)

### DIFF
--- a/Wrapping/Python/CMakeLists.txt
+++ b/Wrapping/Python/CMakeLists.txt
@@ -17,6 +17,15 @@ if (Python_SOABI MATCHES "t-" OR Python_SOABI MATCHES "t$")
       "CMake ${CMAKE_VERSION} will link against the wrong Python DLL, causing crashes. "
       "Please upgrade CMake to 3.30 or later.")
   endif()
+  # Required version for SWIG's -nogil flag, which declares the module thread-safe for free-threaded Python.
+  if(SWIG_VERSION VERSION_LESS "4.4.0")
+    message(
+      FATAL_ERROR
+      "Free-threaded Python (detected SOABI: '${Python_SOABI}') requires SWIG >= 4.4.0 "
+      "for the -nogil flag. SWIG ${SWIG_VERSION} does not support it. "
+      "Please upgrade SWIG to 4.4.0 or later."
+    )
+  endif()
 endif()
 
 include_directories ( ${SimpleITK_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR} )
@@ -66,6 +75,16 @@ if( SimpleITK_PYTHON_THREADS )
 endif()
 if (SimpleITK_PYTHON_FLATSTATICMETHOD AND SWIG_VERSION VERSION_GREATER_EQUAL "4.1.0")
   set(CMAKE_SWIG_FLAGS ${CMAKE_SWIG_FLAGS} -flatstaticmethod )
+endif()
+if(SWIG_VERSION VERSION_GREATER_EQUAL "4.4.0")
+  # Declares the module thread-safe for free-threaded Python (PEP 703) via the
+  # Py_mod_gil module slot, a no-op on Python builds without free-threading
+  # support.
+  set(
+    CMAKE_SWIG_FLAGS
+    ${CMAKE_SWIG_FLAGS}
+    -nogil
+  )
 endif()
 set(CMAKE_SWIG_OUTDIR ${CMAKE_CURRENT_BINARY_DIR}/SimpleITK)
 set(SWIG_MODULE_SimpleITK_EXTRA_DEPS ${SWIG_EXTRA_DEPS}

--- a/Wrapping/Python/Python.i
+++ b/Wrapping/Python/Python.i
@@ -30,10 +30,6 @@
 %}
 
 %init %{
-#ifdef Py_GIL_DISABLED
-    // Declare this module as safe to use without the GIL (PEP 703 / free-threaded).
-    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
-#endif
 %}
 
 %include "PythonDocstrings.i"


### PR DESCRIPTION
## Summary

Backport of #2693 to the `release` branch.

CPython 3.15 requires the free-threading-safe declaration to be made via a static `Py_mod_gil` module slot. The runtime-only `PyUnstable_Module_SetGIL()` call used since 3.13t/3.14t support was added is no longer sufficient to keep the GIL disabled after import.

This switches to SWIG's own `-nogil` flag (SWIG >= 4.4.0), which emits the correct static slot natively, instead of the manual declaration in `Python.i`. The configure now fails with a clear error, rather than degrading silently, if a free-threaded Python build is targeted with an older SWIG that doesn't support the flag.

## Changes

- `Wrapping/Python/CMakeLists.txt`: add `-nogil` to `CMAKE_SWIG_FLAGS` when `SWIG_VERSION >= 4.4.0` and the target Python is free-threaded; fail the configure with a clear error if an older SWIG is used with a free-threaded Python build.
- `Wrapping/Python/Python.i`: remove the manual `PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED)` call under `#ifdef Py_GIL_DISABLED` — this declaration is now handled natively by SWIG via `-nogil`.

Cherry-picked from `9e8db7c56` (main), adapted for the existing free-threaded CMake >= 3.30 check already present on `release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)