### PR TITLE
CI: gated production PyPI publish via pypi-release environment

### DIFF
--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -14,7 +14,9 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: '${{ github.workflow }}@${{ github.event.pull_request.head.sha || github.head_ref || github.ref }}'
+  # PR number is stable across pushes so superseded PR runs get cancelled; tag/release runs never are.
+  group: '${{ github.workflow }}@${{ github.event.pull_request.number || github.ref }}'
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Set minimal permissions for all jobs (read-only)
 permissions:

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -429,7 +429,7 @@ jobs:
             gh release edit "${TAG_NAME}" --draft=false
           fi
 
-  publish-pypi:
+  publish-testpypi:
     if: github.event_name != 'pull_request' && startsWith(github.ref_name, 'v')
     environment:
       name: pypi-test
@@ -454,3 +454,32 @@ jobs:
         with:
           repository-url: ${{ vars.PYPI_REPOSITORY_URL }}
           skip-existing: true
+
+  # Gated: requires manual approval via the pypi-release environment's required reviewers.
+  publish-pypi:
+    if: github.event_name != 'pull_request' && needs.check-release-tag.outputs.is_final == 'true'
+    environment:
+      name: pypi-release
+      url: ${{ vars.ENVIRONMENT_URL }}
+    permissions:
+      id-token: write  # for PyPI trusted publishing
+    needs:
+      - publish-github
+      - check-release-tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        id: download
+        with:
+          path: ${{ github.workspace }}/artifacts
+      - name: Prepare for PyPI upload
+        shell: bash
+        run: |
+          mkdir -p dist
+          mv $( find  ${{ steps.download.outputs.download-path }} -type f \( -name "*.whl" -o -name "simpleitk-*.tar.gz" \) ) dist/
+      - name: PyPI Publish package
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33
+        with:
+          repository-url: ${{ vars.PYPI_REPOSITORY_URL }}
+          skip-existing: true
+          print-hash: true

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -290,6 +290,34 @@ jobs:
           name: artifacts-sdist
           path: dist/simpleitk-*.tar.gz
 
+  # Actions `if:` expressions have no regex support, so a dedicated job computes this for reuse.
+  check-release-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      is_final: ${{ steps.check.outputs.is_final }}
+      is_prerelease: ${{ steps.check.outputs.is_prerelease }}
+    steps:
+      - name: Check release tag type
+        id: check
+        shell: bash
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [[ "${REF_NAME}" == "latest" ||
+              "${REF_NAME}" =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)?([-.]?[a-zA-Z]+[0-9]*)$ ]]; then
+            is_prerelease=true
+            is_final=false
+          elif [[ "${REF_NAME}" =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+            is_prerelease=false
+            is_final=true
+          else
+            is_prerelease=false
+            is_final=false
+          fi
+
+          echo "is_prerelease=${is_prerelease}" >> "$GITHUB_OUTPUT"
+          echo "is_final=${is_final}" >> "$GITHUB_OUTPUT"
+
   publish-github:
     if: github.event_name != 'pull_request' && (github.ref_name == 'latest' || startsWith(github.ref_name, 'v'))
     environment:
@@ -301,6 +329,7 @@ jobs:
       - doxygen
       - package-docker
       - sdist
+      - check-release-tag
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -376,13 +405,13 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
           GIT_SHA: ${{ github.sha }}
           DOWNLOAD_PATH: ${{ steps.download.outputs.download-path }}
+          IS_PRERELEASE: ${{ needs.check-release-tag.outputs.is_prerelease }}
         run: |
           if [ "${TAG_NAME}" == "latest" ]; then
             gh release delete "${TAG_NAME}" --yes || true
           fi
 
-          if [[  "${TAG_NAME}" == "latest" ||
-              "${REF_NAME}" =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)?((-.)?[a-zA-Z]+[0-9]*)$ ]]; then
+          if [ "${IS_PRERELEASE}" == "true" ]; then
             create_args="--prerelease"
           fi
 


### PR DESCRIPTION
## Summary

- Fix `concurrency` so superseded pull request runs are actually cancelled (grouped by PR number, which is stable across pushes, instead of head SHA which changes every push). Tag/release runs are never auto-cancelled.
- Consolidate the release-tag classification (final vs pre-release vs `latest`) into a new `check-release-tag` job, and have `publish-github` reuse its `is_prerelease` output instead of duplicating the regex inline.
- Rename `publish-pypi` to `publish-testpypi` (unchanged behavior).
- Add a new `publish-pypi` job that publishes to production PyPI via [trusted publishing](https://docs.pypi.org/trusted-publishers/) (OIDC), gated by the `pypi-release` GitHub environment (requires manual approval), and only runs for final release tags (`vX.Y[.Z]`, no `latest`/pre-release suffix).

## Requires (outside this PR, in repo/environment settings)

- A PyPI trusted publisher configured for this repo referencing workflow `Package.yml` and environment `pypi-release`.
- The `pypi-release` GitHub environment created with required reviewers, and its own `PYPI_REPOSITORY_URL`/`ENVIRONMENT_URL` variables set to the real PyPI endpoint (environment-scoped vars override repo-level ones with the same name, so these must differ from `pypi-test`'s values).

## Test plan

- [ ] Push a PR touching this workflow and confirm a second push cancels the first run.
- [ ] Verify workflow YAML lints cleanly (e.g. actionlint).
- [ ] Tag a pre-release and confirm `publish-pypi` (production) is skipped while `publish-testpypi` still runs.
- [ ] Tag a final release and confirm `publish-pypi` pauses for environment approval, then succeeds after approval.
