### PR TITLE
BUG: Fix FastApproximateRank by23 hash and bump ITK pin

### DIFF
--- a/CMake/sitkITKGitOptions.cmake
+++ b/CMake/sitkITKGitOptions.cmake
@@ -15,7 +15,7 @@ if(COMMAND sitk_legacy_naming)
   sitk_legacy_naming(ITK_GIT_REPOSITORY ITK_REPOSITORY)
 endif()
 
-set(_DEFAULT_ITK_GIT_TAG "8ae03df92e7db51c03ba657d84cde0dbbd273f57") # main on 2026-07-10
+set(_DEFAULT_ITK_GIT_TAG "841f4b66d37804907cef5758d80bde19aa08d104") # main on 2026-07-10, includes ITK#6580 fix for FastApproximateRankImageFilter
 set(ITK_GIT_TAG "${_DEFAULT_ITK_GIT_TAG}" CACHE STRING "Tag in ITK git repo")
 mark_as_advanced(ITK_GIT_TAG)
 

--- a/Code/BasicFilters/yaml/FastApproximateRankImageFilter.yaml
+++ b/Code/BasicFilters/yaml/FastApproximateRankImageFilter.yaml
@@ -29,7 +29,7 @@ tests:
   - Input/cthead1.png
 - tag: by23
   description: Test by 23
-  md5hash: 67615832b6f0e0bb877ce03418d3328c
+  md5hash: b8a6f4f77a7df4b1e5d5dba0297945bb
   settings:
   - parameter: Rank
     type: double


### PR DESCRIPTION
## Summary
Supersedes/extends #2652, which found and fixed the right underlying issue but missed a step that left CI broken.

- ITK PR [InsightSoftwareConsortium/ITK#6580](https://github.com/InsightSoftwareConsortium/ITK/pull/6580) / commit [`841f4b66d3`](https://github.com/InsightSoftwareConsortium/ITK/commit/841f4b66d37804907cef5758d80bde19aa08d104) ("BUG: Propagate rank to the last axis in FastApproximateRank") fixed an off-by-one loop bound in `FastApproximateRankImageFilter::SetRank()`: the last axis's per-axis sub-filter never received the requested rank and silently ran at the default median instead.
- The `by23` subtest (`Rank=1`, `Radius=[2,3]`) exercises exactly this last-axis code path, so its output — and therefore the expected MD5 hash — changed after the ITK fix. Updated `Code/BasicFilters/yaml/FastApproximateRankImageFilter.yaml`'s `by23` `md5hash` to the new correct value (same value #2652 used).
- **The part #2652 missed:** `CMake/sitkITKGitOptions.cmake` pins the ITK commit SimpleITK's CI/SuperBuild actually builds against (`_DEFAULT_ITK_GIT_TAG`, main as of 2026-07-10), and that pin predates the ITK fix. #2652 updated the expected hash but never bumped this pin, so CI kept building the pre-fix ITK and failed with a hash mismatch against the *old* (buggy) hash — see e.g. the `linux-x64-superbuild-elastix-python-r` leg on #2652. This PR bumps `_DEFAULT_ITK_GIT_TAG` to `841f4b66d3` so CI actually builds the ITK commit the new hash corresponds to.

## Test plan
- [x] `BasicFilters.FastApproximateRankImageFilter`, `Python.FastApproximateRankImageFilter`, and all three `Java.FastApproximateRankImageFilter.*` tests pass locally, built against ITK main (past `841f4b66d3`, no further changes to this filter since)
- [x] Confirmed the 23 commits between the old and new ITK pin don't touch other filters exercised by SimpleITK's test suite in a way that regresses them