### PR TITLE
BUG: Silence ITK legacy deprecation warnings when building elastix

### DIFF
--- a/CMake/sitkElastixFetchContent.cmake
+++ b/CMake/sitkElastixFetchContent.cmake
@@ -135,11 +135,22 @@ foreach(
 endforeach()
 
 # elastix calls some ITK methods that are marked legacy/deprecated in newer
-# ITK versions. Scoped to elastix's own subdirectory via a saved/restored
-# variable, so it doesn't leak into SimpleITK's own targets defined later
-# in this same directory scope.
-set(_sitk_elastix_saved_cxx_flags "${CMAKE_CXX_FLAGS}")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DITK_LEGACY_SILENT")
+# ITK versions. Use a directory-scoped compile definition (portable across
+# MSVC/GCC/Clang, unlike hand-rolled -D/CxxFlags) saved/restored around
+# FetchContent_MakeAvailable() so it doesn't leak into SimpleITK's own
+# targets defined later in this same directory scope.
+get_property(
+  _sitk_elastix_saved_compile_defs
+  DIRECTORY
+  PROPERTY COMPILE_DEFINITIONS
+)
+set_property(
+  DIRECTORY
+  APPEND
+  PROPERTY
+    COMPILE_DEFINITIONS
+      "ITK_LEGACY_SILENT"
+)
 
 FetchContent_Declare(
   Elastix
@@ -151,8 +162,13 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(Elastix)
 
-set(CMAKE_CXX_FLAGS "${_sitk_elastix_saved_cxx_flags}")
-unset(_sitk_elastix_saved_cxx_flags)
+set_property(
+  DIRECTORY
+  PROPERTY
+    COMPILE_DEFINITIONS
+      "${_sitk_elastix_saved_compile_defs}"
+)
+unset(_sitk_elastix_saved_compile_defs)
 
 # Check if FetchContent used find_package() or fetched from source
 FetchContent_GetProperties(Elastix)

--- a/CMake/sitkElastixFetchContent.cmake
+++ b/CMake/sitkElastixFetchContent.cmake
@@ -134,6 +134,13 @@ foreach(
   set(${_component} "${SimpleITK_ELASTIX_USE_OPENCL}")
 endforeach()
 
+# elastix calls some ITK methods that are marked legacy/deprecated in newer
+# ITK versions. Scoped to elastix's own subdirectory via a saved/restored
+# variable, so it doesn't leak into SimpleITK's own targets defined later
+# in this same directory scope.
+set(_sitk_elastix_saved_cxx_flags "${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DITK_LEGACY_SILENT")
+
 FetchContent_Declare(
   Elastix
   GIT_REPOSITORY "${ELASTIX_GIT_REPOSITORY}"
@@ -143,6 +150,9 @@ FetchContent_Declare(
 )
 
 FetchContent_MakeAvailable(Elastix)
+
+set(CMAKE_CXX_FLAGS "${_sitk_elastix_saved_cxx_flags}")
+unset(_sitk_elastix_saved_cxx_flags)
 
 # Check if FetchContent used find_package() or fetched from source
 FetchContent_GetProperties(Elastix)

--- a/SuperBuild/External_Elastix.cmake
+++ b/SuperBuild/External_Elastix.cmake
@@ -17,11 +17,17 @@ include("${CMAKE_CURRENT_LIST_DIR}/../CMake/sitkElastixGitOptions.cmake")
 # elastix calls some ITK methods that are marked legacy/deprecated in newer
 # ITK versions. Append (not replace) so the flags already forwarded via
 # ep_common_args are preserved; this later -DCMAKE_CXX_FLAGS wins for elastix's build.
+if(MSVC)
+  set(_sitk_elastix_legacy_silent_flag "/DITK_LEGACY_SILENT")
+else()
+  set(_sitk_elastix_legacy_silent_flag "-DITK_LEGACY_SILENT")
+endif()
 list(
   APPEND
   ep_elastix_args
-  "-DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS} -DITK_LEGACY_SILENT"
+  "-DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS} ${_sitk_elastix_legacy_silent_flag}"
 )
+unset(_sitk_elastix_legacy_silent_flag)
 
 if(NOT ${BUILD_SHARED_LIBS})
   list(

--- a/SuperBuild/External_Elastix.cmake
+++ b/SuperBuild/External_Elastix.cmake
@@ -14,6 +14,15 @@ file(
 
 include("${CMAKE_CURRENT_LIST_DIR}/../CMake/sitkElastixGitOptions.cmake")
 
+# elastix calls some ITK methods that are marked legacy/deprecated in newer
+# ITK versions. Append (not replace) so the flags already forwarded via
+# ep_common_args are preserved; this later -DCMAKE_CXX_FLAGS wins for elastix's build.
+list(
+  APPEND
+  ep_elastix_args
+  "-DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS} -DITK_LEGACY_SILENT"
+)
+
 if(NOT ${BUILD_SHARED_LIBS})
   list(
     APPEND


### PR DESCRIPTION
## Summary
- elastix calls some ITK methods that are marked legacy/deprecated in newer ITK versions, producing compiler warnings during the SuperBuild.
- Pass `ITK_LEGACY_SILENT` as a compile definition (via `CMAKE_CXX_FLAGS`) to elastix's `ExternalProject_Add` configure step, so `itkMacro.h`'s `itkLegacyMacro` omits the `[[deprecated]]` attribute for elastix's own translation units — without needing to reconfigure/rebuild ITK itself.
- Appends to (rather than replaces) the `CMAKE_CXX_FLAGS` already forwarded via `ep_common_args`, since the later `-DCMAKE_CXX_FLAGS` on the CMake command line wins for a given cache variable.

## Test plan
- [ ] Full SuperBuild with elastix enabled, confirm ITK legacy deprecation warnings from elastix's compile no longer appear
- [ ] Confirm elastix build still succeeds and SimpleITK tests using elastix pass