### PR TITLE
ENH: Add Windows ARM64 job to batch build matrix

### DIFF
--- a/.github/workflows/BatchBuild.yml
+++ b/.github/workflows/BatchBuild.yml
@@ -93,6 +93,16 @@ jobs:
               ITK_USE_BUILD_DIR:BOOL=ON
               CXXFLAGS:STRING= /wd4251 /MP
 
+          - os: windows-11-arm
+            cmake-build-type: "Release"
+            cmake-generator: "Visual Studio 17 2022"
+            cmake-generator-toolset: v143,host=ARM64
+            cmake-generator-platform: ARM64
+            use-superbuild: true
+            ctest-cache: |
+              WRAP_PYTHON:BOOL=ON
+              CXXFLAGS:STRING= /wd4251 /MP
+
           - os: ubuntu-24.04-arm
             cmake-build-type: "Release"
             cmake-generator: "Ninja"


### PR DESCRIPTION
## Summary
- Adds a `windows-11-arm` entry to the `BatchBuild.yml` matrix to start exercising Windows-on-Arm builds.
- Uses the native ARM64 MSVC toolset (`v143,host=ARM64`) since the `windows-11-arm` GitHub-hosted runner is native arm64, not emulated x64.
- Kept the initial config minimal (superbuild + Python wrapping only) since this is a new, unproven platform for CI; other language wrappers (Java, C#, Elastix) can be added once this baseline is green.

## Test plan
- [ ] Confirm the `windows-11-arm` job in `Batch Build and Test` triggers and configures successfully via `workflow_dispatch`
- [ ] Confirm ITK superbuild compiles natively for ARM64
- [ ] Confirm Python wrapping builds and the SimpleITK test suite passes