### PR TITLE
CI: Build manylinux Python wheels with cibuildwheel

### DIFF
--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -99,6 +99,22 @@ jobs:
       CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
       CIBW_TEST_SKIP: "*"
       CIBW_BUILD_VERBOSITY: 1
+      # Mount host directories into the container so both the CMake build
+      # tree and ccache's cache persist across every CIBW_BUILD identifier
+      # in this job and across both cibuildwheel steps below (but not
+      # across job runs). By default scikit-build-core gives every
+      # invocation its own fresh random /tmp build tree and re-fetches
+      # ITK's source into it each time, which defeats both ccache's hashing
+      # (path/mtime differences) and, more importantly, CMake/Ninja's own
+      # incremental rebuild: pinning SKBUILD_BUILD_DIR to a stable path
+      # means ITK's ~2900 object files simply aren't touched again once
+      # built for the first identifier, since Ninja sees them as already
+      # up to date - this is the main win, ccache is a secondary safety net
+      # for whatever legitimately does need recompiling (e.g. the
+      # abi3/free-threaded-specific wrapping code).
+      CIBW_CONTAINER_ENGINE: "docker; create_args: --volume /tmp/ccache-cache:/ccache --volume /tmp/skbuild-build:/build"
+      CIBW_BEFORE_ALL_LINUX: "yum install -y ccache"
+      CIBW_ENVIRONMENT_LINUX: 'CCACHE_DIR=/ccache CCACHE_NOHASHDIR=1 CCACHE_MAXSIZE=10G CCACHE_COMPRESS=1 CCACHE_SLOPPINESS=include_file_mtime,include_file_ctime,pch_defines,time_macros SKBUILD_BUILD_DIR=/build SKBUILD_CMAKE_DEFINE="CMAKE_C_COMPILER_LAUNCHER=ccache;CMAKE_CXX_COMPILER_LAUNCHER=ccache"'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -49,10 +49,9 @@ jobs:
       - name: Build ${{ matrix.dockerfile }}
         shell: bash
         env:
-          PYTHON_VERSIONS: "cp310-cp310 cp314-cp314t cp315-cp315t"
+          PYTHON_VERSIONS: ""
           BUILD_CSHARP: ${{ matrix.build_csharp }}
           BUILD_JAVA: ${{ matrix.build_java }}
-          BUILD_PYTHON_LIMITED_API: 1
           SIMPLEITK_USE_ELASTIX: 1
         run: |
           echo "BUILD_CSHARP: ${BUILD_CSHARP}"
@@ -78,8 +77,56 @@ jobs:
         with:
           name: artifacts-${{ matrix.os }}-${{matrix.dockerfile}}
           path: |
-            Utilities/Distribution/manylinux/wheelhouse/*.whl
             Utilities/Distribution/manylinux/SimpleITK*.zip
+
+  python-wheels:
+    if: github.repository == 'SimpleITK/SimpleITK'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            cibw_archs: x86_64
+            artifact_suffix: manylinux-x86_64
+          - os: ubuntu-22.04-arm
+            cibw_archs: aarch64
+            artifact_suffix: manylinux-aarch64
+    env:
+      CIBW_SKIP: "*-manylinux_i686 *-musllinux*"
+      CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs }}
+      CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+      CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
+      CIBW_TEST_SKIP: "*"
+      CIBW_BUILD_VERBOSITY: 1
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          fetch-depth: 0
+      - name: Build Python wheels with cibuildwheel
+        uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
+        env:
+          CIBW_BUILD: "cp310-* cp311-* cp314t-*"
+        with:
+          package-dir: .
+          output-dir: wheelhouse
+      - name: Build cp315t (prerelease) wheel with cibuildwheel
+        # cp315t is a pre-release, best-effort build: it may not yet be
+        # available in the manylinux image, so don't fail the job over it.
+        continue-on-error: true
+        uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
+        env:
+          CIBW_BUILD: "cp315t-*"
+          CIBW_ENABLE: cpython-prerelease
+        with:
+          package-dir: .
+          output-dir: wheelhouse
+      - name: Upload wheel artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: artifacts-wheels-${{ matrix.artifact_suffix }}
+          path: wheelhouse/*.whl
+          if-no-files-found: ignore
 
   build:
     if: github.repository == 'SimpleITK/SimpleITK'
@@ -298,6 +345,7 @@ jobs:
       - build
       - doxygen
       - package-docker
+      - python-wheels
       - sdist
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -95,10 +95,13 @@ jobs:
     env:
       CIBW_SKIP: "*-manylinux_i686 *-musllinux*"
       CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs }}
-      CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
-      CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
-      CIBW_TEST_SKIP: "*"
-      CIBW_BUILD_VERBOSITY: 1
+      # build-verbosity, enable, the test-* settings (running the
+      # hand-written pytest suite in Wrapping/Python/tests against the
+      # built wheel; test deps come from the "test" extra in pyproject.toml),
+      # and the manylinux images are OS/env-agnostic (or, for the images,
+      # just don't need to vary per matrix entry), so they're declared once
+      # in pyproject.toml's [tool.cibuildwheel]/[tool.cibuildwheel.linux]
+      # instead of duplicated here.
       # Mount host directories into the container so both the CMake build
       # tree and ccache's cache persist across every CIBW_BUILD identifier
       # in this job and across both cibuildwheel steps below (but not
@@ -133,7 +136,6 @@ jobs:
         uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
         env:
           CIBW_BUILD: "cp315t-*"
-          CIBW_ENABLE: cpython-prerelease
         with:
           package-dir: .
           output-dir: wheelhouse

--- a/Utilities/Distribution/manylinux/imagefiles/cmd.sh
+++ b/Utilities/Distribution/manylinux/imagefiles/cmd.sh
@@ -11,8 +11,10 @@ echo "BUILD_JAVA: ${BUILD_JAVA}"
 
 SIMPLEITK_GIT_TAG=${SIMPLEITK_GIT_TAG:-v1.1rc1}
 
-# Remove Python 2 and pure Python builds
-PYTHON_VERSIONS=${PYTHON_VERSIONS:-$(ls /opt/python | sed -e 's/cp2[^ ]\+ \?//g' -e 's/pp3[^ ]\+ \?//g')}
+# Remove Python 2 and pure Python builds. Use "-" rather than ":-" so that an
+# explicitly empty PYTHON_VERSIONS (as opposed to unset) disables Python wheel
+# building entirely, instead of falling back to autodetection.
+PYTHON_VERSIONS=${PYTHON_VERSIONS-$(ls /opt/python | sed -e 's/cp2[^ ]\+ \?//g' -e 's/pp3[^ ]\+ \?//g')}
 
 NPROC=$(grep -c processor /proc/cpuinfo)
 export MAKEFLAGS="-j ${NPROC}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ BUILD_SHARED_LIBS = "OFF"
 ITK_C_OPTIMIZATION_FLAGS = ""
 ITK_CXX_OPTIMIZATION_FLAGS = ""
 SimpleITK_BUILD_DISTRIBUTE = "ON"
+SimpleITK_USE_ELASTIX = "ON"
 
 [[tool.scikit-build.overrides]]
 if.python-version = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ classifiers = [
 requires-python = ">=3.10"
 dynamic = ["version"]
 
+[project.optional-dependencies]
+test = ["pytest", "numpy"]
+
 [[tool.dynamic-metadata]]
 provider = "scikit_build_core.metadata.setuptools_scm"
 
@@ -67,6 +70,17 @@ SimpleITK_USE_ELASTIX = "ON"
 [[tool.scikit-build.overrides]]
 if.python-version = ">=3.11"
 wheel.py-api = "cp311"
+
+[tool.cibuildwheel]
+build-verbosity = 1
+enable = ["cpython-prerelease"]
+test-extras = ["test"]
+test-sources = ["Wrapping/Python/tests"]
+test-command = "pytest -v --capture=no -o python_files=*.py Wrapping/Python/tests"
+
+[tool.cibuildwheel.linux]
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
 
 [project.urls]
 homepage = "https://simpleitk.org/"


### PR DESCRIPTION
## Summary
- Replace the ad-hoc Python wheel building done inside the manylinux `package-docker` container with a dedicated `python-wheels` job using `pypa/cibuildwheel` (v4.2.0).
- Covers the same set of currently-published Linux wheels: `cp310` (version-specific), `cp311` (abi3), `cp314t` (free-threaded), and a best-effort `cp315t` (free-threaded prerelease) — for both x86_64 and aarch64, using the same `manylinux_2_28` base image as before.
- The docker job still builds the C#/Java distribution zips; it no longer builds any Python wheels (`PYTHON_VERSIONS`/`BUILD_PYTHON_LIMITED_API` disabled).
- `publish-github` now also depends on `python-wheels`.
- macOS/Windows wheel building (`package_python` action) is intentionally untouched — out of scope for this PR.

## Notable fix along the way
- `Utilities/Distribution/manylinux/imagefiles/cmd.sh` used `${PYTHON_VERSIONS:-...}`, so an explicitly-empty `PYTHON_VERSIONS` (as now set by the workflow to disable wheel building) would have fallen through to autodetecting and building every Python in the image instead of none. Switched to `${PYTHON_VERSIONS-...}` so empty-but-set disables it, while local dev usage via `run.sh` (which leaves it unset) is unaffected.

## Design notes
- `cp315t` is built in its own `continue-on-error: true` step within the same job (not a separate parallel job), so a prerelease failure doesn't mask a real regression in the stable wheels, without doubling job/runner overhead.
- `CIBW_MANYLINUX_X86_64_IMAGE`/`CIBW_MANYLINUX_AARCH64_IMAGE` are pinned to `manylinux_2_28` to match the wheel platform tag currently published via the Dockerfiles.
- Verified locally with `cibuildwheel --print-build-identifiers` that the existing `pyproject.toml`/scikit-build-core setup already resolves to the expected wheel tags (cp310 plain, cp311-abi3, cp314t/cp315t free-threaded) with no changes needed there.

## Test plan
- [ ] CI run of this PR builds `python-wheels` successfully for both x86_64 and aarch64 (cp310/cp311/cp314t)
- [ ] `cp315t` step is allowed to fail without failing the job
- [ ] `package-docker` job still produces C#/Java zips, no longer produces wheels
- [ ] `publish-github` (on a tag) picks up wheel artifacts from `python-wheels`