### PR TITLE
BUG: Update test hashes for 3 upstream ITK bug fixes

### DIFF
--- a/CMake/sitkITKGitOptions.cmake
+++ b/CMake/sitkITKGitOptions.cmake
@@ -15,7 +15,7 @@ if(COMMAND sitk_legacy_naming)
   sitk_legacy_naming(ITK_GIT_REPOSITORY ITK_REPOSITORY)
 endif()
 
-set(_DEFAULT_ITK_GIT_TAG "8ae03df92e7db51c03ba657d84cde0dbbd273f57") # main on 2026-07-10
+set(_DEFAULT_ITK_GIT_TAG "46060cb79126affaa34152749165f67bc2471384") # main on 2026-07-13
 set(ITK_GIT_TAG "${_DEFAULT_ITK_GIT_TAG}" CACHE STRING "Tag in ITK git repo")
 mark_as_advanced(ITK_GIT_TAG)
 

--- a/Code/BasicFilters/yaml/FastApproximateRankImageFilter.yaml
+++ b/Code/BasicFilters/yaml/FastApproximateRankImageFilter.yaml
@@ -29,7 +29,7 @@ tests:
   - Input/cthead1.png
 - tag: by23
   description: Test by 23
-  md5hash: 67615832b6f0e0bb877ce03418d3328c
+  md5hash: b8a6f4f77a7df4b1e5d5dba0297945bb
   settings:
   - parameter: Rank
     type: double

--- a/Code/BasicFilters/yaml/MultiLabelSTAPLEImageFilter.yaml
+++ b/Code/BasicFilters/yaml/MultiLabelSTAPLEImageFilter.yaml
@@ -77,7 +77,7 @@ measurements:
 tests:
 - tag: basic
   description: Basic usage
-  md5hash: 77ac8604a252c5130602645a5f02cc36
+  md5hash: 08d9ca203d70ceffd8a9c9c09bf9426f
   inputs:
   - Input/STAPLE1-binary.png
   - Input/STAPLE2-binary.png

--- a/Code/BasicFilters/yaml/ThresholdMaximumConnectedComponentsImageFilter.yaml
+++ b/Code/BasicFilters/yaml/ThresholdMaximumConnectedComponentsImageFilter.yaml
@@ -91,7 +91,7 @@ tests:
 - tag: float
   description: 3D-float
   settings: []
-  md5hash: e475b27bd0dd66ede330c4eab93c17e9
+  md5hash: 63d4c611a5633ba010f1857401b13150
   inputs:
   - Input/RA-Float.nrrd
 briefdescription: Finds the threshold value of an image based on maximizing the number of objects in the image that are larger


### PR DESCRIPTION
## Summary
Replaces #2697 (closed) with a single consolidated PR. Rolls up the `md5hash`-only test fixes for three separate ITK bug fixes into one PR, one commit per filter, plus one shared commit bumping the pinned ITK commit far enough to cover all three:

1. **FastApproximateRankImageFilter** — ITK commit `841f4b66d3` ([ITK#6580](https://github.com/InsightSoftwareConsortium/ITK/pull/6580)) fixed `SetRank()` never reaching the last axis's sub-filter. Affects the `by23` subtest.
2. **MultiLabelSTAPLEImageFilter** — ITK commit `6df2f5fe87` fixed confusion-matrix corruption when a rater's seed vote is undecided (a tie). Affects the `basic` subtest.
3. **ThresholdMaximumConnectedComponentsImageFilter** — ITK commit `46060cb79126` fixed a bisection-midpoint bug that only misbehaves when the image's minimum pixel value is nonzero. Affects the `float` subtest only (`default`/`parameters` use images with a zero minimum, where the bug was a no-op).

The ITK pin bump (`CMake/sitkITKGitOptions.cmake`, `_DEFAULT_ITK_GIT_TAG`) moves from ITK main@2026-07-10 to main@2026-07-13 (`46060cb79126`) — exactly far enough to include these three fixes, and no further. This is the step the original #2652 (superseded by #2697, now superseded by this PR) missed: without bumping the pin, CI keeps building the pre-fix ITK and fails with a hash mismatch against the *old* hash.

This range deliberately **excludes** two other ITK fixes in the same batch that also change SimpleITK test output — `23a4da9cd4` (`LabelVotingImageFilter` now throws instead of silently corrupting output on unrepresentable undecided labels) and `4f0b3147be2` (`CurvatureFlowFunction` derivative-scale fix, affects `BinaryMinMaxCurvatureFlowImageFilter`). Those need test-content changes beyond a hash update (an explicit `SetLabelForUndecidedPixels` setting, and new baseline image data, respectively) and are tracked separately.

## Test plan
- [x] `BasicFilters`/`Python`/`Java` tests for all three filters (13 tests total) pass locally against an ITK main build well past `46060cb79126`
- [x] Verified via `git merge-base --is-ancestor` that the new pin includes `841f4b66d3`, `6df2f5fe87`, and `46060cb79126`, and excludes `23a4da9cd4`/`4f0b3147be2`, so no other currently-passing test should regress