### PR TITLE
ENH: Improve exception message for PixelType/NumberOfComponents mismatch

### DIFF
--- a/Code/IO/src/sitkImageReaderBase.cxx
+++ b/Code/IO/src/sitkImageReaderBase.cxx
@@ -233,8 +233,12 @@ ImageReaderBase ::GetPixelIDFromImageIO(const ImageIOBase * iobase,
   }
   else
   {
-    sitkExceptionMacro("Unknown PixelType: " << itk::ImageIOBase::GetComponentTypeAsString(componentType) << "("
-                                             << (int)componentType << ")");
+    sitkExceptionMacro("Unable to determine PixelType from ImageIO: PixelType=\""
+                       << itk::ImageIOBase::GetPixelTypeAsString(pixelType) << "\" (" << static_cast<int>(pixelType)
+                       << "), NumberOfComponents=" << numberOfComponents << ", ComponentType=\""
+                       << itk::ImageIOBase::GetComponentTypeAsString(componentType) << "\" ("
+                       << static_cast<int>(componentType) << "). This is an inconsistent state reported by the "
+                       << "ImageIO, likely indicating a bug in \"" << iobase->GetNameOfClass() << "\".");
   }
 
   sitkExceptionMacro("Unable to load image.");

--- a/Testing/Unit/sitkImageIOTests.cxx
+++ b/Testing/Unit/sitkImageIOTests.cxx
@@ -26,8 +26,131 @@
 #include <sitkExtractImageFilter.h>
 #include <sitkRegionOfInterestImageFilter.h>
 
+#include <itkImageIOBase.h>
+#include <itkObjectFactoryBase.h>
+#include <itkCreateObjectFunction.h>
+#include <itkVersion.h>
+
 #include <cmath>
 #include <itksys/SystemTools.hxx>
+
+namespace
+{
+// A minimal ImageIOBase that reports an inconsistent (numberOfComponents>1,
+// pixelType==SCALAR) state, to exercise ImageReaderBase::GetPixelIDFromImageIO's
+// diagnostic exception for that case, without relying on a real ImageIO having a bug.
+class InconsistentPixelTypeImageIO : public itk::ImageIOBase
+{
+public:
+  using Self = InconsistentPixelTypeImageIO;
+  using Superclass = itk::ImageIOBase;
+  using Pointer = itk::SmartPointer<Self>;
+
+  itkOverrideGetNameOfClassMacro(InconsistentPixelTypeImageIO);
+  itkNewMacro(Self);
+
+  bool
+  CanReadFile(const char *) override
+  {
+    return true;
+  }
+  bool
+  CanWriteFile(const char *) override
+  {
+    return false;
+  }
+
+  void
+  ReadImageInformation() override
+  {
+    this->SetNumberOfDimensions(2);
+    this->SetDimensions(0, 1);
+    this->SetDimensions(1, 1);
+    this->SetComponentType(itk::IOComponentEnum::FLOAT);
+    this->SetNumberOfComponents(3);
+    this->SetPixelType(itk::IOPixelEnum::SCALAR);
+  }
+
+  void
+  Read(void *) override
+  {}
+  void
+  WriteImageInformation() override
+  {}
+  void
+  Write(const void *) override
+  {}
+};
+
+class InconsistentPixelTypeImageIOFactory : public itk::ObjectFactoryBase
+{
+public:
+  using Self = InconsistentPixelTypeImageIOFactory;
+  using Superclass = itk::ObjectFactoryBase;
+  using Pointer = itk::SmartPointer<Self>;
+
+  const char *
+  GetITKSourceVersion() const override
+  {
+    return ITK_SOURCE_VERSION;
+  }
+  const char *
+  GetDescription() const override
+  {
+    return "InconsistentPixelTypeImageIO test factory";
+  }
+
+  itkOverrideGetNameOfClassMacro(InconsistentPixelTypeImageIOFactory);
+  itkFactorylessNewMacro(Self);
+
+protected:
+  InconsistentPixelTypeImageIOFactory()
+  {
+    this->RegisterOverride("itkImageIOBase",
+                           "InconsistentPixelTypeImageIO",
+                           "Inconsistent PixelType Test ImageIO",
+                           true,
+                           itk::CreateObjectFunction<InconsistentPixelTypeImageIO>::New());
+  }
+};
+
+// RAII helper registering InconsistentPixelTypeImageIOFactory for the lifetime of the instance.
+class InconsistentPixelTypeImageIOFactoryRegistration
+{
+public:
+  InconsistentPixelTypeImageIOFactoryRegistration() { itk::ObjectFactoryBase::RegisterFactory(m_Factory); }
+  ~InconsistentPixelTypeImageIOFactoryRegistration() { itk::ObjectFactoryBase::UnRegisterFactory(m_Factory); }
+
+private:
+  InconsistentPixelTypeImageIOFactory::Pointer m_Factory{ InconsistentPixelTypeImageIOFactory::New() };
+};
+} // namespace
+
+
+TEST(IO, ImageFileReader_InconsistentPixelTypeExceptionMessage)
+{
+  namespace sitk = itk::simple;
+
+  const InconsistentPixelTypeImageIOFactoryRegistration registration;
+
+  sitk::ImageFileReader reader;
+  reader.SetImageIO("InconsistentPixelTypeImageIO");
+  reader.SetFileName("does-not-matter.iotest");
+
+  try
+  {
+    reader.Execute();
+    FAIL() << "Expected sitk::GenericException to be thrown.";
+  }
+  catch (const sitk::GenericException & e)
+  {
+    const std::string what(e.what());
+    EXPECT_NE(what.find("PixelType=\"scalar\""), std::string::npos) << what;
+    EXPECT_NE(what.find("NumberOfComponents=3"), std::string::npos) << what;
+    EXPECT_NE(what.find("ComponentType=\"float\""), std::string::npos) << what;
+    EXPECT_NE(what.find("InconsistentPixelTypeImageIO"), std::string::npos) << what;
+  }
+}
 
 
 TEST(IO, ImageFileReader)


### PR DESCRIPTION
## Summary

`ImageReaderBase::GetPixelIDFromImageIO()` previously reported any unhandled `(numberOfComponents, pixelType)` combination from an `ImageIO` as:

```
Unknown PixelType: float(11)
```

This only prints the *component* type, not the actual problem: an inconsistent `PixelType`/`NumberOfComponents` state reported by the `ImageIO`. This came up directly while diagnosing #2702 (HDF5 vector-pixel-type round-trip failure, fixed upstream in ITK: [InsightSoftwareConsortium/ITK#6829](https://github.com/InsightSoftwareConsortium/ITK/pull/6829)) — the error message gave no hint that a mismatch, rather than the component type, was the cause, which made the bug harder to diagnose than necessary.

The exception now reports the `PixelType`, `NumberOfComponents`, `ComponentType`, and the offending `ImageIO`'s class name, e.g.:

```
Unable to determine PixelType from ImageIO: PixelType="scalar" (1), NumberOfComponents=3, ComponentType="float" (9). This is an inconsistent state reported by the ImageIO, likely indicating a bug in "HDF5ImageIO".
```

## Changes

- `Code/IO/src/sitkImageReaderBase.cxx`: expand the diagnostic exception message in `GetPixelIDFromImageIO()`.
- `Testing/Unit/sitkImageIOTests.cxx`: add `TEST(IO, ImageFileReader_InconsistentPixelTypeExceptionMessage)`, which registers a minimal fake `itk::ImageIOBase`/`ObjectFactoryBase` reporting a deliberately inconsistent `(NumberOfComponents=3, PixelType=SCALAR)` state (via `itk::ObjectFactoryBase::RegisterOverride`), so the diagnostic path is exercised directly without depending on a real `ImageIO` having a matching bug.

## Test plan

- [x] New test `IO.ImageFileReader_InconsistentPixelTypeExceptionMessage` passes, verifying the message contains the pixel type, component count, component type, and IO class name.
- [x] Full `IO.*` SimpleITK unit test suite (20 tests) passes, no regressions.