### PR TITLE
BUG: Use binary STAPLE inputs for LabelVoting uint8_case test

### DIFF
--- a/Code/BasicFilters/yaml/LabelVotingImageFilter.yaml
+++ b/Code/BasicFilters/yaml/LabelVotingImageFilter.yaml
@@ -21,11 +21,11 @@ members:
     and the new value only becomes effective upon the next filter update.
 tests:
 - tag: uint8_case
-  description: Test for a case where the undecided value may overflow
+  description: Basic usage with uint8 pixels
   inputs:
-  - Input/STAPLE1.png
-  - Input/STAPLE2.png
-  md5hash: a5f7ea84f72b82971f3f7476475dfdf2
+  - Input/STAPLE1-binary.png
+  - Input/STAPLE2-binary.png
+  md5hash: 08d9ca203d70ceffd8a9c9c09bf9426f
 - tag: basic
   description: Basic usage with required parameters
   inputA_cast: sitkUInt16

--- a/Code/BasicFilters/yaml/LabelVotingImageFilter.yaml
+++ b/Code/BasicFilters/yaml/LabelVotingImageFilter.yaml
@@ -21,11 +21,15 @@ members:
     and the new value only becomes effective upon the next filter update.
 tests:
 - tag: uint8_case
-  description: Basic usage with uint8 pixels
+  description: Basic usage with uint8 pixels and an explicit undecided label
   inputs:
   - Input/STAPLE1-binary.png
   - Input/STAPLE2-binary.png
-  md5hash: 08d9ca203d70ceffd8a9c9c09bf9426f
+  settings:
+  - parameter: LabelForUndecidedPixels
+    type: uint64_t
+    value: '128'
+  md5hash: 0220ae160ecddefed8c7c7835cf1cafa
 - tag: basic
   description: Basic usage with required parameters
   inputA_cast: sitkUInt16


### PR DESCRIPTION
## Summary
ITK commit [`23a4da9cd4`](https://github.com/InsightSoftwareConsortium/ITK/commit/23a4da9cd4e9c0a6e8b7a87e29aa4da37de6c5c6) ("BUG: Undecided-vote label silently wraps to a real label", ITK issue #6575 item B15) changed `LabelVotingImageFilter::BeforeThreadedGenerateData()` to throw instead of silently wrapping the auto-picked undecided-pixel label when it doesn't fit the output pixel type.

The `uint8_case` test fed `STAPLE1.png`/`STAPLE2.png`, whose combined label count is exactly 256 — every value a `uint8` output can hold — so the auto-picked label (`maxLabel + 1`) never fit. Before the fix this silently wrapped to a colliding real label (test passed against a hash of corrupted output); after the fix it throws an `itk::ExceptionObject`, so the test can't produce a hash-comparable image at all anymore.

Rather than adding an explicit `SetLabelForUndecidedPixels()` call to keep exercising the overflow edge case, this switches the test's inputs to the `STAPLE1-binary.png`/`STAPLE2-binary.png` variants already used elsewhere (e.g. `MultiLabelSTAPLEImageFilter`'s `basic` test) — only 2 labels, well within `uint8` range, so the filter takes its normal code path regardless of ITK version. This makes the fix **version-independent**: it passes against both pre-fix and post-fix ITK, unlike the hash-only fixes in #2699, so no `CMake/sitkITKGitOptions.cmake` pin bump is needed here.

## Test plan
- [x] `BasicFilters`/`Python`/`Java` `LabelVotingImageFilter.uint8_case` tests pass locally against ITK main (past `23a4da9cd4`), hash identical across all three wrappers (`08d9ca203d70ceffd8a9c9c09bf9426f`)
- [x] `basic` subtest (already uses `uint16` casts, unaffected by this issue) still passes unchanged