### PR TITLE
ENH: Suppress SWIG Warning 560 (Unknown Doxygen command)

### DIFF
--- a/Wrapping/Common/SimpleITK_Common.i
+++ b/Wrapping/Common/SimpleITK_Common.i
@@ -18,7 +18,9 @@
 %module(directors="1") SimpleITK
 
 // Remove some warnings
-#pragma SWIG nowarn=362,503,401,389,516,511
+// 560: Unknown Doxygen command. ITK's Doxygen comments use commands that
+// SWIG's Doxygen parser does not recognize.
+#pragma SWIG nowarn=362,503,401,389,516,511,560
 
 // SWIG >= 4.5.0's Ruby -autorename drops these std::vector partial
 // specializations as duplicate "Vector" names (Warning 302), breaking


### PR DESCRIPTION
## Summary
- Adds warning 560 (`WARN_DOXYGEN_UNKNOWN_COMMAND`) to the existing `#pragma SWIG nowarn=...` list in `Wrapping/Common/SimpleITK_Common.i`.
- ITK's header comments use Doxygen commands that SWIG's Doxygen parser doesn't recognize, which floods the build log with `Warning 560: Unknown Doxygen command: ...` during wrapping (Python/Java, which pass `-doxygen` to SWIG).
- This follows the codebase's existing convention of suppressing SWIG warnings via the shared `nowarn` pragma in `SimpleITK_Common.i` rather than per-language `-w` flags, since that pragma already applies to every language wrapper.

## Test plan
- [x] Verified locally with SWIG 4.5.0 that `-doxygen` mode emits `Warning 560: Unknown Doxygen command` for an interface file with an unrecognized `\command`, and that the file no longer emits it after adding `560` to the `nowarn` pragma.
- [ ] CI build should show no more Warning 560 noise in the Python/Java wrapping logs.